### PR TITLE
Fix server handler that was broken by the strong mode conversion.

### DIFF
--- a/app/bin/server.dart
+++ b/app/bin/server.dart
@@ -38,7 +38,7 @@ void main() {
       }
       final shelf.Handler apiHandler = await setupServices(activeConfiguration);
 
-      AppEngineRequestHandler requestHandler = (ioRequest) async {
+      var requestHandler = (HttpRequest ioRequest) async {
         if (context.isProductionEnvironment &&
             ioRequest.requestedUri.scheme != 'https') {
           final secureUri = ioRequest.requestedUri.replace(scheme: 'https');
@@ -67,11 +67,11 @@ void main() {
         }
       };
       if (Platform.isMacOS) {
-        final AppEngineRequestHandler origHandler = requestHandler;
+        final origHandler = requestHandler;
         requestHandler = (ioRequest) {
-          fork(() {
+          fork(() async {
             registerDbService(savedDb);
-            origHandler(ioRequest);
+            await origHandler(ioRequest);
           });
         };
       }


### PR DESCRIPTION
Fork requires a Future to be returned, while the AppEngineRequestHandler returns a void. It affected only local development. Reverting to untyped Function reference for the time being.