### PR TITLE
Enable strong mode, a few linter rules and run dartfmt on most files

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -1,0 +1,57 @@
+# https://www.dartlang.org/guides/language/analysis-options
+analyzer:
+  strong-mode: true
+
+# http://dart-lang.github.io/linter/lints/options/options.html
+linter:
+  rules:
+    - always_declare_return_types
+#    - always_specify_types
+    - annotate_overrides
+#    - avoid_as
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_return_types_on_setters
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    - close_sinks
+#    - comment_references
+#    - constant_identifier_names
+    - control_flow_in_finally
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - hash_and_equals
+#    - implementation_imports
+    - invariant_booleans
+    - iterable_contains_unrelated_type
+    - library_names
+    - library_prefixes
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+#    - non_constant_identifier_names
+    - one_member_abstracts
+#    - only_throw_errors
+    - overridden_fields
+#    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+#    - parameter_assignments
+    - prefer_final_fields
+    - prefer_final_locals
+    - prefer_is_not_empty
+#    - public_member_api_docs
+    - slash_for_doc_comments
+#    - sort_constructors_first
+#    - sort_unnamed_constructors_first
+    - super_goes_last
+    - test_types_in_equals
+    - throw_in_finally
+#    - type_annotate_public_apis
+    - type_init_formals
+#    - unawaited_futures
+    - unnecessary_brace_in_string_interp
+    - unnecessary_getters_setters
+    - unrelated_type_equality_checks
+    - valid_regexps

