### PR TITLE
Update "Try Angular" link to new About page

### DIFF
--- a/app/views/index.mustache
+++ b/app/views/index.mustache
@@ -29,11 +29,11 @@
     &nbsp;
   </div>
   <div class="angular_framework_link">
-    <a href="https://webdev.dartlang.org/angular/guide">
+    <a href="https://webdev.dartlang.org/angular">
       <img class="framework_image" src="/static/angulardart.png" />
     </a>
     <h2>Web development?</h2>
-    <a class="get-started" href="https://webdev.dartlang.org/angular/guide">
+    <a class="get-started" href="https://webdev.dartlang.org/angular">
       Try Angular!
     </a>
     <br/>


### PR DESCRIPTION
AngularDart has a new _About_ page.  Use that, rather than the Guide, as a landing page.

cc @kwalrath @kevmoo