### PR TITLE
Add link to Crossdart on the pkg/show page

### DIFF
--- a/app/lib/models.dart
+++ b/app/lib/models.dart
@@ -155,6 +155,13 @@ class PackageVersion extends db.ExpandoModel {
 
   String get documentationNice => niceUrl(documentation);
 
+  String get crossdart {
+    var name = Uri.encodeComponent(packageKey.id);
+    var version = Uri.encodeComponent(id);
+    return 'https://www.crossdart.info/p/$name/$version/';
+  }
+
+  String get crossdartNice => niceUrl(crossdart);
 
   String get homepage {
     return pubspec.homepage;

--- a/app/lib/templates.dart
+++ b/app/lib/templates.dart
@@ -203,6 +203,8 @@ class TemplateService {
           'nice_homepage' : latestVersion.homepageNice,
           'documentation' : latestVersion.documentation,
           'nice_documentation' : latestVersion.documentationNice,
+          'crossdart' : latestVersion.crossdart,
+          'nice_crossdart' : latestVersion.crossdartNice,
           // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
           'uploaders_title' : 'Uploader',
           'uploaders_html' : _getUploadersHtml(package),

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -121,6 +121,11 @@ $ <strong>pub get</strong>
       <p class="main-documentation"><a href="{{package.documentation}}">{{package.nice_documentation}}</a></p>
     {{/package.documentation}}
 
+    {{#package.crossdart}}
+      <h4>Source code (hyperlinked)</h4>
+      <p class="main-crossdart"><a href="{{package.crossdart}}">{{package.nice_crossdart}}</a></p>
+    {{/package.crossdart}}
+
     <h4>{{package.uploaders_title}}</h4>
     <p>{{& package.uploaders_html}}</p>
 


### PR DESCRIPTION
**Note**: I didn't test it, it's pretty hard to run it locally, it depends on Google Cloud account heavily.
But it type checks! :)

Crossdart contains the hyperlinked source code of all the packages on
pub. Somewhat like dartdocs.org, but in case you want to read the source
code of a package instead of its documentation :)

It gonna look like this:

![image](https://cloud.githubusercontent.com/assets/12795/15787405/dc582dc8-2987-11e6-934e-36d10d95735d.png)

/cc @filiph 