### PR TITLE
Add latest dev version to the search result page.

### DIFF
--- a/app/lib/handlers.dart
+++ b/app/lib/handlers.dart
@@ -114,8 +114,8 @@ sitemapHandler(_) => _htmlResponse(templateService.renderSitemapPage());
 searchHandler(shelf.Request request) async {
   var query = request.url.queryParameters['q'];
   if (query == null) {
-    return _htmlResponse(
-        templateService.renderSearchPage(query, [], new SearchLinks.empty('')));
+    return _htmlResponse(templateService.renderSearchPage(
+        query, [], [], new SearchLinks.empty('')));
   }
 
   int page = _pageFromUrl(request.url,
@@ -126,7 +126,7 @@ searchHandler(shelf.Request request) async {
   var searchPage = await searchService.search(query, offset, resultCount);
   var links = new SearchLinks(query, searchPage.offset, searchPage.totalCount);
   return _htmlResponse(templateService.renderSearchPage(
-      query, searchPage.packageVersions, links));
+      query, searchPage.stableVersions, searchPage.devVersions, links));
 }
 
 /// Handles requests for /packages - multiplexes to JSON/HTML handler.

--- a/app/lib/templates.dart
+++ b/app/lib/templates.dart
@@ -312,17 +312,24 @@ class TemplateService {
 
   /// Renders the `views/search.mustache` template.
   String renderSearchPage(String query,
-                          List<PackageVersion> latestVersions,
+                          List<PackageVersion> stableVersions,
+                          List<PackageVersion> devVersions,
                           PageLinks pageLinks) {
-    var results = latestVersions.map((PackageVersion version) {
-      return {
-        'url' : '/packages/${version.packageKey.id}',
-        'name' : version.packageKey.id,
-        'version' : version.id,
-        'last_uploaded': version.shortCreated,
-        'desc' : version.ellipsizedDescription,
-      };
-    }).toList();
+    List results = [];
+    for (int i = 0; i < stableVersions.length; i++) {
+      PackageVersion stable = stableVersions[i];
+      PackageVersion dev = devVersions.length > i ? devVersions[i] : stable;
+      results.add({
+        'url' : '/packages/${stable.packageKey.id}',
+        'name' : stable.packageKey.id,
+        'version' : _HtmlEscaper.convert(stable.id),
+        'show_dev_version': stable.id != dev.id,
+        'dev_version': _HtmlEscaper.convert(dev.id),
+        'dev_version_href': Uri.encodeComponent(dev.id),
+        'last_uploaded': stable.shortCreated,
+        'desc' : stable.ellipsizedDescription,
+      });
+    }
 
     var values = {
         'query' : query,

--- a/app/test/handlers_test.dart
+++ b/app/test/handlers_test.dart
@@ -153,7 +153,8 @@ main() {
           expect(query, 'foobar');
           expect(offset, 0);
           expect(numResults, PageSize);
-          return new SearchResultPage(query, offset, 1, [testPackageVersion]);
+          return new SearchResultPage(
+              query, offset, 1, [testPackageVersion], [testPackageVersion]);
         }));
         expectHtmlResponse(await issueGet('/search?q=foobar'), status: 200);
       });
@@ -164,7 +165,8 @@ main() {
           expect(query, 'foobar');
           expect(offset, PageSize);
           expect(numResults, PageSize);
-          return new SearchResultPage(query, offset, 1, [testPackageVersion]);
+          return new SearchResultPage(
+              query, offset, 1, [testPackageVersion], [testPackageVersion]);
         }));
         expectHtmlResponse(await issueGet('/search?q=foobar&page=2'));
       });

--- a/app/test/handlers_test_utils.dart
+++ b/app/test/handlers_test_utils.dart
@@ -179,7 +179,8 @@ class TemplateMock implements TemplateService {
   }
 
   String renderSearchPage(String query,
-                          List<PackageVersion> latestVersions,
+                          List<PackageVersion> stableVersions,
+                          List<PackageVersion> devVersions,
                           PageLinks pageLinks) {
     return Response;
   }

--- a/app/views/search.mustache
+++ b/app/views/search.mustache
@@ -10,7 +10,18 @@
 {{#results}}
   <tr>
   <td>
-  <h3><a href="{{url}}">{{name}} <small>{{version}}</small></a></h3>
+  <h3>
+    <a href="{{url}}">{{name}}</a>
+    <span style="font-weight: normal; font-size: smaller">
+    {{^show_dev_version}}
+      (<a href="{{url}}">{{version}}</a>)
+    {{/show_dev_version}}
+    {{#show_dev_version}}
+      (latest: <a href="{{url}}">{{version}}</a> /
+               <a href="{{url}}/versions/{{dev_version_href}}">{{dev_version}}</a>)
+    {{/show_dev_version}}
+    </span>
+  </h3>
   <p>{{desc}}</p>
   <p><small>last updated {{last_uploaded}}</small></p>
   </td>


### PR DESCRIPTION
Fixes #47.

Disclaimer: first time touching gcloud database code. The proposed solution is suboptimal, it would be faster if we would store latest_dev_version value at the package object.