--- a/app/bin/configuration.dart
+++ b/app/bin/configuration.dart
@@ -43,7 +43,7 @@ class Configuration {
   /// Storage is retrieved from the Datastore.
   Configuration.prod()
       : projectId = 'dartlang-pub',
-        packageBucketName = 'pub-packages' {}
+        packageBucketName = 'pub-packages';
 
   /// Create a configuration for development/staging deployment.
   Configuration.dev()

--- a/app/bin/server.dart
+++ b/app/bin/server.dart
@@ -43,12 +43,12 @@ void main() {
             ioRequest.requestedUri.scheme != 'https') {
           final secureUri = ioRequest.requestedUri.replace(scheme: 'https');
           ioRequest.response
-              ..redirect(secureUri)
-              ..close();
+            ..redirect(secureUri)
+            ..close();
         } else {
           try {
             return shelf_io.handleRequest(ioRequest,
-                                          (shelf.Request request) async {
+                (shelf.Request request) async {
               logger.info('Handling request: ${request.requestedUri}');
               await registerLoggedInUserIfPossible(request);
               try {
@@ -67,11 +67,11 @@ void main() {
         }
       };
       if (Platform.isMacOS) {
-        AppEngineRequestHandler origHandler = requestHandler;
+        final AppEngineRequestHandler origHandler = requestHandler;
         requestHandler = (ioRequest) {
-          return fork(() {
+          fork(() {
             registerDbService(savedDb);
-            return origHandler(ioRequest);
+            origHandler(ioRequest);
           });
         };
       }
@@ -103,8 +103,8 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
     final authClient = await auth.clientViaMetadataServer();
     registerScopeExitCallback(authClient.close);
     final email = await obtainServiceAccountEmail();
-    uploadSigner = new IamBasedUploadSigner(
-        configuration.projectId, email, authClient);
+    uploadSigner =
+        new IamBasedUploadSigner(configuration.projectId, email, authClient);
   }
   registerUploadSigner(uploadSigner);
 
@@ -128,9 +128,7 @@ shelf.Request sanitizeRequestedUri(shelf.Request request) {
     // (The pub client will not remove it and instead directly try to request
     //  "GET //api/..." :-/ )
     final changedUri = uri.replace(path: normalizedResource);
-    return new shelf.Request(
-        request.method,
-        changedUri,
+    return new shelf.Request(request.method, changedUri,
         protocolVersion: request.protocolVersion,
         headers: request.headers,
         body: request.read(),

--- a/app/bin/server_common.dart
+++ b/app/bin/server_common.dart
@@ -22,10 +22,10 @@ import 'package:pub_dartlang_org/search_service.dart';
 final TemplateLocation = Platform.script.resolve('../views').toFilePath();
 
 const List<String> SCOPES = const [
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/datastore",
-    "https://www.googleapis.com/auth/devstorage.full_control",
-    "https://www.googleapis.com/auth/userinfo.email",
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/datastore',
+  'https://www.googleapis.com/auth/devstorage.full_control',
+  'https://www.googleapis.com/auth/userinfo.email',
 ];
 
 final Logger logger = new Logger('pub');
@@ -33,7 +33,7 @@ final Logger logger = new Logger('pub');
 void initOAuth2Service() {
   // The oauth2 service is used for getting an email address from an oauth2
   // access token (which the pub client sends).
-  var client = new http.Client();
+  final client = new http.Client();
   registerOAuth2Service(new OAuth2Service(client));
   registerScopeExitCallback(client.close);
 }
@@ -43,7 +43,7 @@ void initStorage(String projectId, authClient) {
 }
 
 Future initSearchService() async {
-  var searchService = await searchServiceViaApiKeyFromDb();
+  final searchService = await searchServiceViaApiKeyFromDb();
   registerSearchService(searchService);
   registerScopeExitCallback(searchService.httpClient.close);
 }
@@ -54,15 +54,14 @@ void initBackend({UIPackageCache cache}) {
 
 /// Looks at [request] and if the 'Authorization' header was set tries to get
 /// the user email address and registers it.
-registerLoggedInUserIfPossible(shelf.Request request) async {
-  var authorization = request.headers['authorization'];
+Future registerLoggedInUserIfPossible(shelf.Request request) async {
+  final authorization = request.headers['authorization'];
   if (authorization != null) {
-    var parts = authorization.split(' ');
-    if (parts.length == 2 &&
-        parts.first.trim().toLowerCase() == 'bearer') {
-      var accessToken = parts.last.trim();
+    final parts = authorization.split(' ');
+    if (parts.length == 2 && parts.first.trim().toLowerCase() == 'bearer') {
+      final accessToken = parts.last.trim();
 
-      var email = await oauth2Service.lookup(accessToken);
+      final email = await oauth2Service.lookup(accessToken);
       if (email != null) {
         registerLoggedInUser(email);
       }
@@ -83,6 +82,6 @@ Future<String> obtainServiceAccountEmail() async {
   final http.Response response = await http.get(
       'http://metadata/computeMetadata/'
       'v1/instance/service-accounts/default/email',
-      headers: const {'Metadata-Flavor' : 'Google'});
+      headers: const {'Metadata-Flavor': 'Google'});
   return response.body.trim();
 }

--- a/app/bin/tools_common.dart
+++ b/app/bin/tools_common.dart
@@ -11,7 +11,7 @@ import 'package:pub_dartlang_org/upload_signer_service.dart';
 import 'server_common.dart';
 import 'configuration.dart';
 
-withProdServices(Future fun()) async {
+Future withProdServices(Future fun()) async {
   if (!Platform.environment.containsKey('GCLOUD_PROJECT') ||
       !Platform.environment.containsKey('GCLOUD_KEY')) {
     throw 'Missing GCLOUD_* environments for package:appengine';

--- a/app/bin/tools_copy_data.dart
+++ b/app/bin/tools_copy_data.dart
@@ -15,7 +15,7 @@ import 'package:appengine/src/grpc_api_impl/datastore_impl.dart'
     as grpc_datastore_impl;
 import 'package:appengine/src/grpc_api_impl/grpc.dart' as grpc;
 
-main(List<String> args) async {
+Future main(List<String> args) async {
   if (args.length != 4) {
     print('Usage: ${Platform.executable} ${Platform.script} '
         '<from-project> <from-service-account-key.json> '
@@ -43,7 +43,7 @@ main(List<String> args) async {
 }
 
 Future migrate(db.DatastoreDB from, db.DatastoreDB to) async {
-  List<db.Model> entities = [];
+  final List<db.Model> entities = [];
 
   Future flush({bool force: false}) async {
     if (force || entities.length >= 10) {

--- a/app/bin/tools_uploader.dart
+++ b/app/bin/tools_uploader.dart
@@ -10,10 +10,10 @@ import 'package:pub_dartlang_org/models.dart';
 
 import 'tools_common.dart';
 
-main(List<String> arguments) async {
-  if (arguments.length < 2 || (
-      !(arguments.length == 2 && arguments[0] == 'list') &&
-      !(arguments.length == 3))) {
+Future main(List<String> arguments) async {
+  if (arguments.length < 2 ||
+      (!(arguments.length == 2 && arguments[0] == 'list') &&
+          !(arguments.length == 3))) {
     print('Usage:');
     print('   ${Platform.script} list   <package>');
     print('   ${Platform.script} add    <package> <email-to-add>');
@@ -21,9 +21,9 @@ main(List<String> arguments) async {
     exit(1);
   }
 
-  String command = arguments[0];
-  String package = arguments[1];
-  String uploader = arguments.length == 3 ? arguments[2] : null;
+  final String command = arguments[0];
+  final String package = arguments[1];
+  final String uploader = arguments.length == 3 ? arguments[2] : null;
 
   await withProdServices(() async {
     if (command == 'list') {
@@ -41,8 +41,9 @@ main(List<String> arguments) async {
 
 Future listUploaders(String packageName) async {
   return dbService.withTransaction((Transaction T) async {
-    final Package package = (await T.lookup(
-        [dbService.emptyKey.append(Package, id: packageName)])).first;
+    final Package package =
+        (await T.lookup([dbService.emptyKey.append(Package, id: packageName)]))
+            .first;
     if (package == null) {
       throw new Exception("Package $packageName does not exist.");
     }
@@ -53,12 +54,13 @@ Future listUploaders(String packageName) async {
 
 Future addUploader(String packageName, String uploader) async {
   return dbService.withTransaction((Transaction T) async {
-    Package package = (await T.lookup(
-        [dbService.emptyKey.append(Package, id: packageName)])).first;
+    final Package package =
+        (await T.lookup([dbService.emptyKey.append(Package, id: packageName)]))
+            .first;
     if (package == null) {
       throw new Exception("Package $packageName does not exist.");
     }
-    var uploaders = package.uploaderEmails;
+    final uploaders = package.uploaderEmails;
     print('Current uploaders: $uploaders');
     if (uploaders.contains(uploader)) {
       throw new Exception('Uploader $uploader already exists');
@@ -72,12 +74,13 @@ Future addUploader(String packageName, String uploader) async {
 
 Future removeUploader(String packageName, String uploader) async {
   return dbService.withTransaction((Transaction T) async {
-    Package package = (await T.lookup(
-        [dbService.emptyKey.append(Package, id: packageName)])).first;
+    final Package package =
+        (await T.lookup([dbService.emptyKey.append(Package, id: packageName)]))
+            .first;
     if (package == null) {
       throw new Exception("Package $packageName does not exist.");
     }
-    var uploaders = package.uploaderEmails;
+    final uploaders = package.uploaderEmails;
     print('Current uploaders: $uploaders');
     if (!uploaders.contains(uploader)) {
       throw new Exception('Uploader $uploader does not exist');

--- a/app/lib/atom_feed.dart
+++ b/app/lib/atom_feed.dart
@@ -23,17 +23,17 @@ class FeedEntry {
   final String alternateTitle;
 
   FeedEntry(this.id, this.title, this.updated, this.authors, this.content,
-            this.alternateUrl, this.alternateTitle);
+      this.alternateUrl, this.alternateTitle);
 
   void writeToXmlBuffer(StringBuffer buffer) {
-    var escape = _HtmlEscaper.convert;
+    final escape = _HtmlEscaper.convert;
 
     var authorTags = '';
-    if (!authors.isEmpty) {
-      var escapedAuthors = authors.map(escape);
+    if (authors.isNotEmpty) {
+      final escapedAuthors = authors.map(escape);
       authorTags = '<author><name>'
-                   '${escapedAuthors.join('</name></author><author><name>')}'
-                   '</name></author>';
+          '${escapedAuthors.join('</name></author><author><name>')}'
+          '</name></author>';
     }
 
     buffer.writeln('''
@@ -41,7 +41,7 @@ class FeedEntry {
           <id>urn:uuid:${escape(id)}</id>
           <title>${escape(title)}</title>
           <updated>${updated.toIso8601String()}</updated>
-          ${authorTags}
+          $authorTags
           <content type="html">${escape(content)}</content>
           <link href="$alternateUrl"
                 rel="alternate"
@@ -64,12 +64,20 @@ class Feed {
 
   final List<FeedEntry> entries;
 
-  Feed(this.id, this.title, this.subTitle, this.updated, this.author,
-       this.alternateUrl, this.selfUrl, this.generator, this.generatorVersion,
-       this.entries);
+  Feed(
+      this.id,
+      this.title,
+      this.subTitle,
+      this.updated,
+      this.author,
+      this.alternateUrl,
+      this.selfUrl,
+      this.generator,
+      this.generatorVersion,
+      this.entries);
 
   String toXmlDocument() {
-    var buffer = new StringBuffer();
+    final buffer = new StringBuffer();
     buffer..writeln('<?xml version="1.0" encoding="UTF-8"?>');
 
     writeToXmlBuffer(buffer);
@@ -77,12 +85,12 @@ class Feed {
   }
 
   void writeToXmlBuffer(StringBuffer buffer) {
-    var escape = _HtmlEscaper.convert;
+    final escape = _HtmlEscaper.convert;
 
     buffer.writeln('<feed xmlns="http://www.w3.org/2005/Atom">');
 
     buffer.writeln('''
-        <id>${id}</id>
+        <id>$id</id>
         <title>${escape(title)}</title>
         <updated>${updated.toIso8601String()}</updated>
         <author>
@@ -103,23 +111,25 @@ class Feed {
 }
 
 Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
-  var uuid = new Uuid();
+  final uuid = new Uuid();
 
   // TODO: Remove this after the we moved the to the dart version of the app.
-  requestedUri = Uri.parse('https://pub.dartlang.org/feed.atom');
+  final requestedUri = Uri.parse('https://pub.dartlang.org/feed.atom');
 
-  var entries = versions.map((PackageVersion version) {
-    var url = requestedUri.resolve(
-        '/packages/${version.package}#${version.version}').toString();
-    var alternateUrl = requestedUri.resolve(
-        '/packages/${Uri.encodeComponent(version.package)}').toString();
-    var alternateTitle = version.package;
+  final entries = versions.map((PackageVersion version) {
+    final url = requestedUri
+        .resolve('/packages/${version.package}#${version.version}')
+        .toString();
+    final alternateUrl = requestedUri
+        .resolve('/packages/${Uri.encodeComponent(version.package)}')
+        .toString();
+    final alternateTitle = version.package;
 
-    var id = uuid.v5(Uuid.NAMESPACE_URL, url);
-    var title = 'v${version.version} of ${version.package}';
+    final id = uuid.v5(Uuid.NAMESPACE_URL, url);
+    final title = 'v${version.version} of ${version.package}';
 
     // NOTE: A pubspec.yaml file can have "author: ..." or "authors: ...".
-    var authors = const [];
+    List<String> authors = const <String>[];
     if (version.pubspec.author != null) {
       authors = [version.pubspec.author];
     } else if (version.pubspec.authors != null) {
@@ -128,7 +138,7 @@ Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
 
     var content = 'No README Found';
     if (version.readme != null) {
-      var filename = version.readme.filename;
+      final filename = version.readme.filename;
       content = version.readme.text;
       if (filename.endsWith('.md')) {
         content = md.markdownToHtml(content);
@@ -139,14 +149,14 @@ Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
         alternateUrl, alternateTitle);
   }).toList();
 
-  var id = requestedUri.resolve('/feed.atom').toString();
-  var selfUrl = id;
+  final id = requestedUri.resolve('/feed.atom').toString();
+  final selfUrl = id;
 
-  var title = 'Pub Packages for Dart';
-  var subTitle = 'Last Updated Packages';
-  var alternateUrl = requestedUri.resolve('/').toString();
-  var author = 'Dart Team';
-  var updated = new DateTime.now().toUtc();
+  final title = 'Pub Packages for Dart';
+  final subTitle = 'Last Updated Packages';
+  final alternateUrl = requestedUri.resolve('/').toString();
+  final author = 'Dart Team';
+  final updated = new DateTime.now().toUtc();
 
   return new Feed(id, title, subTitle, updated, author, alternateUrl, selfUrl,
       'Pub Feed Generator', '0.1.0', entries);

--- a/app/lib/colored_markdown.dart
+++ b/app/lib/colored_markdown.dart
@@ -22,16 +22,16 @@ final List<InlineSyntax> inlineSyntaxes = ExtensionSet.gitHub.inlineSyntaxes
     .toList();
 
 String markdownToHtmlWithSyntax(String text) {
-  var lines = text.replaceAll('\r\n', '\n').split('\n');
+  final lines = text.replaceAll('\r\n', '\n').split('\n');
 
-  var document = new Document(
+  final document = new Document(
       blockSyntaxes: blockSyntaxes,
       inlineSyntaxes: inlineSyntaxes,
       extensionSet: ExtensionSet.none);
 
-  var blocks = document.parseLines(lines);
+  final blocks = document.parseLines(lines);
 
-  var colorizer = new ColorizeDartCode();
+  final colorizer = new ColorizeDartCode();
   blocks.forEach((Node node) => node.accept(colorizer));
 
   return new HtmlRenderer().render(blocks);
@@ -46,9 +46,9 @@ String markdownToHtmlWithoutSyntax(String text) {
 
 Scanner _scanner(String contents, {String name}) {
   if (name == null) name = '<unknown source>';
-  var source = new StringSource(contents, name);
-  var reader = new CharSequenceReader(contents);
-  var scanner =
+  final source = new StringSource(contents, name);
+  final reader = new CharSequenceReader(contents);
+  final scanner =
       new Scanner(source, reader, AnalysisErrorListener.NULL_LISTENER);
   return scanner;
 }
@@ -58,7 +58,7 @@ String escapeAngleBrackets(String msg) =>
     const HtmlEscape(HtmlEscapeMode.ELEMENT).convert(msg);
 
 void _writePrettifiedSource(String source, StringBuffer buffer) {
-  Scanner scanner = _scanner(source);
+  final Scanner scanner = _scanner(source);
   Token token = scanner.tokenize();
 
   int lineOfOffset(int offset) {
@@ -71,6 +71,7 @@ void _writePrettifiedSource(String source, StringBuffer buffer) {
     }
     return line;
   }
+
   int offsetOfOffset(int offset) {
     return offset - scanner.lineStarts[lineOfOffset(offset)];
   }
@@ -78,11 +79,11 @@ void _writePrettifiedSource(String source, StringBuffer buffer) {
   int line = 0;
   int lineOffset = 0;
 
-  handleToken(Token token) {
+  void handleToken(Token token) {
     String klass = 'n';
 
-    int newLine = lineOfOffset(token.offset);
-    int newLineOffset = offsetOfOffset(token.offset);
+    final int newLine = lineOfOffset(token.offset);
+    final int newLineOffset = offsetOfOffset(token.offset);
     if (newLine > line) {
       buffer.write('\n' * (newLine - line));
       lineOffset = 0;
@@ -92,7 +93,7 @@ void _writePrettifiedSource(String source, StringBuffer buffer) {
 
     switch (token.type) {
       case TokenType.IDENTIFIER:
-        var char = token.lexeme.substring(0, 1);
+        final char = token.lexeme.substring(0, 1);
         if (char == char.toUpperCase()) {
           // We highlight X in "class X" and "new X".
           var previous = token.previous;
@@ -268,12 +269,14 @@ void _writePrettifiedSource(String source, StringBuffer buffer) {
 }
 
 class ColorizeDartCode extends NodeVisitor {
+  @override
   void visitText(Text text) {}
 
+  @override
   bool visitElementBefore(Element element) {
     if (_isDartCodeElement(element)) {
-      Text text = _getSourceFromElement(element);
-      var buffer = new StringBuffer();
+      final Text text = _getSourceFromElement(element);
+      final buffer = new StringBuffer();
       _writePrettifiedSource(unEscape(text.text).trim(), buffer);
 
       element.attributes['class'] = 'highlight';
@@ -285,6 +288,7 @@ class ColorizeDartCode extends NodeVisitor {
     return true;
   }
 
+  @override
   void visitElementAfter(Element element) {}
 
   bool _isDartCodeElement(Element element) =>

--- a/app/lib/keys.dart
+++ b/app/lib/keys.dart
@@ -13,10 +13,10 @@ import 'models.dart';
 /// Uses the datastore API in the current service scope to retrieve custom
 /// search API Key.
 Future<String> customSearchKeyFromDB() async {
-  var db = dbService;
+  final db = dbService;
 
-  var privateKeyKey = db.emptyKey.append(PrivateKey, id: 'api');
-  PrivateKey apiKey = (await db.lookup([privateKeyKey])).first;
+  final privateKeyKey = db.emptyKey.append(PrivateKey, id: 'api');
+  final PrivateKey apiKey = (await db.lookup([privateKeyKey])).first;
 
   if (apiKey == null) {
     throw new Exception('Could not find Custom search API key in DB.');

--- a/app/lib/models.dart
+++ b/app/lib/models.dart
@@ -50,18 +50,18 @@ class Package extends db.ExpandoModel {
 
   // Check if a user is an uploader for a package.
   bool hasUploader(String email) {
-    return uploaderEmails.map((s) => s.toLowerCase())
-                         .contains(email.toLowerCase());
-
+    return uploaderEmails
+        .map((s) => s.toLowerCase())
+        .contains(email.toLowerCase());
   }
 
   // Remove the email from the list of uploaders.
   void removeUploader(String email) {
-    var lowerEmail = email.toLowerCase();
-    uploaderEmails =
-        uploaderEmails.map((s) => s.toLowerCase())
-                      .where((email) => email != lowerEmail).toList();
-
+    final lowerEmail = email.toLowerCase();
+    uploaderEmails = uploaderEmails
+        .map((s) => s.toLowerCase())
+        .where((email) => email != lowerEmail)
+        .toList();
   }
 }
 
@@ -76,7 +76,7 @@ class Package extends db.ExpandoModel {
 @db.Kind(name: 'PackageVersion', idType: db.IdType.String)
 class PackageVersion extends db.ExpandoModel {
   @db.StringProperty(required: true)
-  String version;  // Same as id
+  String version; // Same as id
 
   String get package => packageKey.id;
 
@@ -134,7 +134,7 @@ class PackageVersion extends db.ExpandoModel {
   Version get semanticVersion => new Version.parse(version);
 
   String get ellipsizedDescription {
-    String description = pubspec.description;
+    final String description = pubspec.description;
     if (description == null) return null;
     return description.substring(0, min(description.length, 200));
   }
@@ -144,8 +144,8 @@ class PackageVersion extends db.ExpandoModel {
   }
 
   String get dartdocsUrl {
-    var name = Uri.encodeComponent(packageKey.id);
-    var version = Uri.encodeComponent(id);
+    final name = Uri.encodeComponent(packageKey.id);
+    final version = Uri.encodeComponent(id);
     return 'http://www.dartdocs.org/documentation/$name/$version/';
   }
 
@@ -157,8 +157,8 @@ class PackageVersion extends db.ExpandoModel {
   String get documentationNice => niceUrl(documentation);
 
   String get crossdart {
-    var name = Uri.encodeComponent(packageKey.id);
-    var version = Uri.encodeComponent(id);
+    final name = Uri.encodeComponent(packageKey.id);
+    final version = Uri.encodeComponent(id);
     return 'https://www.crossdart.info/p/$name/$version/';
   }
 

--- a/app/lib/oauth2_service.dart
+++ b/app/lib/oauth2_service.dart
@@ -15,8 +15,8 @@ import 'package:http/http.dart' as http;
 OAuth2Service get oauth2Service => ss.lookup(#_oauth2_service);
 
 /// Look up the current registered [OAuth2Service].
-void registerOAuth2Service(OAuth2Service service)
-    => ss.register(#_oauth2_service, service);
+void registerOAuth2Service(OAuth2Service service) =>
+    ss.register(#_oauth2_service, service);
 
 /// A service used for looking up email addresses using an OAuth2 access token.
 class OAuth2Service {
@@ -27,14 +27,14 @@ class OAuth2Service {
   /// Looks up the email address by using the [accessTokenString] which
   /// contains an access token.
   Future<String> lookup(String accessTokenString) async {
-    var future = new DateTime.utc(4242);
-    var accessToken = new AccessToken('Bearer', accessTokenString, future);
-    var credentials = new AccessCredentials(accessToken, null, []);
-    var authClient = authenticatedClient(client, credentials);
+    final future = new DateTime.utc(4242);
+    final accessToken = new AccessToken('Bearer', accessTokenString, future);
+    final credentials = new AccessCredentials(accessToken, null, []);
+    final authClient = authenticatedClient(client, credentials);
 
     oauth2_v2.Userinfoplus info;
     try {
-      var api = new oauth2_v2.Oauth2Api(authClient);
+      final api = new oauth2_v2.Oauth2Api(authClient);
       info = await api.userinfo.get();
     } finally {
       authClient.close();

--- a/app/lib/package_memcache.dart
+++ b/app/lib/package_memcache.dart
@@ -41,28 +41,35 @@ class AppEnginePackageMemcache implements PackageCache, UIPackageCache {
 
   AppEnginePackageMemcache(this.memcache, String namespace)
       : keyPrefix = (namespace == null || namespace.isEmpty)
-          ? KEY_PREFIX : 'ns_${namespace}_$KEY_PREFIX',
+            ? KEY_PREFIX
+            : 'ns_${namespace}_$KEY_PREFIX',
         uiKeyPrefix = (namespace == null || namespace.isEmpty)
-          ? UI_KEY_PREFIX : 'ns_${namespace}_$UI_KEY_PREFIX';
+            ? UI_KEY_PREFIX
+            : 'ns_${namespace}_$UI_KEY_PREFIX';
 
+  @override
   Future<List<int>> getPackageData(String package) async {
-    var result =
+    final result =
         await _ignoreErrors(memcache.get(_packageKey(package), asBinary: true));
 
-    if (result != null) _logger.info('memcache["$package"] found');
-    else _logger.info('memcache["$package"] not found');
+    if (result != null)
+      _logger.info('memcache["$package"] found');
+    else
+      _logger.info('memcache["$package"] not found');
 
     return result;
   }
 
+  @override
   Future setPackageData(String package, List<int> data) {
     _logger.info('memcache["$package"] setting to new data');
     return _ignoreErrors(
         memcache.set(_packageKey(package), data, expiration: EXPIRATION));
   }
 
+  @override
   Future<String> getUIPackagePage(String package, String version) async {
-    var result = await _ignoreErrors(
+    final result = await _ignoreErrors(
         memcache.get(_packageUIKey(package, version), asBinary: true));
 
     if (result != null) {
@@ -74,31 +81,34 @@ class AppEnginePackageMemcache implements PackageCache, UIPackageCache {
     return null;
   }
 
+  @override
   Future setUIPackagePage(String package, String version, String data) async {
     _logger.info('memcache["$package"] setting to new rendered UI data');
-    return _ignoreErrors(
-        memcache.set(_packageUIKey(package, version),
-        UTF8.encode(data),
+    return _ignoreErrors(memcache.set(
+        _packageUIKey(package, version), UTF8.encode(data),
         expiration: EXPIRATION));
   }
 
+  @override
   Future invalidateUIPackagePage(String package) async {
     _logger.info('memcache["$package"] invalidating UI data');
     return _ignoreErrors(Future.wait([
-        memcache.remove(_packageUIKey(package, null)),
-        memcache.remove(INDEX_PAGE_KEY),
+      memcache.remove(_packageUIKey(package, null)),
+      memcache.remove(INDEX_PAGE_KEY),
     ]));
   }
 
+  @override
   Future invalidatePackageData(String package) {
     _logger.info('memcache["$package"] invalidate entry');
     return _ignoreErrors(Future.wait([
-        memcache.remove(_packageKey(package)),
-        memcache.remove(_packageUIKey(package, null)),
-        memcache.remove(INDEX_PAGE_KEY),
+      memcache.remove(_packageKey(package)),
+      memcache.remove(_packageUIKey(package, null)),
+      memcache.remove(INDEX_PAGE_KEY),
     ]));
   }
 
+  @override
   Future<String> getUIIndexPage() async {
     final result = await _ignoreErrors(memcache.get(INDEX_PAGE_KEY));
     if (result != null) {
@@ -109,6 +119,7 @@ class AppEnginePackageMemcache implements PackageCache, UIPackageCache {
     return result;
   }
 
+  @override
   Future setUIIndexPage(String content) async {
     _logger.info('memcache[index-page] setting to new rendered UI data');
     await _ignoreErrors(
@@ -129,8 +140,7 @@ class AppEnginePackageMemcache implements PackageCache, UIPackageCache {
   //    => The duration for inconsistency is limited to 60 minutes ATM.
   Future _ignoreErrors(Future f) {
     return f.catchError((error, stackTrace) {
-      _logger.warning(
-          'Ignoring failed memcache API call (error: $error)',
+      _logger.warning('Ignoring failed memcache API call (error: $error)',
           error, stackTrace);
     });
   }

--- a/app/lib/templates.dart
+++ b/app/lib/templates.dart
@@ -18,8 +18,8 @@ const HtmlEscape _HtmlEscaper = const HtmlEscape();
 
 final _AuthorsRegExp = new RegExp(r'^\s*(.+)\s+<(.+)>\s*$');
 
-void registerTemplateService(TemplateService service)
-    => ss.register(#_templates, service);
+void registerTemplateService(TemplateService service) =>
+    ss.register(#_templates, service);
 
 TemplateService get templateService => ss.lookup(#_templates);
 
@@ -37,23 +37,22 @@ class TemplateService {
 
   /// Renders the `views/private_keys/new.mustache` template.
   String renderPrivateKeysNewPage(bool wasAlreadySet, bool isProduction) {
-    var values = {
-        'already_set': wasAlreadySet,
-        'production' : isProduction,
+    final values = {
+      'already_set': wasAlreadySet,
+      'production': isProduction,
     };
     return _renderPage('private_keys/new', values);
   }
 
   /// Renders the `views/pkg/versions/index` template.
-  String renderPkgVersionsPage(String package,
-                               List<PackageVersion> versions,
-                               List<Uri> versionDownloadUrls) {
+  String renderPkgVersionsPage(String package, List<PackageVersion> versions,
+      List<Uri> versionDownloadUrls) {
     assert(versions.length == versionDownloadUrls.length);
 
-    var versionsJson = [];
+    final versionsJson = [];
     for (int i = 0; i < versions.length; i++) {
-      PackageVersion version = versions[i];
-      String url = versionDownloadUrls[i].toString();
+      final PackageVersion version = versions[i];
+      final String url = versionDownloadUrls[i].toString();
       versionsJson.add({
         'version': version.id,
         'short_created': version.shortCreated,
@@ -62,35 +61,34 @@ class TemplateService {
       });
     }
 
-    var values = {
-        'package': {
-          'name' : package,
-        },
-        'versions' : versionsJson,
+    final values = {
+      'package': {
+        'name': package,
+      },
+      'versions': versionsJson,
     };
     return _renderPage('pkg/versions/index', values);
   }
 
   /// Renders the `views/pkg/index.mustache` template.
-  String renderPkgIndexPage(List<Package> packages,
-                            List<PackageVersion> versions,
-                            PageLinks links) {
-    var packagesJson = [];
+  String renderPkgIndexPage(
+      List<Package> packages, List<PackageVersion> versions, PageLinks links) {
+    final packagesJson = [];
     for (int i = 0; i < packages.length; i++) {
-      var package = packages[i];
-      var version = versions[i];
+      final package = packages[i];
+      final version = versions[i];
       packagesJson.add({
-          'name' : package.name,
-          'description' : {
-            'ellipsized_description' : version.ellipsizedDescription,
-          },
-          'authors_html' : _getAuthorsHtml(version),
-          'short_updated' : version.shortCreated,
+        'name': package.name,
+        'description': {
+          'ellipsized_description': version.ellipsizedDescription,
+        },
+        'authors_html': _getAuthorsHtml(version),
+        'short_updated': version.shortCreated,
       });
     }
-    var values = {
-        'packages': packagesJson,
-        'pagination' : renderPagination(links),
+    final values = {
+      'packages': packagesJson,
+      'pagination': renderPagination(links),
     };
 
     var title = 'All Packages';
@@ -102,33 +100,36 @@ class TemplateService {
   }
 
   /// Renders the `views/private_keys/show.mustache` template.
-  String renderPkgShowPage(Package package,
-                           List<PackageVersion> versions,
-                           List<Uri> versionDownloadUrls,
-                           PackageVersion selectedVersion,
-                           PackageVersion latestStableVersion,
-                           PackageVersion latestDevVersion,
-                           int totalNumberOfVersions) {
+  String renderPkgShowPage(
+      Package package,
+      List<PackageVersion> versions,
+      List<Uri> versionDownloadUrls,
+      PackageVersion selectedVersion,
+      PackageVersion latestStableVersion,
+      PackageVersion latestDevVersion,
+      int totalNumberOfVersions) {
     assert(versions.length == versionDownloadUrls.length);
 
     var importExamples;
     if (selectedVersion.libraries.contains('${package.id}.dart')) {
-      importExamples = [{
-        'package' : package.id,
-        'library' : '${package.id}.dart',
-      }];
+      importExamples = [
+        {
+          'package': package.id,
+          'library': '${package.id}.dart',
+        }
+      ];
     } else {
       importExamples = selectedVersion.libraries.map((library) {
         return {
-          'package' : selectedVersion.packageKey.id,
-          'library' : library,
+          'package': selectedVersion.packageKey.id,
+          'library': library,
         };
       }).toList();
     }
 
     // TODO(nweiz): Once the 1.11 SDK is out and pub supports ">=1.2.3-pre
     // <1.2.3", suggest that as the version constraint for prerelease versions.
-    var exampleVersionConstraint = '"^${selectedVersion.version}"';
+    final exampleVersionConstraint = '"^${selectedVersion.version}"';
 
     bool isMarkdownFile(String filename) {
       return filename.toLowerCase().endsWith('.md');
@@ -136,12 +137,12 @@ class TemplateService {
 
     String renderPlainText(String text) {
       return '<div class="highlight"><pre>${cmd.escapeAngleBrackets(text)}'
-             '</pre></div>';
+          '</pre></div>';
     }
 
     String renderFile(FileObject file) {
-      var filename = file.filename;
-      var content = file.text;
+      final filename = file.filename;
+      final content = file.text;
       if (content != null) {
         if (isMarkdownFile(filename)) {
           try {
@@ -170,10 +171,10 @@ class TemplateService {
       renderedChangelog = renderFile(selectedVersion.changelog);
     }
 
-    var versionsJson = [];
+    final versionsJson = [];
     for (int i = 0; i < versions.length; i++) {
-      PackageVersion version = versions[i];
-      String url = versionDownloadUrls[i].toString();
+      final PackageVersion version = versions[i];
+      final String url = versionDownloadUrls[i].toString();
       versionsJson.add({
         'version': version.id,
         'short_created': version.shortCreated,
@@ -182,49 +183,49 @@ class TemplateService {
       });
     }
 
-    bool should_show_dev =
+    final bool should_show_dev =
         latestStableVersion.semanticVersion < latestDevVersion.semanticVersion;
-    bool should_show =
+    final bool should_show =
         selectedVersion != latestStableVersion || should_show_dev;
 
-    var values = {
-        'package': {
-          'name' : package.name,
-          'selected_version' : {
-            'version' : selectedVersion.id,
-            'example_version_constraint' : exampleVersionConstraint,
-            'has_libraries' : importExamples.length > 0,
-            'import_examples' : importExamples,
-          },
-          'latest' : {
-            'should_show' : should_show,
-            'should_show_dev' : should_show_dev,
-            'stable_href' : Uri.encodeComponent(latestStableVersion.id),
-            'stable_name' : _HtmlEscaper.convert(latestStableVersion.id),
-            'dev_href' : Uri.encodeComponent(latestDevVersion.id),
-            'dev_name' : _HtmlEscaper.convert(latestDevVersion.id),
-          },
-          'description' : selectedVersion.pubspec.description,
-          // TODO: make this 'Authors' if PackageVersion.authors is a list?!
-          'authors_title' : 'Author',
-          'authors_html' : _getAuthorsHtml(selectedVersion),
-          'homepage' : selectedVersion.homepage,
-          'nice_homepage' : selectedVersion.homepageNice,
-          'documentation' : selectedVersion.documentation,
-          'nice_documentation' : selectedVersion.documentationNice,
-          'crossdart' : selectedVersion.crossdart,
-          'nice_crossdart' : selectedVersion.crossdartNice,
-          // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
-          'uploaders_title' : 'Uploader',
-          'uploaders_html' : _getUploadersHtml(package),
+    final values = {
+      'package': {
+        'name': package.name,
+        'selected_version': {
+          'version': selectedVersion.id,
+          'example_version_constraint': exampleVersionConstraint,
+          'has_libraries': importExamples.length > 0,
+          'import_examples': importExamples,
         },
-        'versions' : versionsJson,
-        'show_versions_link' : totalNumberOfVersions > versions.length,
-        'readme' : renderedReadme,
-        'readme_filename' : readmeFilename,
-        'changelog' : renderedChangelog,
-        'changelog_filename': changelogFilename,
-        'version_count' : '$totalNumberOfVersions',
+        'latest': {
+          'should_show': should_show,
+          'should_show_dev': should_show_dev,
+          'stable_href': Uri.encodeComponent(latestStableVersion.id),
+          'stable_name': _HtmlEscaper.convert(latestStableVersion.id),
+          'dev_href': Uri.encodeComponent(latestDevVersion.id),
+          'dev_name': _HtmlEscaper.convert(latestDevVersion.id),
+        },
+        'description': selectedVersion.pubspec.description,
+        // TODO: make this 'Authors' if PackageVersion.authors is a list?!
+        'authors_title': 'Author',
+        'authors_html': _getAuthorsHtml(selectedVersion),
+        'homepage': selectedVersion.homepage,
+        'nice_homepage': selectedVersion.homepageNice,
+        'documentation': selectedVersion.documentation,
+        'nice_documentation': selectedVersion.documentationNice,
+        'crossdart': selectedVersion.crossdart,
+        'nice_crossdart': selectedVersion.crossdartNice,
+        // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
+        'uploaders_title': 'Uploader',
+        'uploaders_html': _getUploadersHtml(package),
+      },
+      'versions': versionsJson,
+      'show_versions_link': totalNumberOfVersions > versions.length,
+      'readme': renderedReadme,
+      'readme_filename': readmeFilename,
+      'changelog': renderedChangelog,
+      'changelog_filename': changelogFilename,
+      'version_count': '$totalNumberOfVersions',
     };
     return _renderPage('pkg/show', values,
         title: '${package.name} ${selectedVersion.id} | Pub Package Manager',
@@ -233,17 +234,19 @@ class TemplateService {
 
   /// Renders the `views/admin.mustache` template.
   String renderAdminPage(bool privateKeysSet, bool isProduction,
-                         {ReloadStatus reloadStatus}) {
-    var reload_status = reloadStatus == null ? {} : {
-      'count' : reloadStatus.count,
-      'total' : reloadStatus.total,
-      'percentage' : reloadStatus.percentage,
-    };
+      {ReloadStatus reloadStatus}) {
+    final reload_status = reloadStatus == null
+        ? {}
+        : {
+            'count': reloadStatus.count,
+            'total': reloadStatus.total,
+            'percentage': reloadStatus.percentage,
+          };
 
-    var values = {
-        'reload_status': reload_status,
-        'private_keys_set':
-            privateKeysSet && isProduction ? {'production' : true} : false,
+    final values = {
+      'reload_status': reload_status,
+      'private_keys_set':
+          privateKeysSet && isProduction ? {'production': true} : false,
     };
     return _renderPage('admin', values, title: 'Admin Console');
   }
@@ -255,43 +258,42 @@ class TemplateService {
 
   /// Renders the `views/index.mustache` template.
   String renderErrorPage(String status, String message, String traceback) {
-    var values = {
-        'status' : status,
-        'message' : message,
-        'traceback' : traceback,
+    final values = {
+      'status': status,
+      'message': message,
+      'traceback': traceback,
     };
     return _renderPage('error', values, title: 'Error $status');
   }
 
   /// Renders the `views/index.mustache` template.
   String renderIndexPage(List<PackageVersion> recentPackages) {
-    var values = {
-        'recent_packages': recentPackages.map((PackageVersion version) {
-          var description = version.ellipsizedDescription;
-          return {
-            'name' : version.packageKey.id,
-            'short_updated' : version.shortCreated,
-            'latest_version' : {
-                'version' : version.id
-            },
-            'description' : description != null,
-            'ellipsized_description': description,
-          };
-        }).toList(),
+    final values = {
+      'recent_packages': recentPackages.map((PackageVersion version) {
+        final description = version.ellipsizedDescription;
+        return {
+          'name': version.packageKey.id,
+          'short_updated': version.shortCreated,
+          'latest_version': {'version': version.id},
+          'description': description != null,
+          'ellipsized_description': description,
+        };
+      }).toList(),
     };
     return _renderPage('index', values, title: 'Pub Package Manager');
   }
 
   /// Renders the `views/layout.mustache` template.
-  String renderLayoutPage(String title,
-                          String contentString,
-                          {PackageVersion packageVersion}) {
-    var values = {
-      'package': packageVersion == null ? false : {
-        'name' : _HtmlEscaper.convert(packageVersion.packageKey.id),
-        'description' :
-            _HtmlEscaper.convert(packageVersion.ellipsizedDescription),
-      },
+  String renderLayoutPage(String title, String contentString,
+      {PackageVersion packageVersion}) {
+    final values = {
+      'package': packageVersion == null
+          ? false
+          : {
+              'name': _HtmlEscaper.convert(packageVersion.packageKey.id),
+              'description':
+                  _HtmlEscaper.convert(packageVersion.ellipsizedDescription),
+            },
       'title': _HtmlEscaper.convert(title),
       // This is not escaped as it is already escaped by the caller.
       'content': contentString,
@@ -304,38 +306,37 @@ class TemplateService {
 
   /// Renders the `views/pagination.mustache` template.
   String renderPagination(PageLinks pageLinks) {
-    var values = {
-      'page_links' : pageLinks.hrefPatterns(),
+    final values = {
+      'page_links': pageLinks.hrefPatterns(),
     };
     return _renderTemplate('pagination', values, escapeValues: false);
   }
 
   /// Renders the `views/search.mustache` template.
-  String renderSearchPage(String query,
-                          List<PackageVersion> stableVersions,
-                          List<PackageVersion> devVersions,
-                          PageLinks pageLinks) {
-    List results = [];
+  String renderSearchPage(String query, List<PackageVersion> stableVersions,
+      List<PackageVersion> devVersions, PageLinks pageLinks) {
+    final List results = [];
     for (int i = 0; i < stableVersions.length; i++) {
-      PackageVersion stable = stableVersions[i];
-      PackageVersion dev = devVersions.length > i ? devVersions[i] : stable;
+      final PackageVersion stable = stableVersions[i];
+      final PackageVersion dev =
+          devVersions.length > i ? devVersions[i] : stable;
       results.add({
-        'url' : '/packages/${stable.packageKey.id}',
-        'name' : stable.packageKey.id,
-        'version' : _HtmlEscaper.convert(stable.id),
+        'url': '/packages/${stable.packageKey.id}',
+        'name': stable.packageKey.id,
+        'version': _HtmlEscaper.convert(stable.id),
         'show_dev_version': stable.id != dev.id,
         'dev_version': _HtmlEscaper.convert(dev.id),
         'dev_version_href': Uri.encodeComponent(dev.id),
         'last_uploaded': stable.shortCreated,
-        'desc' : stable.ellipsizedDescription,
+        'desc': stable.ellipsizedDescription,
       });
     }
 
-    var values = {
-        'query' : query,
-        'results' : results,
-        'pagination' : renderPagination(pageLinks),
-        'hasResults' : results.length > 0,
+    final values = {
+      'query': query,
+      'results': results,
+      'pagination': renderPagination(pageLinks),
+      'hasResults': results.length > 0,
     };
     return _renderPage('search', values, title: 'Search results for $query.');
   }
@@ -349,7 +350,7 @@ class TemplateService {
   /// the provided [template] for the content.
   String _renderPage(String template, values,
       {String title: 'pub.dartlang.org', PackageVersion packageVersion}) {
-    var renderedContent = _renderTemplate(template, values);
+    final renderedContent = _renderTemplate(template, values);
     return renderLayoutPage(title, renderedContent,
         packageVersion: packageVersion);
   }
@@ -358,20 +359,18 @@ class TemplateService {
   ///
   /// If [escapeValues] is `false`, values in `values` will not be escaped.
   String _renderTemplate(String template, values, {bool escapeValues: true}) {
-    mustache.Template parsedTemplate =
+    final mustache.Template parsedTemplate =
         _CachedMustacheTemplates.putIfAbsent(template, () {
-      var file = new File('$templateDirectory/$template.mustache');
-      return new mustache.Template(
-          file.readAsStringSync(),
-          htmlEscapeValues: escapeValues,
-          lenient: true);
+      final file = new File('$templateDirectory/$template.mustache');
+      return new mustache.Template(file.readAsStringSync(),
+          htmlEscapeValues: escapeValues, lenient: true);
     });
     return parsedTemplate.renderString(values);
   }
 }
 
 String _getAuthorsHtml(PackageVersion version) {
-  var author = version.pubspec.author;
+  final author = version.pubspec.author;
   var authors = version.pubspec.authors;
 
   if (authors == null && author != null) authors = [author];
@@ -381,7 +380,7 @@ String _getAuthorsHtml(PackageVersion version) {
     var name = value;
     var email = value;
 
-    var match = _AuthorsRegExp.matchAsPrefix(value);
+    final match = _AuthorsRegExp.matchAsPrefix(value);
     if (match != null) {
       name = match.group(1);
       email = match.group(2);
@@ -389,7 +388,7 @@ String _getAuthorsHtml(PackageVersion version) {
 
     // TODO: Properly escape this.
     return '<span class="author"><a href="mailto:$email" title="Email $email">'
-           '<i class="icon-envelope">Email $email</i></a> $name</span>';
+        '<i class="icon-envelope">Email $email</i></a> $name</span>';
   }).join('<br/>');
 }
 
@@ -397,7 +396,6 @@ String _getUploadersHtml(Package package) {
   // TODO: HTML escape email addresses.
   return package.uploaderEmails.join('<br/>');
 }
-
 
 class ReloadStatus {
   final int count;
@@ -416,44 +414,45 @@ abstract class PageLinks {
 
   PageLinks(this.offset, this.count);
 
-  PageLinks.empty() : offset = 1, count = 1;
+  PageLinks.empty()
+      : offset = 1,
+        count = 1;
 
-  int get leftmostPage
-      => max(1 + offset ~/ RESULTS_PER_PAGE - MAX_PAGES ~/ 2, 1);
+  int get leftmostPage =>
+      max(1 + offset ~/ RESULTS_PER_PAGE - MAX_PAGES ~/ 2, 1);
 
   int get currentPage => 1 + offset ~/ RESULTS_PER_PAGE;
 
   int get rightmostPage {
-    var extension = max(MAX_PAGES ~/ 2 - leftmostPage, 1);
-    return 1 + min(offset ~/ RESULTS_PER_PAGE + MAX_PAGES ~/ 2 + extension,
-                   count ~/ RESULTS_PER_PAGE);
+    final extension = max(MAX_PAGES ~/ 2 - leftmostPage, 1);
+    return 1 +
+        min(offset ~/ RESULTS_PER_PAGE + MAX_PAGES ~/ 2 + extension,
+            count ~/ RESULTS_PER_PAGE);
   }
 
   List<Map> hrefPatterns() {
-    var results = [];
+    final List<Map> results = [];
 
     results.add({
-        'state' : {'state' : currentPage <= 1 ? 'disabled' : null},
-        'href' : {'href' : formatHref(currentPage - 1) },
-        'text' : '&laquo',
+      'state': {'state': currentPage <= 1 ? 'disabled' : null},
+      'href': {'href': formatHref(currentPage - 1)},
+      'text': '&laquo',
     });
 
     for (int page = leftmostPage; page <= rightmostPage; page++) {
-      String state = (page == currentPage) ? 'active' : null;
+      final String state = (page == currentPage) ? 'active' : null;
 
       results.add({
-          'state' : {'state' : state },
-          'href' : {'href' : formatHref(page) },
-          'text' : '$page',
+        'state': {'state': state},
+        'href': {'href': formatHref(page)},
+        'text': '$page',
       });
     }
 
     results.add({
-        'state' : {
-          'state' : currentPage >= rightmostPage ? 'disabled' : null
-        },
-        'href' : {'href' : formatHref(currentPage + 1) },
-        'text' : '&raquo',
+      'state': {'state': currentPage >= rightmostPage ? 'disabled' : null},
+      'href': {'href': formatHref(currentPage + 1)},
+      'text': '&raquo',
     });
     return results;
   }
@@ -468,8 +467,9 @@ class SearchLinks extends PageLinks {
 
   SearchLinks.empty(this.query) : super.empty();
 
-  String formatHref(int page)
-      => '/search?q=${Uri.encodeQueryComponent(query)}&page=$page';
+  @override
+  String formatHref(int page) =>
+      '/search?q=${Uri.encodeQueryComponent(query)}&page=$page';
 }
 
 class PackageLinks extends PageLinks {
@@ -480,5 +480,6 @@ class PackageLinks extends PageLinks {
 
   PackageLinks.empty() : super.empty();
 
+  @override
   String formatHref(int page) => '/packages?page=$page';
 }

--- a/app/lib/upload_signer_service.dart
+++ b/app/lib/upload_signer_service.dart
@@ -23,8 +23,8 @@ UploadSignerService get uploadSigner => ss.lookup(#_url_signer);
 
 /// Register a new [UploadSignerService] object into the current service
 /// scope.
-void registerUploadSigner(UploadSignerService uploadSigner)
-    => ss.register(#_url_signer, uploadSigner);
+void registerUploadSigner(UploadSignerService uploadSigner) =>
+    ss.register(#_url_signer, uploadSigner);
 
 /// Signs Google Cloud Storage upload URLs.
 ///
@@ -43,42 +43,39 @@ abstract class UploadSignerService {
   static const int MAX_UPLOAD_SIZE = 100 * 1024 * 1024;
   static final Uri UploadUrl = Uri.parse('https://storage.googleapis.com');
 
-  Future<AsyncUploadInfo> buildUpload(
-      String bucket,
-      String object,
-      Duration lifetime,
-      String successRedirectUrl,
+  Future<AsyncUploadInfo> buildUpload(String bucket, String object,
+      Duration lifetime, String successRedirectUrl,
       {String predefinedAcl: 'project-private',
-       int maxUploadSize: MAX_UPLOAD_SIZE}) async {
-    var now = new DateTime.now().toUtc();
-    var expirationString = now.add(lifetime).toIso8601String();
+      int maxUploadSize: MAX_UPLOAD_SIZE}) async {
+    final now = new DateTime.now().toUtc();
+    final expirationString = now.add(lifetime).toIso8601String();
 
     object = '$bucket/$object';
-    var conditions = [
-        {'key' : object},
-        {'acl' : predefinedAcl},
-        {'expires' : expirationString},
-        {'success_action_redirect' : successRedirectUrl},
-        ['content-length-range', 0, maxUploadSize],
+    final conditions = [
+      {'key': object},
+      {'acl': predefinedAcl},
+      {'expires': expirationString},
+      {'success_action_redirect': successRedirectUrl},
+      ['content-length-range', 0, maxUploadSize],
     ];
 
-    var policyMap = {
-        'expiration' : expirationString,
-        'conditions' : conditions,
+    final policyMap = {
+      'expiration': expirationString,
+      'conditions': conditions,
     };
 
-    var policyString = BASE64.encode(UTF8.encode(JSON.encode(policyMap)));
+    final policyString = BASE64.encode(UTF8.encode(JSON.encode(policyMap)));
     final SigningResult result = await sign(ASCII.encode(policyString));
     final signatureString = BASE64.encode(result.bytes);
 
-    var fields = {
-        'key' : object,
-        'acl' : predefinedAcl,
-        'Expires' : expirationString,
-        'GoogleAccessId' : result.googleAccessId,
-        'policy' : policyString,
-        'signature' : signatureString,
-        'success_action_redirect' : successRedirectUrl,
+    final fields = {
+      'key': object,
+      'acl': predefinedAcl,
+      'Expires': expirationString,
+      'GoogleAccessId': result.googleAccessId,
+      'policy': policyString,
+      'signature': signatureString,
+      'success_action_redirect': successRedirectUrl,
     };
 
     return new AsyncUploadInfo(UploadUrl, fields);
@@ -99,6 +96,7 @@ class ServiceAccountBasedUploadSigner extends UploadSignerService {
       : googleAccessId = account.email,
         signer = new RS256Signer(account.privateRSAKey);
 
+  @override
   Future<SigningResult> sign(List<int> bytes) async {
     return new SigningResult(googleAccessId, signer.sign(bytes));
   }
@@ -113,11 +111,11 @@ class IamBasedUploadSigner extends UploadSignerService {
   final iam.IamApi iamApi;
 
   IamBasedUploadSigner(this.projectId, this.email, http.Client client)
-    : iamApi = new iam.IamApi(client);
+      : iamApi = new iam.IamApi(client);
 
+  @override
   Future<SigningResult> sign(List<int> bytes) async {
-    final request = new iam.SignBlobRequest()
-        ..bytesToSignAsBytes = bytes;
+    final request = new iam.SignBlobRequest()..bytesToSignAsBytes = bytes;
     final name = 'projects/$projectId/serviceAccounts/$email';
     final iam.SignBlobResponse response =
         await iamApi.projects.serviceAccounts.signBlob(request, name);

--- a/app/lib/utils.dart
+++ b/app/lib/utils.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 
 import 'package:pub_semver/pub_semver.dart' as semver;
 
-Future withTempDirectory(Future func(Directory dir),
-                         {String prefix: 'dart-tempdir'}) {
+Future<T> withTempDirectory<T>(Future<T> func(Directory dir),
+    {String prefix: 'dart-tempdir'}) {
   return Directory.systemTemp.createTemp(prefix).then((Directory dir) {
     return func(dir).whenComplete(() {
       return dir.delete(recursive: true);
@@ -19,7 +19,7 @@ Future withTempDirectory(Future func(Directory dir),
 }
 
 Future<List<String>> listTarball(String path) async {
-  var result = await Process.run('tar', ['--exclude=*/*/*', '-tzf', path]);
+  final result = await Process.run('tar', ['--exclude=*/*/*', '-tzf', path]);
   if (result.exitCode != 0) {
     throw 'Failed to list tarball contents.';
   }
@@ -28,7 +28,7 @@ Future<List<String>> listTarball(String path) async {
 }
 
 Future<String> readTarballFile(String path, String name) async {
-  var result = await Process.run('tar', ['-O', '-xzf', path, name]);
+  final result = await Process.run('tar', ['-O', '-xzf', path, name]);
   if (result.exitCode != 0) throw 'Failed to read tarball contents.';
 
   return result.stdout;
@@ -37,13 +37,15 @@ Future<String> readTarballFile(String path, String name) async {
 String canonicalizeVersion(String version) {
   // NOTE: This is a hack because [semver.Version.parse] does not remove
   // leading zeros for integer fields.
-  var v = new semver.Version.parse(version);
-  var pre = v.preRelease != null && v.preRelease.isNotEmpty ?
-      v.preRelease.join('.') : null;
-  var build = v.build != null && v.build.isNotEmpty ? v.build.join('.') : null;
+  final v = new semver.Version.parse(version);
+  final pre = v.preRelease != null && v.preRelease.isNotEmpty
+      ? v.preRelease.join('.')
+      : null;
+  final build =
+      v.build != null && v.build.isNotEmpty ? v.build.join('.') : null;
 
-  var canonicalVersion = new semver.Version(
-      v.major, v.minor, v.patch, pre: pre, build: build);
+  final canonicalVersion =
+      new semver.Version(v.major, v.minor, v.patch, pre: pre, build: build);
 
   if (v != canonicalVersion) {
     throw new StateError(

--- a/app/test/backend_test.dart
+++ b/app/test/backend_test.dart
@@ -21,17 +21,24 @@ import 'backend_test_utils.dart';
 import 'utils.dart';
 
 // TODO: Add missing tests when a query returns more than one result.
-main() {
+void main() {
   group('backend', () {
     group('Backend.latestPackages', () {
-      ({
-        'one package' : [testPackage],
-        'empty' : [],
+      (<String, List<Package>>{
+        'one package': [testPackage],
+        'empty': [],
       }).forEach((String testName, List<Package> expectedPackages) {
         test(testName, () async {
-          var completion = new TestDelayCompletion();
-          queryRunFun({kind, partition, ancestorKey, filters,
-                       filterComparisonObjects, offset, limit, orders}) {
+          final completion = new TestDelayCompletion();
+          Stream<Package> queryRunFun(
+              {kind,
+              partition,
+              ancestorKey,
+              filters,
+              filterComparisonObjects,
+              offset,
+              limit,
+              orders}) {
             completion.complete();
             expect(kind, Package);
             expect(offset, 4);
@@ -40,10 +47,10 @@ main() {
             return new Stream.fromIterable(expectedPackages);
           }
 
-          var db = new DatastoreDBMock(queryMock: new QueryMock(queryRunFun));
-          var backend = new Backend(db, null);
+          final db = new DatastoreDBMock(queryMock: new QueryMock(queryRunFun));
+          final backend = new Backend(db, null);
 
-          var packages = await backend.latestPackages(offset: 4, limit: 9);
+          final packages = await backend.latestPackages(offset: 4, limit: 9);
           expect(packages, equals(expectedPackages));
         });
       });
@@ -51,9 +58,16 @@ main() {
 
     group('Backend.latestPackageVersions', () {
       test('one package', () async {
-        var completion = new TestDelayCompletion();
-        queryRunFun({kind, partition, ancestorKey, filters,
-                     filterComparisonObjects, offset, limit, orders}) {
+        final completion = new TestDelayCompletion();
+        Stream<Package> queryRunFun(
+            {kind,
+            partition,
+            ancestorKey,
+            filters,
+            filterComparisonObjects,
+            offset,
+            limit,
+            orders}) {
           completion.complete();
           expect(kind, Package);
           expect(offset, 4);
@@ -62,134 +76,150 @@ main() {
           return new Stream.fromIterable([testPackage]);
         }
 
-        lookupFun(keys) {
+        List<PackageVersion> lookupFun(keys) {
           expect(keys, hasLength(1));
           expect(keys.first, testPackage.latestVersionKey);
           return [testPackageVersion];
         }
 
-        var db = new DatastoreDBMock(queryMock: new QueryMock(queryRunFun),
-                                     lookupFun: expectAsync(lookupFun));
-        var backend = new Backend(db, null);
+        final db = new DatastoreDBMock(
+            queryMock: new QueryMock(queryRunFun),
+            lookupFun: expectAsync1(lookupFun));
+        final backend = new Backend(db, null);
 
-        var versions = await backend.latestPackageVersions(offset: 4, limit: 9);
+        final versions =
+            await backend.latestPackageVersions(offset: 4, limit: 9);
         expect(versions, hasLength(1));
         expect(versions.first, equals(testPackageVersion));
       });
 
       test('empty', () async {
-        var completion = new TestDelayCompletion();
-        queryRunFun({kind, partition, ancestorKey, filters,
-                     filterComparisonObjects, offset, limit, orders}) {
+        final completion = new TestDelayCompletion();
+        Stream<Model> queryRunFun(
+            {kind,
+            partition,
+            ancestorKey,
+            filters,
+            filterComparisonObjects,
+            offset,
+            limit,
+            orders}) {
           completion.complete();
           expect(kind, Package);
           expect(offset, 4);
           expect(limit, 9);
           expect(orders, ['-updated']);
-          return new Stream.fromIterable([]);
+          return new Stream.fromIterable(<Model>[]);
         }
 
-        lookupFun(keys) {
+        List lookupFun(keys) {
           expect(keys, hasLength(0));
           return [];
         }
 
-        var db = new DatastoreDBMock(queryMock: new QueryMock(queryRunFun),
-                                     lookupFun: expectAsync(lookupFun));
-        var backend = new Backend(db, null);
+        final db = new DatastoreDBMock(
+            queryMock: new QueryMock(queryRunFun),
+            lookupFun: expectAsync1(lookupFun));
+        final backend = new Backend(db, null);
 
-        var versions = await backend.latestPackageVersions(offset: 4, limit: 9);
+        final versions =
+            await backend.latestPackageVersions(offset: 4, limit: 9);
         expect(versions, hasLength(0));
       });
     });
 
     group('Backend.lookupPackage', () {
-      ({
-        'exists' : [testPackage],
-        'does not exist' : [null],
+      (<String, List<Package>>{
+        'exists': [testPackage],
+        'does not exist': [null],
       }).forEach((String testName, List<Package> expectedPackages) {
         test(testName, () async {
-          lookupFun(List<Key> keys) {
+          List<Package> lookupFun(List<Key> keys) {
             expect(keys, hasLength(1));
             expect(keys.first.type, Package);
             expect(keys.first.id, 'foobar');
             return expectedPackages;
           }
 
-          var db = new DatastoreDBMock(lookupFun: expectAsync(lookupFun));
-          var backend = new Backend(db, null);
+          final db = new DatastoreDBMock(lookupFun: expectAsync1(lookupFun));
+          final backend = new Backend(db, null);
 
-          var package = await backend.lookupPackage('foobar');
+          final package = await backend.lookupPackage('foobar');
           expect(package, equals(expectedPackages.first));
         });
       });
     });
 
     group('Backend.lookupPackageVersion', () {
-      ({
-        'exists' : [testPackageVersion],
-        'does not exist' : [null],
+      (<String, List<PackageVersion>>{
+        'exists': [testPackageVersion],
+        'does not exist': [null],
       }).forEach((String testName, List<PackageVersion> expectedVersions) {
         test(testName, () async {
-          lookupFun(List<Key> keys) {
+          List<PackageVersion> lookupFun(List<Key> keys) {
             expect(keys, hasLength(1));
             expect(keys.first, testPackageVersion.key);
             return expectedVersions;
           }
 
-          var db = new DatastoreDBMock(lookupFun: expectAsync(lookupFun));
-          var backend = new Backend(db, null);
+          final db = new DatastoreDBMock(lookupFun: expectAsync1(lookupFun));
+          final backend = new Backend(db, null);
 
-          var version = await backend.lookupPackageVersion(
+          final version = await backend.lookupPackageVersion(
               testPackageVersion.package, testPackageVersion.version);
           expect(version, equals(expectedVersions.first));
         });
       });
     });
 
-
     group('Backend.lookupLatestVersions', () {
-      ({
-        'one version' : [testPackageVersion],
-        'empty' : [null],
+      (<String, List<PackageVersion>>{
+        'one version': [testPackageVersion],
+        'empty': [null],
       }).forEach((String testName, List<PackageVersion> expectedVersions) {
         test(testName, () async {
-          lookupFun(List<Key> keys) {
+          List<PackageVersion> lookupFun(List<Key> keys) {
             expect(keys, hasLength(1));
             expect(keys.first, testPackageVersion.key);
             return expectedVersions;
           }
 
-          var db = new DatastoreDBMock(lookupFun: expectAsync(lookupFun));
-          var backend = new Backend(db, null);
+          final db = new DatastoreDBMock(lookupFun: expectAsync1(lookupFun));
+          final backend = new Backend(db, null);
 
-          var versions = await backend.lookupLatestVersions([testPackage]);
+          final versions = await backend.lookupLatestVersions([testPackage]);
           expect(versions, hasLength(1));
           expect(versions.first, equals(expectedVersions.first));
         });
       });
     });
 
-
     group('Backend.versionsOfPackage', () {
-      ({
-        'one version' : [testPackageVersion],
-        'empty' : [null],
+      (<String, List<PackageVersion>>{
+        'one version': [testPackageVersion],
+        'empty': [null],
       }).forEach((String testName, List<PackageVersion> expectedVersions) {
         test(testName, () async {
-          var completion = new TestDelayCompletion();
-          queryRunFun({kind, partition, ancestorKey, filters,
-                       filterComparisonObjects, offset, limit, orders}) {
+          final completion = new TestDelayCompletion();
+          Stream<PackageVersion> queryRunFun(
+              {kind,
+              partition,
+              ancestorKey,
+              filters,
+              filterComparisonObjects,
+              offset,
+              limit,
+              orders}) {
             completion.complete();
             expect(kind, PackageVersion);
             expect(ancestorKey, testPackage.key);
             return new Stream.fromIterable(expectedVersions);
           }
 
-          var db = new DatastoreDBMock(queryMock: new QueryMock(queryRunFun));
-          var backend = new Backend(db, null);
+          final db = new DatastoreDBMock(queryMock: new QueryMock(queryRunFun));
+          final backend = new Backend(db, null);
 
-          var versions = await backend.versionsOfPackage(testPackage.name);
+          final versions = await backend.versionsOfPackage(testPackage.name);
           expect(versions, hasLength(1));
           expect(versions.first, equals(expectedVersions.first));
         });
@@ -197,16 +227,16 @@ main() {
     });
 
     test('Backend.downloadUrl', () async {
-      var db = new DatastoreDBMock();
-      var tarballStorage = new TarballStorageMock(
-          downloadUrlFun: expectAsync((package, version) {
+      final db = new DatastoreDBMock();
+      final tarballStorage = new TarballStorageMock(
+          downloadUrlFun: expectAsync2((package, version) {
         expect(package, 'foobar');
         expect(version, '0.1.0');
         return Uri.parse('http://blob/foobar/0.1.0.tar.gz');
       }));
-      var backend = new Backend(db, tarballStorage);
+      final backend = new Backend(db, tarballStorage);
 
-      var url = await backend.downloadUrl('foobar', '0.1.0');
+      final url = await backend.downloadUrl('foobar', '0.1.0');
       expect(url.toString(), 'http://blob/foobar/0.1.0.tar.gz');
     });
   });
@@ -214,50 +244,50 @@ main() {
   group('backend.repository', () {
     void negativeUploaderTests(Function getMethod(repo)) {
       scopedTest('not logged in', () async {
-        var db = new DatastoreDBMock();
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+        final db = new DatastoreDBMock();
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
-        await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync((e, _) {
+        final pkg = testPackage.name;
+        await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync2((e, _) {
           expect(e is pub_server.UnauthorizedAccessException, isTrue);
         }));
       });
 
       scopedTest('not authorized', () async {
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [testPackage];
             }),
-            rollbackFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            rollbackFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         registerLoggedInUser('foo@bar.com');
-        await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync((e, _) {
+        await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync2((e, _) {
           expect(e is pub_server.UnauthorizedAccessException, isTrue);
         }));
       });
 
       scopedTest('package does not exist', () async {
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [null];
             }),
-            rollbackFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            rollbackFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         registerLoggedInUser(testPackage.uploaderEmails.first);
-        await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync((e, _) {
+        await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync2((e, _) {
           expect('$e', equals('Exception: Package "null" does not exist'));
         }));
       });
@@ -266,77 +296,79 @@ main() {
     group('GCloudRepository.addUploader', () {
       negativeUploaderTests((repo) => repo.addUploader);
 
-      testAlreadyExists(user, uploaderEmails, newUploader) async {
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+      Future testAlreadyExists(user, uploaderEmails, newUploader) async {
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [testPackage];
             }),
-            rollbackFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            rollbackFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         registerLoggedInUser(user);
         testPackage.uploaderEmails = uploaderEmails;
-        await repo.addUploader(pkg, newUploader).catchError(expectAsync((e,_) {
+        await repo
+            .addUploader(pkg, newUploader)
+            .catchError(expectAsync2((e, _) {
           expect(e is pub_server.UploaderAlreadyExistsException, isTrue);
         }));
       }
 
       test('already exists', () async {
-        await scoped(() => testAlreadyExists(
-            'foo@b.com', ['foo@b.com'], 'foo@b.com'));
-        await scoped(() => testAlreadyExists(
-            'foo@B.com', ['foo@b.com'], 'foo@b.com'));
-        await scoped(() => testAlreadyExists(
-            'foo@B.com', ['foo@B.com'], 'foo@b.com'));
-        await scoped(() => testAlreadyExists(
-            'foo@b.com', ['foo@B.com'], 'foo@B.com'));
-        await scoped(() => testAlreadyExists(
-            'foo@b.com', ['foo@b.com'], 'foo@B.com'));
-        await scoped(() => testAlreadyExists(
-            'foo@B.com', ['foo@b.com'], 'foo@B.com'));
+        await scoped(
+            () => testAlreadyExists('foo@b.com', ['foo@b.com'], 'foo@b.com'));
+        await scoped(
+            () => testAlreadyExists('foo@B.com', ['foo@b.com'], 'foo@b.com'));
+        await scoped(
+            () => testAlreadyExists('foo@B.com', ['foo@B.com'], 'foo@b.com'));
+        await scoped(
+            () => testAlreadyExists('foo@b.com', ['foo@B.com'], 'foo@B.com'));
+        await scoped(
+            () => testAlreadyExists('foo@b.com', ['foo@b.com'], 'foo@B.com'));
+        await scoped(
+            () => testAlreadyExists('foo@B.com', ['foo@b.com'], 'foo@B.com'));
         await scoped(() => testAlreadyExists(
             'foo@b.com', ['foo@b.com', 'bar@b.com'], 'foo@B.com'));
         await scoped(() => testAlreadyExists(
             'foo@b.com', ['bar@b.com', 'foo@b.com'], 'foo@B.com'));
       });
 
-      testSuccessful(user, uploaderEmails, newUploader) async {
-        var completion = new TestDelayCompletion();
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+      Future testSuccessful(user, uploaderEmails, newUploader) async {
+        final completion = new TestDelayCompletion();
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [testPackage];
             }),
             queueMutationFun: ({inserts, deletes}) {
               expect(inserts, hasLength(1));
-              for (var email in uploaderEmails) {
+              for (final email in uploaderEmails) {
                 expect(inserts.first.uploaderEmails, contains(email));
               }
               expect(inserts.first.uploaderEmails, contains(newUploader));
               completion.complete();
             },
-            commitFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            commitFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         testPackage.uploaderEmails = uploaderEmails;
         registerLoggedInUser(user);
         await repo.addUploader(pkg, newUploader);
-      };
+      }
 
       test('successful', () async {
-        await scoped(() => testSuccessful(
-            'foo@b.com', ['foo@b.com'], 'bar@b.com'));
-        await scoped(() => testSuccessful(
-            'foo@B.com', ['foo@b.com'], 'bar@B.com'));
+        await scoped(
+            () => testSuccessful('foo@b.com', ['foo@b.com'], 'bar@b.com'));
+        await scoped(
+            () => testSuccessful('foo@B.com', ['foo@b.com'], 'bar@B.com'));
         await scoped(() => testSuccessful(
             'foo@B.com', ['foo@B.com', 'bar@b.com'], 'baz@b.com'));
         await scoped(() => testSuccessful(
@@ -348,51 +380,53 @@ main() {
       negativeUploaderTests((repo) => repo.removeUploader);
 
       scopedTest('cannot remove last uploader', () async {
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [testPackage];
             }),
-            rollbackFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            rollbackFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         testPackage.uploaderEmails = ['foo@bar.com'];
         registerLoggedInUser(testPackage.uploaderEmails.first);
-        await repo.removeUploader(pkg, 'foo@bar.com')
-            .catchError(expectAsync((e, _) {
+        await repo
+            .removeUploader(pkg, 'foo@bar.com')
+            .catchError(expectAsync2((e, _) {
           expect(e is pub_server.LastUploaderRemoveException, isTrue);
         }));
       });
 
       scopedTest('cannot remove non-existent uploader', () async {
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [testPackage];
             }),
-            rollbackFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            rollbackFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         testPackage.uploaderEmails = ['foo1@bar.com'];
         registerLoggedInUser(testPackage.uploaderEmails.first);
-        await repo.removeUploader(pkg, 'foo2@bar.com')
-            .catchError(expectAsync((e, _) {
+        await repo
+            .removeUploader(pkg, 'foo2@bar.com')
+            .catchError(expectAsync2((e, _) {
           expect('$e', 'Exception: The uploader to remove does not exist.');
         }));
       });
 
       scopedTest('successful', () async {
-        var completion = new TestDelayCompletion();
-        var transactionMock = new TransactionMock(
-            lookupFun: expectAsync((keys) {
+        final completion = new TestDelayCompletion();
+        final transactionMock = new TransactionMock(
+            lookupFun: expectAsync1((keys) {
               expect(keys, hasLength(1));
               expect(keys.first, testPackage.key);
               return [testPackage];
@@ -402,12 +436,12 @@ main() {
               expect(inserts.first.uploaderEmails.contains('b@x.com'), isFalse);
               completion.complete();
             },
-            commitFun: expectAsync(() {}));
-        var db = new DatastoreDBMock(transactionMock: transactionMock);
-        var tarballStorage = new TarballStorageMock();
-        var repo = new GCloudPackageRepository(db, tarballStorage);
+            commitFun: expectAsync0(() {}));
+        final db = new DatastoreDBMock(transactionMock: transactionMock);
+        final tarballStorage = new TarballStorageMock();
+        final repo = new GCloudPackageRepository(db, tarballStorage);
 
-        var pkg = testPackage.name;
+        final pkg = testPackage.name;
         testPackage.uploaderEmails = ['a@x.com', 'b@x.com'];
         registerLoggedInUser(testPackage.uploaderEmails.first);
         await repo.removeUploader(pkg, 'b@x.com');
@@ -416,53 +450,55 @@ main() {
 
     group('GCloudRepository.downloadUrl', () {
       test('successful', () async {
-        var tarballStorage = new TarballStorageMock(
-            downloadUrlFun: expectAsync((package, version) {
+        final tarballStorage = new TarballStorageMock(
+            downloadUrlFun: expectAsync2((package, version) {
           return Uri.parse('http://blobstore/$package/$version.tar.gz');
         }));
-        var repo = new GCloudPackageRepository(null, tarballStorage);
+        final repo = new GCloudPackageRepository(null, tarballStorage);
 
-        var url = await repo.downloadUrl('foo', '0.1.0');
+        final url = await repo.downloadUrl('foo', '0.1.0');
         expect('$url', 'http://blobstore/foo/0.1.0.tar.gz');
       });
     });
 
     group('GCloudRepository.download', () {
       test('successful', () async {
-        var tarballStorage = new TarballStorageMock(
-            downloadFun: expectAsync((package, version) {
-          return new Stream.fromIterable([[1, 2, 3]]);
+        final tarballStorage = new TarballStorageMock(
+            downloadFun: expectAsync2((package, version) {
+          return new Stream.fromIterable([
+            [1, 2, 3]
+          ]);
         }));
-        var repo = new GCloudPackageRepository(null, tarballStorage);
+        final repo = new GCloudPackageRepository(null, tarballStorage);
 
-        var stream = await repo.download('foo', '0.1.0');
-        var data = await stream.fold([], (b, d) => b..addAll(d));
+        final stream = await repo.download('foo', '0.1.0');
+        final data = await stream.fold([], (b, d) => b..addAll(d));
         expect(data, [1, 2, 3]);
       });
     });
 
     group('GCloudRepository.lookupVersion', () {
       test('not found', () async {
-        var db = new DatastoreDBMock(lookupFun: expectAsync((keys) {
+        final db = new DatastoreDBMock(lookupFun: expectAsync1((keys) {
           expect(keys, hasLength(1));
           expect(keys.first, testPackageVersionKey);
           return [null];
         }));
-        var repo = new GCloudPackageRepository(db, null);
-        var version = await repo.lookupVersion(testPackageVersion.package,
-                                               testPackageVersion.version);
+        final repo = new GCloudPackageRepository(db, null);
+        final version = await repo.lookupVersion(
+            testPackageVersion.package, testPackageVersion.version);
         expect(version, isNull);
       });
 
       test('successful', () async {
-        var db = new DatastoreDBMock(lookupFun: expectAsync((keys) {
+        final db = new DatastoreDBMock(lookupFun: expectAsync1((keys) {
           expect(keys, hasLength(1));
           expect(keys.first, testPackageVersionKey);
           return [testPackageVersion];
         }));
-        var repo = new GCloudPackageRepository(db, null);
-        var version = await repo.lookupVersion(testPackageVersion.package,
-                                               testPackageVersion.version);
+        final repo = new GCloudPackageRepository(db, null);
+        final version = await repo.lookupVersion(
+            testPackageVersion.package, testPackageVersion.version);
         expect(version, isNotNull);
         expect(version.packageName, testPackageVersion.package);
         expect(version.versionString, testPackageVersion.version);
@@ -471,34 +507,52 @@ main() {
 
     group('GCloudRepository.versions', () {
       test('not found', () async {
-        var completion = new TestDelayCompletion();
-        queryRunFun({kind, partition, ancestorKey, filters,
-                     filterComparisonObjects, offset, limit, orders}) {
+        final completion = new TestDelayCompletion();
+        Stream<Model> queryRunFun(
+            {kind,
+            partition,
+            ancestorKey,
+            filters,
+            filterComparisonObjects,
+            offset,
+            limit,
+            orders}) {
           completion.complete();
           expect(kind, PackageVersion);
           expect(ancestorKey, testPackageKey);
-          return new Stream.fromIterable([]);
+          return new Stream.fromIterable(<Model>[]);
         }
-        var queryMock = new QueryMock(queryRunFun);
-        var db = new DatastoreDBMock(queryMock: queryMock);
-        var repo = new GCloudPackageRepository(db, null);
-        var version = await repo.versions(testPackageVersion.package).toList();
+
+        final queryMock = new QueryMock(queryRunFun);
+        final db = new DatastoreDBMock(queryMock: queryMock);
+        final repo = new GCloudPackageRepository(db, null);
+        final version =
+            await repo.versions(testPackageVersion.package).toList();
         expect(version, isEmpty);
       });
 
       test('found', () async {
-        var completion = new TestDelayCompletion();
-        queryRunFun({kind, partition, ancestorKey, filters,
-                     filterComparisonObjects, offset, limit, orders}) {
+        final completion = new TestDelayCompletion();
+        Stream<PackageVersion> queryRunFun(
+            {kind,
+            partition,
+            ancestorKey,
+            filters,
+            filterComparisonObjects,
+            offset,
+            limit,
+            orders}) {
           completion.complete();
           expect(kind, PackageVersion);
           expect(ancestorKey, testPackageKey);
           return new Stream.fromIterable([testPackageVersion]);
         }
-        var queryMock = new QueryMock(queryRunFun);
-        var db = new DatastoreDBMock(queryMock: queryMock);
-        var repo = new GCloudPackageRepository(db, null);
-        var version = await repo.versions(testPackageVersion.package).toList();
+
+        final queryMock = new QueryMock(queryRunFun);
+        final db = new DatastoreDBMock(queryMock: queryMock);
+        final repo = new GCloudPackageRepository(db, null);
+        final version =
+            await repo.versions(testPackageVersion.package).toList();
         expect(version, hasLength(1));
         expect(version.first.packageName, testPackageVersion.package);
         expect(version.first.versionString, testPackageVersion.version);
@@ -506,12 +560,12 @@ main() {
     });
 
     group('uploading', () {
-      var dateBeforeTest = new DateTime.now().toUtc();
+      final dateBeforeTest = new DateTime.now().toUtc();
 
-      validateSuccessfullUpdate(List<Model> inserts) {
+      void validateSuccessfullUpdate(List<Model> inserts) {
         expect(inserts, hasLength(2));
-        Package package = inserts[0];
-        PackageVersion version = inserts[1];
+        final Package package = inserts[0];
+        final PackageVersion version = inserts[1];
 
         expect(package.key, testPackage.key);
         expect(package.name, testPackage.name);
@@ -534,58 +588,64 @@ main() {
         expect(version.sortOrder, 1);
       }
 
-      validateSuccessfullSortOrderUpdate(PackageVersion model) {
+      void validateSuccessfullSortOrderUpdate(PackageVersion model) {
         expect(model.sortOrder, 0);
       }
 
-      sortOrderUpdateQueryMock({Type kind, Partition partition, Key ancestorKey,
-                                List<String> filters,
-                                List filterComparisonObjects,
-                                int offset, int limit,
-                                List<String> orders}) {
-          expect(orders, []);
-          expect(filters, []);
-          expect(offset, isNull);
-          expect(limit, isNull);
-          expect(kind, PackageVersion);
-          expect(ancestorKey, testPackage.key);
-          testPackageVersion.sortOrder = 50;
-          return new Stream.fromIterable([testPackageVersion]);
+      Stream<PackageVersion> sortOrderUpdateQueryMock(
+          {Type kind,
+          Partition partition,
+          Key ancestorKey,
+          List<String> filters,
+          List filterComparisonObjects,
+          int offset,
+          int limit,
+          List<String> orders}) {
+        expect(orders, []);
+        expect(filters, []);
+        expect(offset, isNull);
+        expect(limit, isNull);
+        expect(kind, PackageVersion);
+        expect(ancestorKey, testPackage.key);
+        testPackageVersion.sortOrder = 50;
+        return new Stream.fromIterable([testPackageVersion]);
       }
 
       group('GCloudRepository.startAsyncUpload', () {
         final Uri redirectUri = Uri.parse('http://blobstore.com/upload');
 
         scopedTest('no active user', () async {
-          var db = new DatastoreDBMock();
-          var repo = new GCloudPackageRepository(db, null);
+          final db = new DatastoreDBMock();
+          final repo = new GCloudPackageRepository(db, null);
           registerUploadSigner(new UploadSignerServiceMock(null));
-          await repo.startAsyncUpload(redirectUri)
-              .catchError(expectAsync((e, _) {
+          await repo
+              .startAsyncUpload(redirectUri)
+              .catchError(expectAsync2((e, _) {
             expect(e is pub_server.UnauthorizedAccessException, isTrue);
           }));
         });
 
         scopedTest('successful', () async {
-          var uri = Uri.parse('http://foobar.com');
-          var expectedUploadInfo =
-              new pub_server.AsyncUploadInfo(uri, {'a' : 'b'});
-          var bucketMock = new BucketMock('mbucket');
-          var tarballStorage = new TarballStorageMock(
-              tmpObjectNameFun: expectAsync((guid) {
+          final uri = Uri.parse('http://foobar.com');
+          final expectedUploadInfo =
+              new pub_server.AsyncUploadInfo(uri, {'a': 'b'});
+          final bucketMock = new BucketMock('mbucket');
+          final tarballStorage = new TarballStorageMock(
+              tmpObjectNameFun: expectAsync1((guid) {
                 return 'obj/$guid';
-              }), bucketMock: bucketMock);
-          var db = new DatastoreDBMock();
-          var repo = new GCloudPackageRepository(db, tarballStorage);
-          var uploadSignerMock = new UploadSignerServiceMock(
+              }),
+              bucketMock: bucketMock);
+          final db = new DatastoreDBMock();
+          final repo = new GCloudPackageRepository(db, tarballStorage);
+          final uploadSignerMock = new UploadSignerServiceMock(
               (bucket, object, lifetime, successRedirectUrl,
-               {predefinedAcl, maxUploadSize}) {
+                  {predefinedAcl, maxUploadSize}) {
             expect(bucket, 'mbucket');
             return expectedUploadInfo;
           });
           registerUploadSigner(uploadSignerMock);
           registerLoggedInUser('hans@juergen.com');
-          var uploadInfo = await repo.startAsyncUpload(redirectUri);
+          final uploadInfo = await repo.startAsyncUpload(redirectUri);
           expect(identical(uploadInfo, expectedUploadInfo), isTrue);
         });
       });
@@ -595,8 +655,8 @@ main() {
             Uri.parse('http://blobstore.com/upload?upload_id=myguid');
 
         scopedTest('upload-too-big', () async {
-          var oneKB = new List.filled(1024, 42);
-          var bigTarball = [];
+          final oneKB = new List.filled(1024, 42);
+          final bigTarball = [];
           for (int i = 0;
               i < UploadSignerService.MAX_UPLOAD_SIZE ~/ 1024;
               i++) {
@@ -605,45 +665,43 @@ main() {
           // Add one more byte than allowed.
           bigTarball.add([1]);
 
-          var tarballStorage = new TarballStorageMock(
-              readTempObjectFun: (guid) {
-                expect(guid, 'myguid');
-                return new Stream.fromIterable(bigTarball);
-              },
-              removeTempObjectFun: (guid) {
-                expect(guid, 'myguid');
-              });
-          var transactionMock = new TransactionMock();
-          var db = new DatastoreDBMock(transactionMock: transactionMock);
-          var repo = new GCloudPackageRepository(db, tarballStorage);
+          final tarballStorage =
+              new TarballStorageMock(readTempObjectFun: (guid) {
+            expect(guid, 'myguid');
+            return new Stream.fromIterable(bigTarball);
+          }, removeTempObjectFun: (guid) {
+            expect(guid, 'myguid');
+          });
+          final transactionMock = new TransactionMock();
+          final db = new DatastoreDBMock(transactionMock: transactionMock);
+          final repo = new GCloudPackageRepository(db, tarballStorage);
           registerLoggedInUser('hans@juergen.com');
-          Future result = repo.finishAsyncUpload(redirectUri);
-          await result.catchError(expectAsync((error, _) {
-            expect(error, contains(
-                'Exceeded ${UploadSignerService.MAX_UPLOAD_SIZE} upload size'));
+          final Future result = repo.finishAsyncUpload(redirectUri);
+          await result.catchError(expectAsync2((error, _) {
+            expect(
+                error,
+                contains(
+                    'Exceeded ${UploadSignerService.MAX_UPLOAD_SIZE} upload size'));
           }));
         });
 
         scopedTest('successful', () async {
           return withTestPackage((List<int> tarball) async {
-            var tarballStorage = new TarballStorageMock(
+            final tarballStorage = new TarballStorageMock(
                 readTempObjectFun: (guid) {
-                  expect(guid, 'myguid');
-                  return new Stream.fromIterable([tarball]);
-                },
-                uploadViaTempObjectFun : (String guid,
-                                          String package,
-                                          String version) {
-                  expect(guid, 'myguid');
-                  expect(package, testPackage.name);
-                  expect(version, testPackageVersion.version);
-                },
-                removeTempObjectFun: (guid) {
-                  expect(guid, 'myguid');
-                });
-            var queryMock = new QueryMock(sortOrderUpdateQueryMock);
+              expect(guid, 'myguid');
+              return new Stream.fromIterable([tarball]);
+            }, uploadViaTempObjectFun:
+                    (String guid, String package, String version) {
+              expect(guid, 'myguid');
+              expect(package, testPackage.name);
+              expect(version, testPackageVersion.version);
+            }, removeTempObjectFun: (guid) {
+              expect(guid, 'myguid');
+            });
+            final queryMock = new QueryMock(sortOrderUpdateQueryMock);
             int queueMutationCallNr = 0;
-            var transactionMock = new TransactionMock(
+            final transactionMock = new TransactionMock(
                 lookupFun: (keys) {
                   expect(keys, hasLength(2));
                   expect(keys.first, testPackageVersion.key);
@@ -660,12 +718,12 @@ main() {
                   }
                   queueMutationCallNr++;
                 },
-                commitFun: expectAsync(() {}, count: 2),
+                commitFun: expectAsync0(() {}, count: 2),
                 queryMock: queryMock);
-            var db = new DatastoreDBMock(transactionMock: transactionMock);
-            var repo = new GCloudPackageRepository(db, tarballStorage);
+            final db = new DatastoreDBMock(transactionMock: transactionMock);
+            final repo = new GCloudPackageRepository(db, tarballStorage);
             registerLoggedInUser('hans@juergen.com');
-            var version = await repo.finishAsyncUpload(redirectUri);
+            final version = await repo.finishAsyncUpload(redirectUri);
             expect(version.packageName, testPackage.name);
             expect(version.versionString, testPackageVersion.version);
           });
@@ -675,12 +733,13 @@ main() {
       group('GCloudRepository.upload', () {
         scopedTest('not logged in', () async {
           return withTestPackage((List<int> tarball) async {
-            var tarballStorage = new TarballStorageMock();
-            var transactionMock = new TransactionMock();
-            var db = new DatastoreDBMock(transactionMock: transactionMock);
-            var repo = new GCloudPackageRepository(db, tarballStorage);
-            repo.upload(new Stream.fromIterable([tarball]))
-                .catchError(expectAsync((error, _) {
+            final tarballStorage = new TarballStorageMock();
+            final transactionMock = new TransactionMock();
+            final db = new DatastoreDBMock(transactionMock: transactionMock);
+            final repo = new GCloudPackageRepository(db, tarballStorage);
+            repo
+                .upload(new Stream.fromIterable([tarball]))
+                .catchError(expectAsync2((error, _) {
               expect(error is pub_server.UnauthorizedAccessException, isTrue);
             }));
           });
@@ -688,20 +747,21 @@ main() {
 
         scopedTest('not authorized', () async {
           return withTestPackage((List<int> tarball) async {
-            var tarballStorage = new TarballStorageMock();
-            var transactionMock = new TransactionMock(
-                lookupFun: expectAsync((keys) {
+            final tarballStorage = new TarballStorageMock();
+            final transactionMock = new TransactionMock(
+                lookupFun: expectAsync1((keys) {
                   expect(keys, hasLength(2));
                   expect(keys.first, testPackageVersion.key);
                   expect(keys.last, testPackage.key);
                   return [null, testPackage];
                 }),
-                rollbackFun: expectAsync(() {}));
-            var db = new DatastoreDBMock(transactionMock: transactionMock);
-            var repo = new GCloudPackageRepository(db, tarballStorage);
+                rollbackFun: expectAsync0(() {}));
+            final db = new DatastoreDBMock(transactionMock: transactionMock);
+            final repo = new GCloudPackageRepository(db, tarballStorage);
             registerLoggedInUser('un@authorized.com');
-            repo.upload(new Stream.fromIterable([tarball]))
-                .catchError(expectAsync((error, _) {
+            repo
+                .upload(new Stream.fromIterable([tarball]))
+                .catchError(expectAsync2((error, _) {
               expect(error is pub_server.UnauthorizedAccessException, isTrue);
             }));
           });
@@ -709,20 +769,21 @@ main() {
 
         scopedTest('versions already exist', () async {
           return withTestPackage((List<int> tarball) async {
-            var tarballStorage = new TarballStorageMock();
-            var transactionMock = new TransactionMock(
-                lookupFun: expectAsync((keys) {
+            final tarballStorage = new TarballStorageMock();
+            final transactionMock = new TransactionMock(
+                lookupFun: expectAsync1((keys) {
                   expect(keys, hasLength(2));
                   expect(keys.first, testPackageVersion.key);
                   expect(keys.last, testPackage.key);
                   return [testPackageVersion, testPackage];
                 }),
-                rollbackFun: expectAsync(() {}));
-            var db = new DatastoreDBMock(transactionMock: transactionMock);
-            var repo = new GCloudPackageRepository(db, tarballStorage);
+                rollbackFun: expectAsync0(() {}));
+            final db = new DatastoreDBMock(transactionMock: transactionMock);
+            final repo = new GCloudPackageRepository(db, tarballStorage);
             registerLoggedInUser('un@authorized.com');
-            repo.upload(new Stream.fromIterable([tarball]))
-                .catchError(expectAsync((error, _) {
+            repo
+                .upload(new Stream.fromIterable([tarball]))
+                .catchError(expectAsync2((error, _) {
               expect(
                   '$error'.contains(
                       'Version 0.1.1 of package foobar_pkg already exists'),
@@ -763,8 +824,8 @@ main() {
         });
 
         scopedTest('upload-too-big', () async {
-          var oneKB = new List.filled(1024, 42);
-          var bigTarball = [];
+          final oneKB = new List.filled(1024, 42);
+          final List<List<int>> bigTarball = [];
           for (int i = 0;
               i < UploadSignerService.MAX_UPLOAD_SIZE ~/ 1024;
               i++) {
@@ -773,41 +834,43 @@ main() {
           // Add one more byte than allowed.
           bigTarball.add([1]);
 
-          var tarballStorage = new TarballStorageMock();
-          var transactionMock = new TransactionMock();
-          var db = new DatastoreDBMock(transactionMock: transactionMock);
-          var repo = new GCloudPackageRepository(db, tarballStorage);
+          final tarballStorage = new TarballStorageMock();
+          final transactionMock = new TransactionMock();
+          final db = new DatastoreDBMock(transactionMock: transactionMock);
+          final repo = new GCloudPackageRepository(db, tarballStorage);
           registerLoggedInUser('hans@juergen.com');
-          Future result = repo.upload(new Stream.fromIterable(bigTarball));
-          await result.catchError(expectAsync((error, _) {
-            expect(error, contains(
-                'Exceeded ${UploadSignerService.MAX_UPLOAD_SIZE} upload size'));
+          final Future result =
+              repo.upload(new Stream.fromIterable(bigTarball));
+          await result.catchError(expectAsync2((error, _) {
+            expect(
+                error,
+                contains(
+                    'Exceeded ${UploadSignerService.MAX_UPLOAD_SIZE} upload size'));
           }));
         });
 
         scopedTest('successful', () async {
           return withTestPackage((List<int> tarball) async {
-            var completion = new TestDelayCompletion(count: 2);
-            var tarballStorage = new TarballStorageMock(
-                uploadFun : (String package,
-                             String version,
-                             Stream<List<int>> uploadTarball) async {
-                  expect(package, testPackage.name);
-                  expect(version, testPackageVersion.version);
+            final completion = new TestDelayCompletion(count: 2);
+            final tarballStorage = new TarballStorageMock(uploadFun:
+                (String package, String version,
+                    Stream<List<int>> uploadTarball) async {
+              expect(package, testPackage.name);
+              expect(version, testPackageVersion.version);
 
-                  var bytes =
-                      await uploadTarball.fold([], (b, d) => b..addAll(d));
+              final bytes =
+                  await uploadTarball.fold([], (b, d) => b..addAll(d));
 
-                  expect(bytes, tarball);
-                });
+              expect(bytes, tarball);
+            });
 
             // NOTE: There will be two transactions:
             //  a) for inserting a new Package + PackageVersion
             //  b) for inserting a new PackageVersions sorted by `sort_order`.
             int queueMutationCallNr = 0;
-            var queryMock = new QueryMock(sortOrderUpdateQueryMock);
-            var transactionMock = new TransactionMock(
-                lookupFun: expectAsync((keys) {
+            final queryMock = new QueryMock(sortOrderUpdateQueryMock);
+            final transactionMock = new TransactionMock(
+                lookupFun: expectAsync1((keys) {
                   expect(queueMutationCallNr, 0);
 
                   expect(keys, hasLength(2));
@@ -826,12 +889,13 @@ main() {
                   queueMutationCallNr++;
                   completion.complete();
                 },
-                commitFun: expectAsync(() {}, count: 2),
+                commitFun: expectAsync0(() {}, count: 2),
                 queryMock: queryMock);
-            var db = new DatastoreDBMock(transactionMock: transactionMock);
-            var repo = new GCloudPackageRepository(db, tarballStorage);
+            final db = new DatastoreDBMock(transactionMock: transactionMock);
+            final repo = new GCloudPackageRepository(db, tarballStorage);
             registerLoggedInUser('hans@juergen.com');
-            var version = await repo.upload(new Stream.fromIterable([tarball]));
+            final version =
+                await repo.upload(new Stream.fromIterable([tarball]));
             expect(version.packageName, testPackage.name);
             expect(version.versionString, testPackageVersion.version);
           });

--- a/app/test/backend_test_utils.dart
+++ b/app/test/backend_test_utils.dart
@@ -23,20 +23,27 @@ class DatastoreDBMock extends gdb.DatastoreDB {
   final TransactionMock transactionMock;
   final QueryMock queryMock;
 
-  DatastoreDBMock({this.commitFun, this.lookupFun, this.queryFun,
-                   this.queryMock, this.transactionMock})
+  DatastoreDBMock(
+      {this.commitFun,
+      this.lookupFun,
+      this.queryFun,
+      this.queryMock,
+      this.transactionMock})
       : super(null);
 
+  @override
   Future commit({List<gdb.Model> inserts, List<gdb.Key> deletes}) async {
     if (commitFun == null) throw 'no commitFun';
     return commitFun(inserts: inserts, deletes: deletes);
   }
 
+  @override
   Future<List<gdb.Model>> lookup(List<gdb.Key> keys) async {
     if (lookupFun == null) throw 'no lookupFun';
     return lookupFun(keys);
   }
 
+  @override
   gdb.Query query(Type kind, {gdb.Partition partition, gdb.Key ancestorKey}) {
     if (queryMock == null) throw 'no queryMock';
     queryMock._kind = kind;
@@ -45,6 +52,7 @@ class DatastoreDBMock extends gdb.DatastoreDB {
     return queryMock;
   }
 
+  @override
   Future withTransaction(Future handler(gdb.Transaction transaction)) async {
     if (transactionMock == null) throw 'no transactionMock';
     return handler(transactionMock);
@@ -58,21 +66,29 @@ class TransactionMock implements gdb.Transaction {
   final Function rollbackFun;
   final QueryMock queryMock;
 
+  @override
   gdb.DatastoreDB get db => throw 'db not supported';
 
-  TransactionMock({this.commitFun, this.lookupFun, this.queueMutationFun,
-                   this.rollbackFun, this.queryMock});
+  TransactionMock(
+      {this.commitFun,
+      this.lookupFun,
+      this.queueMutationFun,
+      this.rollbackFun,
+      this.queryMock});
 
+  @override
   Future commit() async {
     if (commitFun == null) throw 'no commitFun';
     return commitFun();
   }
 
+  @override
   Future<List<gdb.Model>> lookup(List<gdb.Key> keys) async {
     if (lookupFun == null) throw 'no lookupFun';
     return lookupFun(keys);
   }
 
+  @override
   gdb.Query query(Type kind, gdb.Key ancestorKey, {gdb.Partition partition}) {
     if (queryMock == null) throw 'no queryMock';
     queryMock._kind = kind;
@@ -81,11 +97,13 @@ class TransactionMock implements gdb.Transaction {
     return queryMock;
   }
 
+  @override
   void queueMutations({List<gdb.Model> inserts, List<gdb.Key> deletes}) {
     if (queueMutationFun == null) throw 'no queueMutationFun';
     queueMutationFun(inserts: inserts, deletes: deletes);
   }
 
+  @override
   Future rollback() async {
     if (rollbackFun == null) throw 'no rollbackFun';
     return rollbackFun();
@@ -108,36 +126,50 @@ class QueryMock implements gdb.Query {
   List<String> _filterComparisonObjects = [];
   int _offset;
   int _limit;
-  List<String> _orders = [];
+  final List<String> _orders = [];
 
+  @override
   void filter(String filterString, Object comparisonObject) {
     _filters.add(filterString);
     _filterComparisonObjects.add(comparisonObject);
   }
 
+  @override
   void limit(int limit) {
     _limit = limit;
   }
 
+  @override
   void offset(int offset) {
     _offset = offset;
   }
 
+  @override
   void order(String orderString) => _orders.add(orderString);
 
+  @override
   Stream<gdb.Model> run() {
-    return runFun(kind: _kind, partition: _partition, ancestorKey: _ancestorKey,
-                  filters: _filters,
-                  filterComparisonObjects: _filterComparisonObjects,
-                  offset: _offset, limit: _limit, orders: _orders);
+    return runFun(
+        kind: _kind,
+        partition: _partition,
+        ancestorKey: _ancestorKey,
+        filters: _filters,
+        filterComparisonObjects: _filterComparisonObjects,
+        offset: _offset,
+        limit: _limit,
+        orders: _orders);
   }
 }
 
-typedef Stream<gdb.Model> QueryMockHandler({
-    Type kind, gdb.Partition partition, gdb.Key ancestorKey,
-    List<String> filters, List filterComparisonObjects, int offset, int limit,
+typedef Stream<gdb.Model> QueryMockHandler(
+    {Type kind,
+    gdb.Partition partition,
+    gdb.Key ancestorKey,
+    List<String> filters,
+    List filterComparisonObjects,
+    int offset,
+    int limit,
     List<String> orders});
-
 
 class TarballStorageMock implements TarballStorage {
   final Function downloadFun;
@@ -149,52 +181,67 @@ class TarballStorageMock implements TarballStorage {
   final Function uploadViaTempObjectFun;
   final BucketMock bucketMock;
 
-  TarballStorageMock({this.downloadFun, this.downloadUrlFun,
-                      this.readTempObjectFun, this.removeTempObjectFun,
-                      this.tmpObjectNameFun, this.uploadFun,
-                      this.uploadViaTempObjectFun, this.bucketMock});
+  TarballStorageMock(
+      {this.downloadFun,
+      this.downloadUrlFun,
+      this.readTempObjectFun,
+      this.removeTempObjectFun,
+      this.tmpObjectNameFun,
+      this.uploadFun,
+      this.uploadViaTempObjectFun,
+      this.bucketMock});
 
-  get bucket => bucketMock;
-  get storage => throw 'no storage support';
-  get namer => throw 'no namer support';
+  @override
+  Bucket get bucket => bucketMock;
+  @override
+  Storage get storage => throw 'no storage support';
+  @override
+  TarballStorageNamer get namer => throw 'no namer support';
 
+  @override
   Stream<List<int>> download(String package, String version) {
     if (downloadFun == null) throw 'no downloadFun';
     return downloadFun(package, version);
   }
 
+  @override
   Future<Uri> downloadUrl(String package, String version) async {
     if (downloadUrlFun == null) throw 'no downloadUrlFun';
     return downloadUrlFun(package, version);
   }
 
+  @override
   Stream<List<int>> readTempObject(String guid) {
     if (readTempObjectFun == null) throw 'no readTempObjectFun';
     return readTempObjectFun(guid);
   }
 
+  @override
   Future removeTempObject(String guid) async {
     if (removeTempObjectFun == null) throw 'no removeTempObjectFun';
     return removeTempObjectFun(guid);
   }
 
-
+  @override
   String tempObjectName(String guid) {
     if (tmpObjectNameFun == null) throw 'no tmpObjectNameFun';
     return tmpObjectNameFun(guid);
   }
 
+  @override
   Future upload(String package, String version, Stream<List<int>> tarball) {
     if (uploadFun == null) throw 'no uploadFun';
     return uploadFun(package, version, tarball);
   }
 
+  @override
   Future uploadViaTempObject(
       String guid, String package, String version) async {
     if (uploadViaTempObjectFun == null) throw 'no uploadViaTempObjectFun';
     return uploadViaTempObjectFun(guid, package, version);
   }
 
+  @override
   Future remove(String package, String version) =>
       throw new UnimplementedError();
 }
@@ -204,12 +251,10 @@ class UploadSignerServiceMock implements UploadSignerService {
 
   UploadSignerServiceMock(this.buildUploadFun);
 
-  get serviceAccountEmail => throw 'no serviceAccountEmail support';
-
   @override
-  Future<AsyncUploadInfo> buildUpload(
-      String bucket, String object, Duration lifetime,
-      String successRedirectUrl, {String predefinedAcl: 'project-private',
+  Future<AsyncUploadInfo> buildUpload(String bucket, String object,
+      Duration lifetime, String successRedirectUrl,
+      {String predefinedAcl: 'project-private',
       int maxUploadSize: UploadSignerService.MAX_UPLOAD_SIZE}) async {
     return buildUploadFun(bucket, object, lifetime, successRedirectUrl,
         predefinedAcl: predefinedAcl, maxUploadSize: maxUploadSize);
@@ -220,53 +265,68 @@ class UploadSignerServiceMock implements UploadSignerService {
 }
 
 class BucketMock implements Bucket {
+  @override
   final String bucketName;
 
   BucketMock(this.bucketName);
 
+  @override
   String absoluteObjectName(String objectName) {
     throw 'no absoluteObjectName support';
   }
 
+  @override
   Future delete(String name) {
     throw 'no delete support';
   }
 
+  @override
   Future<ObjectInfo> info(String name) {
     throw 'no info support';
   }
 
+  @override
   Stream<BucketEntry> list({String prefix}) {
     throw 'no list support';
   }
 
+  @override
   Future<Page<BucketEntry>> page({String prefix, int pageSize: 50}) {
     throw 'no page support';
   }
 
+  @override
   Stream<List<int>> read(String objectName, {int offset: 0, int length}) {
     throw 'no read support';
   }
 
+  @override
   Future updateMetadata(String objectName, ObjectMetadata metadata) async {
     throw 'no updateMetadata support';
   }
 
+  @override
   StreamSink<List<int>> write(String objectName,
-      {int length, ObjectMetadata metadata, Acl acl,
-       PredefinedAcl predefinedAcl, String contentType}) {
+      {int length,
+      ObjectMetadata metadata,
+      Acl acl,
+      PredefinedAcl predefinedAcl,
+      String contentType}) {
     throw 'no write support';
   }
 
+  @override
   Future<ObjectInfo> writeBytes(String name, List<int> bytes,
-      {ObjectMetadata metadata, Acl acl, PredefinedAcl predefinedAcl,
-       String contentType}) async {
+      {ObjectMetadata metadata,
+      Acl acl,
+      PredefinedAcl predefinedAcl,
+      String contentType}) async {
     throw 'no writeBytes support';
   }
 }
 
 Future withTempDirectory(Future func(temp)) async {
-  Directory dir =
+  final Directory dir =
       await Directory.systemTemp.createTemp('pub.dartlang.org-backend-test');
   return func(dir.absolute.path).whenComplete(() {
     return dir.delete(recursive: true);
@@ -276,9 +336,9 @@ Future withTempDirectory(Future func(temp)) async {
 Future withTestPackage(Future func(List<int> tarball),
     {String pubspecContent}) {
   return withTempDirectory((String tmp) async {
-    var readme = new File('$tmp/README.md');
-    var changelog = new File('$tmp/CHANGELOG.md');
-    var pubspec = new File('$tmp/pubspec.yaml');
+    final readme = new File('$tmp/README.md');
+    final changelog = new File('$tmp/CHANGELOG.md');
+    final pubspec = new File('$tmp/pubspec.yaml');
 
     await readme.writeAsString(TestPackageReadme);
     await changelog.writeAsString(TestPackageChangelog);
@@ -288,13 +348,18 @@ Future withTestPackage(Future func(List<int> tarball),
     new File('$tmp/lib/test_library.dart')
         .writeAsString('hello() => print("hello");');
 
-    var files =
-        ['README.md', 'CHANGELOG.md', 'pubspec.yaml', 'lib/test_library.dart'];
-    var args = ['cz']..addAll(files);
-    Process p = await Process.start('tar', args, workingDirectory: '$tmp');
+    final files = [
+      'README.md',
+      'CHANGELOG.md',
+      'pubspec.yaml',
+      'lib/test_library.dart'
+    ];
+    final args = ['cz']..addAll(files);
+    final Process p =
+        await Process.start('tar', args, workingDirectory: '$tmp');
     p.stderr.drain();
-    var bytes = await p.stdout.fold([], (b, d) => b..addAll(d));
-    var exitCode = await p.exitCode;
+    final bytes = await p.stdout.fold([], (b, d) => b..addAll(d));
+    final exitCode = await p.exitCode;
     if (exitCode != 0) throw 'Failed to make tarball of test package.';
     return func(bytes);
   });

--- a/app/test/handlers_test.dart
+++ b/app/test/handlers_test.dart
@@ -18,14 +18,14 @@ import 'package:pub_dartlang_org/templates.dart';
 import 'utils.dart';
 import 'handlers_test_utils.dart';
 
-tScopedTest(String name, Future func()) {
-  return scopedTest(name, () {
+void tScopedTest(String name, Future func()) {
+  scopedTest(name, () {
     registerTemplateService(new TemplateMock());
     return func();
   });
 }
 
-main() {
+void main() {
   final PageSize = 10;
 
   group('handlers', () {
@@ -37,103 +37,92 @@ main() {
 
     group('ui', () {
       tScopedTest('/', () async {
-        var backend = new BackendMock(
-            latestPackageVersionsFun: ({offset, limit}) {
-              expect(offset, isNull);
-              expect(limit, equals(5));
-              return [testPackageVersion];
-            });
+        final backend =
+            new BackendMock(latestPackageVersionsFun: ({offset, limit}) {
+          expect(offset, isNull);
+          expect(limit, equals(5));
+          return [testPackageVersion];
+        });
         registerBackend(backend);
 
         expectHtmlResponse(await issueGet('/'));
       });
 
       tScopedTest('/packages', () async {
-        var backend = new BackendMock(
-            latestPackagesFun: ({offset, limit}) {
-              expect(offset, 0);
-              expect(limit, greaterThan(PageSize));
-              return [testPackage];
-            },
-            lookupLatestVersionsFun: (List<Package> packages) {
-              expect(packages.length, 1);
-              expect(packages.first, testPackage);
-              return [testPackageVersion];
-            });
+        final backend = new BackendMock(latestPackagesFun: ({offset, limit}) {
+          expect(offset, 0);
+          expect(limit, greaterThan(PageSize));
+          return [testPackage];
+        }, lookupLatestVersionsFun: (List<Package> packages) {
+          expect(packages.length, 1);
+          expect(packages.first, testPackage);
+          return [testPackageVersion];
+        });
         registerBackend(backend);
         expectHtmlResponse(await issueGet('/packages'));
       });
 
       tScopedTest('/packages?page=2', () async {
-        var backend = new BackendMock(
-            latestPackagesFun: ({offset, limit}) {
-              expect(offset, PageSize);
-              expect(limit, greaterThan(PageSize));
-              return [testPackage];
-            },
-            lookupLatestVersionsFun: (List<Package> packages) {
-              expect(packages.length, 1);
-              expect(packages.first, testPackage);
-              return [testPackageVersion];
-            });
+        final backend = new BackendMock(latestPackagesFun: ({offset, limit}) {
+          expect(offset, PageSize);
+          expect(limit, greaterThan(PageSize));
+          return [testPackage];
+        }, lookupLatestVersionsFun: (List<Package> packages) {
+          expect(packages.length, 1);
+          expect(packages.first, testPackage);
+          return [testPackageVersion];
+        });
         registerBackend(backend);
         expectHtmlResponse(await issueGet('/packages?page=2'));
       });
 
       tScopedTest('/packages/foobar_pkg - found', () async {
-        var backend = new BackendMock(
-            lookupPackageFun: (String packageName) {
-              expect(packageName, 'foobar_pkg');
-              return testPackage;
-            },
-            versionsOfPackageFun: (String package) {
-              expect(package, testPackage.name);
-              return [testPackageVersion];
-            },
-            downloadUrlFun: (String package, String version) {
-              return Uri.parse('http://blobstore/$package/$version');
-            });
+        final backend = new BackendMock(lookupPackageFun: (String packageName) {
+          expect(packageName, 'foobar_pkg');
+          return testPackage;
+        }, versionsOfPackageFun: (String package) {
+          expect(package, testPackage.name);
+          return [testPackageVersion];
+        }, downloadUrlFun: (String package, String version) {
+          return Uri.parse('http://blobstore/$package/$version');
+        });
         registerBackend(backend);
         expectHtmlResponse(await issueGet('/packages/foobar_pkg'));
       });
 
       tScopedTest('/packages/foobar_pkg - not found', () async {
-        var backend = new BackendMock(
-            lookupPackageFun: (String packageName) {
-              expect(packageName, 'foobar_pkg');
-              return null;
-            });
+        final backend = new BackendMock(lookupPackageFun: (String packageName) {
+          expect(packageName, 'foobar_pkg');
+          return null;
+        });
         registerBackend(backend);
         expectHtmlResponse(await issueGet('/packages/foobar_pkg'), status: 404);
       });
 
       tScopedTest('/packages/foobar_pkg/versions - found', () async {
-        var backend = new BackendMock(
-            versionsOfPackageFun: (String package) {
-              expect(package, testPackage.name);
-              return [testPackageVersion];
-            },
-            downloadUrlFun: (String package, String version) {
-              return Uri.parse('http://blobstore/$package/$version');
-            });
+        final backend = new BackendMock(versionsOfPackageFun: (String package) {
+          expect(package, testPackage.name);
+          return [testPackageVersion];
+        }, downloadUrlFun: (String package, String version) {
+          return Uri.parse('http://blobstore/$package/$version');
+        });
         registerBackend(backend);
         expectHtmlResponse(await issueGet('/packages/foobar_pkg/versions'));
       });
 
       tScopedTest('/packages/foobar_pkg/versions - not found', () async {
-        var backend = new BackendMock(
-            versionsOfPackageFun: (String package) {
-              expect(package, testPackage.name);
-              return [];
-            });
+        final backend = new BackendMock(versionsOfPackageFun: (String package) {
+          expect(package, testPackage.name);
+          return [];
+        });
         registerBackend(backend);
         expectHtmlResponse(await issueGet('/packages/foobar_pkg/versions'),
-                           status: 404);
+            status: 404);
       });
 
       tScopedTest('/doc', () async {
         for (var path in REDIRECT_PATHS.keys) {
-          var redirectUrl =
+          final redirectUrl =
               'https://www.dartlang.org/tools/pub/${REDIRECT_PATHS[path]}';
           expectRedirectResponse(await issueGet(path), redirectUrl);
         }
@@ -148,8 +137,8 @@ main() {
       });
 
       tScopedTest('/search?q=foobar', () async {
-        registerSearchService(new SearchServiceMock(
-            (String query, int offset, int numResults) {
+        registerSearchService(
+            new SearchServiceMock((String query, int offset, int numResults) {
           expect(query, 'foobar');
           expect(offset, 0);
           expect(numResults, PageSize);
@@ -160,8 +149,8 @@ main() {
       });
 
       tScopedTest('/search?q=foobar&page=2', () async {
-        registerSearchService(new SearchServiceMock(
-            (String query, int offset, int numResults) {
+        registerSearchService(
+            new SearchServiceMock((String query, int offset, int numResults) {
           expect(query, 'foobar');
           expect(offset, PageSize);
           expect(numResults, PageSize);
@@ -172,14 +161,15 @@ main() {
       });
 
       tScopedTest('/feed.atom', () async {
-        var backend = new BackendMock(
-            latestPackageVersionsFun: ({offset, limit}) {
-              expect(offset, 0);
-              expect(limit, PageSize);
-              return [testPackageVersion];
-            });
+        final backend =
+            new BackendMock(latestPackageVersionsFun: ({offset, limit}) {
+          expect(offset, 0);
+          expect(limit, PageSize);
+          return [testPackageVersion];
+        });
         registerBackend(backend);
-        expectAtomXmlResponse(await issueGet('/feed.atom'), regexp: '''
+        expectAtomXmlResponse(await issueGet('/feed.atom'),
+            regexp: '''
 <\\?xml version="1.0" encoding="UTF-8"\\?>
 <feed xmlns="http://www.w3.org/2005/Atom">
         <id>https://pub.dartlang.org/feed.atom</id>
@@ -192,7 +182,7 @@ main() {
         <link href="https://pub.dartlang.org/feed.atom" rel="self" />
         <generator version="0.1.0">Pub Feed Generator</generator>
         <subtitle>Last Updated Packages</subtitle>
-        
+
         <entry>
           <id>urn:uuid:f38e70f0-13de-51b6-88b8-57430c66ce75</id>
           <title>v0.1.1 of foobar_pkg</title>
@@ -203,7 +193,7 @@ main() {
                 rel="alternate"
                 title="foobar_pkg" />
         </entry>
-      
+
 </feed>
 ''');
       });
@@ -211,50 +201,45 @@ main() {
 
     group('old api', () {
       scopedTest('/packages.json', () async {
-        var backend = new BackendMock(
-            latestPackagesFun: ({offset, limit}) {
-              expect(offset, 0);
-              expect(limit, greaterThan(PageSize));
-              return [testPackage];
-            },
-            lookupLatestVersionsFun: (List<Package> packages) {
-              expect(packages.length, 1);
-              expect(packages.first, testPackage);
-              return [testPackageVersion];
-            });
+        final backend = new BackendMock(latestPackagesFun: ({offset, limit}) {
+          expect(offset, 0);
+          expect(limit, greaterThan(PageSize));
+          return [testPackage];
+        }, lookupLatestVersionsFun: (List<Package> packages) {
+          expect(packages.length, 1);
+          expect(packages.first, testPackage);
+          return [testPackageVersion];
+        });
         registerBackend(backend);
         expectJsonResponse(await issueGet('/packages.json'), body: {
-          "packages" : ["https://pub.dartlang.org/packages/foobar_pkg.json"],
-          "next" : null
+          "packages": ["https://pub.dartlang.org/packages/foobar_pkg.json"],
+          "next": null
         });
       });
 
       tScopedTest('/packages/foobar_pkg.json', () async {
-        var backend = new BackendMock(
-            lookupPackageFun: (String package) {
-              expect(package, 'foobar_pkg');
-              return testPackage;
-            },
-            versionsOfPackageFun: (String package) {
-              expect(package, 'foobar_pkg');
-              return [testPackageVersion];
-            });
+        final backend = new BackendMock(lookupPackageFun: (String package) {
+          expect(package, 'foobar_pkg');
+          return testPackage;
+        }, versionsOfPackageFun: (String package) {
+          expect(package, 'foobar_pkg');
+          return [testPackageVersion];
+        });
         registerBackend(backend);
-        expectJsonResponse(await issueGet('/packages/foobar_pkg.json'),
-            body: {
-              "name" : 'foobar_pkg',
-              "uploaders" : ['hans@juergen.com'],
-              "versions" : ['0.1.1'],
-            });
+        expectJsonResponse(await issueGet('/packages/foobar_pkg.json'), body: {
+          "name": 'foobar_pkg',
+          "uploaders": ['hans@juergen.com'],
+          "versions": ['0.1.1'],
+        });
       });
 
       tScopedTest('/packages/foobar_pkg/versions/0.1.1.yaml', () async {
-        var backend = new BackendMock(
+        final backend = new BackendMock(
             lookupPackageVersionFun: (String package, String version) {
-              expect(package, 'foobar_pkg');
-              expect(version, '0.1.1');
-              return testPackageVersion;
-            });
+          expect(package, 'foobar_pkg');
+          expect(version, '0.1.1');
+          return testPackageVersion;
+        });
         registerBackend(backend);
         expectYamlResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.1.yaml'),
@@ -264,17 +249,15 @@ main() {
 
     group('editor api', () {
       tScopedTest('/api/packages', () async {
-        var backend = new BackendMock(
-            latestPackagesFun: ({offset, limit}) {
-              expect(offset, 0);
-              expect(limit, greaterThan(10));
-              return [testPackage];
-            },
-            lookupLatestVersionsFun: (List<Package> packages) {
-              expect(packages.length, 1);
-              expect(packages.first, testPackage);
-              return [testPackageVersion];
-            });
+        final backend = new BackendMock(latestPackagesFun: ({offset, limit}) {
+          expect(offset, 0);
+          expect(limit, greaterThan(10));
+          return [testPackage];
+        }, lookupLatestVersionsFun: (List<Package> packages) {
+          expect(packages.length, 1);
+          expect(packages.first, testPackage);
+          return [testPackageVersion];
+        });
         registerBackend(backend);
         expectJsonResponse(await issueGet('/api/packages'), body: {
           'next_url': null,
@@ -285,7 +268,7 @@ main() {
                 'version': '0.1.1',
                 'pubspec': loadYaml(TestPackagePubspec),
                 'archive_url': 'https://pub.dartlang.org'
-                               '/packages/foobar_pkg/versions/0.1.1.tar.gz',
+                    '/packages/foobar_pkg/versions/0.1.1.tar.gz',
                 'package_url': 'https://pub.dartlang.org'
                                 '/api/packages/foobar_pkg',
                 'url': 'https://pub.dartlang.org'

--- a/app/test/handlers_test_utils.dart
+++ b/app/test/handlers_test_utils.dart
@@ -18,8 +18,8 @@ import 'package:pub_dartlang_org/search_service.dart';
 import 'package:pub_dartlang_org/templates.dart';
 
 Future<shelf.Response> issueGet(String path) async {
-  var uri = 'https://pub.dartlang.org$path';
-  var request = new shelf.Request('GET', Uri.parse(uri));
+  final uri = 'https://pub.dartlang.org$path';
+  final request = new shelf.Request('GET', Uri.parse(uri));
   return appHandler(request, null);
 }
 
@@ -42,11 +42,11 @@ Future expectYamlResponse(shelf.Response response, {status: 200, body}) async {
 }
 
 Future expectAtomXmlResponse(shelf.Response response,
-                             {int status: 200, String regexp}) async {
+    {int status: 200, String regexp}) async {
   expect(response.statusCode, status);
   expect(response.headers['content-type'],
-         'application/atom+xml; charset="utf-8"');
-  var text = await response.readAsString();
+      'application/atom+xml; charset="utf-8"');
+  final text = await response.readAsString();
   expect(new RegExp(regexp).hasMatch(text), isTrue);
 }
 
@@ -69,52 +69,66 @@ class BackendMock implements Backend {
   final Function versionsOfPackageFun;
   final Function downloadUrlFun;
 
-  BackendMock({this.latestPackageVersionsFun,
-               this.latestPackagesFun,
-               this.lookupLatestVersionsFun,
-               this.lookupPackageFun,
-               this.lookupPackageVersionFun,
-               this.versionsOfPackageFun,
-               this.downloadUrlFun});
+  BackendMock(
+      {this.latestPackageVersionsFun,
+      this.latestPackagesFun,
+      this.lookupLatestVersionsFun,
+      this.lookupPackageFun,
+      this.lookupPackageVersionFun,
+      this.versionsOfPackageFun,
+      this.downloadUrlFun});
 
+  @override
+  // ignore: always_declare_return_types
   get db => throw 'unexpected db access';
+  @override
+  // ignore: always_declare_return_types
   get repository => throw 'unexpected repository access';
+  @override
+  // ignore: always_declare_return_types
   get uiPackageCache => null;
 
+  @override
   Future<List<PackageVersion>> latestPackageVersions(
       {int offset: null, int limit: null}) async {
     if (latestPackageVersionsFun == null) throw 'no latestPackageVersionsFun';
     return latestPackageVersionsFun(offset: offset, limit: limit);
   }
 
+  @override
   Future<List<Package>> latestPackages(
       {int offset: null, int limit: null}) async {
     if (latestPackagesFun == null) throw 'no latestPackagesFun';
     return latestPackagesFun(offset: offset, limit: limit);
   }
 
+  @override
   Future<List<PackageVersion>> lookupLatestVersions(
       List<Package> packages) async {
     if (lookupLatestVersionsFun == null) throw 'no lookupLatestVersionsFun';
     return lookupLatestVersionsFun(packages);
   }
 
+  @override
   Future<Package> lookupPackage(String packageName) async {
     if (lookupPackageFun == null) throw 'no lookupPackageVersionFun';
     return lookupPackageFun(packageName);
   }
 
-  Future<PackageVersion> lookupPackageVersion(String package,
-                                              String version) async {
+  @override
+  Future<PackageVersion> lookupPackageVersion(
+      String package, String version) async {
     if (lookupPackageVersionFun == null) throw 'no lookupPackageVersionFun';
     return lookupPackageVersionFun(package, version);
   }
 
+  @override
   Future<List<PackageVersion>> versionsOfPackage(String packageName) async {
     if (versionsOfPackageFun == null) throw 'no versionsOfPackageFun';
     return versionsOfPackageFun(packageName);
   }
 
+  @override
   Future<Uri> downloadUrl(String package, String version) async {
     if (downloadUrlFun == null) throw 'no downloadUrlFun';
     return downloadUrlFun(package, version);
@@ -124,80 +138,95 @@ class BackendMock implements Backend {
 class TemplateMock implements TemplateService {
   static String Response = 'foobar';
 
+  @override
   String get templateDirectory => null;
 
+  @override
   String renderAdminPage(bool privateKeysSet, bool isProduction,
-                         {ReloadStatus reloadStatus}) {
+      {ReloadStatus reloadStatus}) {
     return Response;
   }
 
+  @override
   String renderAuthorizedPage() {
     return Response;
   }
 
+  @override
   String renderErrorPage(String status, String message, String traceback) {
     return Response;
   }
 
+  @override
   String renderIndexPage(List<PackageVersion> recentPackages) {
     return Response;
   }
 
+  @override
   String renderLayoutPage(String title, String contentString,
-                          {PackageVersion packageVersion}) {
+      {PackageVersion packageVersion}) {
     return Response;
   }
 
+  @override
   String renderPagination(PageLinks pageLinks) {
     return Response;
   }
 
-  String renderPkgIndexPage(List<Package> packages,
-                            List<PackageVersion> versions,
-                            PageLinks links) {
+  @override
+  String renderPkgIndexPage(
+      List<Package> packages, List<PackageVersion> versions, PageLinks links) {
     return Response;
   }
 
-  String renderPkgShowPage(Package package,
-                           List<PackageVersion> versions,
-                           List<Uri> versionDownloadUrls,
-                           PackageVersion selectedVersion,
-                           PackageVersion latestStableVersion,
-                           PackageVersion latestDevVersion,
-                           int totalNumberOfVersions) {
+  @override
+  String renderPkgShowPage(
+      Package package,
+      List<PackageVersion> versions,
+      List<Uri> versionDownloadUrls,
+      PackageVersion selectedVersion,
+      PackageVersion latestStableVersion,
+      PackageVersion latestDevVersion,
+      int totalNumberOfVersions) {
     return Response;
   }
 
-  String renderPkgVersionsPage(String package,
-                               List<PackageVersion> versions,
-                               List<Uri> versionDownloadUrls) {
+  @override
+  String renderPkgVersionsPage(String package, List<PackageVersion> versions,
+      List<Uri> versionDownloadUrls) {
     return Response;
   }
 
+  @override
   String renderPrivateKeysNewPage(bool wasAlreadySet, bool isProduction) {
     return Response;
   }
 
-  String renderSearchPage(String query,
-                          List<PackageVersion> stableVersions,
-                          List<PackageVersion> devVersions,
-                          PageLinks pageLinks) {
+  @override
+  String renderSearchPage(String query, List<PackageVersion> stableVersions,
+      List<PackageVersion> devVersions, PageLinks pageLinks) {
     return Response;
   }
 
+  @override
   String renderSitemapPage() {
     return Response;
   }
 }
 
 class SearchServiceMock implements SearchService {
+  @override
+  // ignore: always_declare_return_types
   get csearch => throw 'unexpected csearch';
+  @override
+  // ignore: always_declare_return_types
   get httpClient => throw 'unexpected httpClient';
 
   final Function searchFun;
 
   SearchServiceMock(this.searchFun);
 
+  @override
   Future<SearchResultPage> search(
       String query, int offset, int numResults) async {
     return searchFun(query, offset, numResults);

--- a/app/test/tarball_storage_namer_test.dart
+++ b/app/test/tarball_storage_namer_test.dart
@@ -7,38 +7,38 @@ library pub_dartlang_org.tarball_storage_namer_test;
 import 'package:pub_dartlang_org/backend.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('tarball_storage_namer', () {
     final bucket = 'pub.dartlang.org';
 
     test('empty namespace', () {
       for (var namespace in [null, '']) {
-        var namer = new TarballStorageNamer(bucket, namespace);
+        final namer = new TarballStorageNamer(bucket, namespace);
         expect(namer.bucket, equals(bucket));
         expect(namer.namespace, equals(''));
         expect(namer.prefix, equals(''));
         expect(namer.tarballObjectName('foobar', '0.1.0'),
-               equals('packages/foobar-0.1.0.tar.gz'));
-        expect(namer.tmpObjectName('guid'),
-               equals('tmp/guid'));
-        expect(namer.tarballObjectUrl('foobar', '0.1.0'),
-               equals('https://storage.googleapis.com/'
-                      '$bucket/packages/foobar-0.1.0.tar.gz'));
+            equals('packages/foobar-0.1.0.tar.gz'));
+        expect(namer.tmpObjectName('guid'), equals('tmp/guid'));
+        expect(
+            namer.tarballObjectUrl('foobar', '0.1.0'),
+            equals('https://storage.googleapis.com/'
+                '$bucket/packages/foobar-0.1.0.tar.gz'));
       }
     });
 
     test('staging namespace', () {
-      var namer = new TarballStorageNamer(bucket, 'staging');
+      final namer = new TarballStorageNamer(bucket, 'staging');
       expect(namer.bucket, equals(bucket));
       expect(namer.namespace, equals('staging'));
       expect(namer.prefix, equals('ns/staging/'));
       expect(namer.tarballObjectName('foobar', '0.1.0'),
-             equals('ns/staging/packages/foobar-0.1.0.tar.gz'));
-      expect(namer.tmpObjectName('guid'),
-             equals('tmp/guid'));
-      expect(namer.tarballObjectUrl('foobar', '0.1.0'),
-             equals('https://storage.googleapis.com/'
-                    '$bucket/ns/staging/packages/foobar-0.1.0.tar.gz'));
+          equals('ns/staging/packages/foobar-0.1.0.tar.gz'));
+      expect(namer.tmpObjectName('guid'), equals('tmp/guid'));
+      expect(
+          namer.tarballObjectUrl('foobar', '0.1.0'),
+          equals('https://storage.googleapis.com/'
+              '$bucket/ns/staging/packages/foobar-0.1.0.tar.gz'));
     });
   });
 }

--- a/app/test/utils.dart
+++ b/app/test/utils.dart
@@ -16,7 +16,7 @@ import 'package:pub_dartlang_org/model_properties.dart';
 
 class TestDelayCompletion {
   final int count;
-  final Function _complete = expectAsync(() {});
+  final Function _complete = expectAsync0(() {});
   int _got = 0;
 
   TestDelayCompletion({this.count: 1});
@@ -36,24 +36,24 @@ final Key testPackageVersionKey =
 final Pubspec testPubspec = new Pubspec.fromYaml(TestPackagePubspec);
 
 final Package testPackage = new Package()
-    ..parentKey = testPackageKey.parent
-    ..id = testPackageKey.id
-    ..name = testPackageKey.id
-    ..created = new DateTime.utc(2014)
-    ..updated = new DateTime.utc(2015)
-    ..uploaderEmails = ['hans@juergen.com']
-    ..latestVersionKey = testPackageVersionKey;
+  ..parentKey = testPackageKey.parent
+  ..id = testPackageKey.id
+  ..name = testPackageKey.id
+  ..created = new DateTime.utc(2014)
+  ..updated = new DateTime.utc(2015)
+  ..uploaderEmails = ['hans@juergen.com']
+  ..latestVersionKey = testPackageVersionKey;
 
 final PackageVersion testPackageVersion = new PackageVersion()
-    ..parentKey = testPackageVersionKey.parent
-    ..id = testPackageVersionKey.id
-    ..version = testPackageVersionKey.id
-    ..packageKey = testPackageKey
-    ..created = new DateTime.utc(2014)
-    ..pubspec = testPubspec
-    ..readmeFilename = 'README'
-    ..readmeContent = 'readme content'
-    ..sortOrder = -1;
+  ..parentKey = testPackageVersionKey.parent
+  ..id = testPackageVersionKey.id
+  ..version = testPackageVersionKey.id
+  ..packageKey = testPackageKey
+  ..created = new DateTime.utc(2014)
+  ..pubspec = testPubspec
+  ..readmeFilename = 'README'
+  ..readmeContent = 'readme content'
+  ..sortOrder = -1;
 
 Future scoped(func()) {
   return fork(() async {
@@ -69,15 +69,12 @@ void scopedTest(String name, func()) {
   });
 }
 
-
-
 final String TestPackageReadme = '''
 Test Package
 ============
 
 This is a readme file.
 ''';
-
 
 final String TestPackageChangelog = '''
 Changelog
@@ -96,4 +93,3 @@ homepage: http://hans.juergen.com
 dependencies:
   gcloud: any
 ''';
-


### PR DESCRIPTION
Apologies for the long PR, the changes are mostly non-functional, with the exception of calling `.toString()` in `app/bin/tools_remove_package.dart` line 95, and using `dart:math`'s `min` in `app/lib/search_service.dart`.

They started out as separate commits, but got squashed along the way, and it would have been too painful to get separated again.