### PR TITLE
Remove font-size from code element. 

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -846,7 +846,6 @@ code,
 pre {
   padding: 0 3px 2px;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-  font-size: 13px;
   color: #333333;
   -webkit-border-radius: 3px;
   -moz-border-radius: 3px;


### PR DESCRIPTION
`pre` will have it anyway, and `code` should inherit it from its parent. Fixes #68.