### PR TITLE
Refactor search query and result page

### DIFF
--- a/app/test/handlers_test.dart
+++ b/app/test/handlers_test.dart
@@ -178,25 +178,23 @@ void main() {
       });
 
       tScopedTest('/search?q=foobar', () async {
-        registerSearchService(
-            new SearchServiceMock((String query, int offset, int numResults) {
-          expect(query, 'foobar');
-          expect(offset, 0);
-          expect(numResults, PageSize);
+        registerSearchService(new SearchServiceMock((SearchQuery query) {
+          expect(query.text, 'foobar');
+          expect(query.offset, 0);
+          expect(query.limit, PageSize);
           return new SearchResultPage(
-              query, offset, 1, [testPackageVersion], [testPackageVersion]);
+              query, 1, [testPackageVersion], [testPackageVersion]);
         }));
         expectHtmlResponse(await issueGet('/search?q=foobar'), status: 200);
       });
 
       tScopedTest('/search?q=foobar&page=2', () async {
-        registerSearchService(
-            new SearchServiceMock((String query, int offset, int numResults) {
-          expect(query, 'foobar');
-          expect(offset, PageSize);
-          expect(numResults, PageSize);
+        registerSearchService(new SearchServiceMock((SearchQuery query) {
+          expect(query.text, 'foobar');
+          expect(query.offset, PageSize);
+          expect(query.limit, PageSize);
           return new SearchResultPage(
-              query, offset, 1, [testPackageVersion], [testPackageVersion]);
+              query, 1, [testPackageVersion], [testPackageVersion]);
         }));
         expectHtmlResponse(await issueGet('/search?q=foobar&page=2'));
       });

--- a/app/test/handlers_test_utils.dart
+++ b/app/test/handlers_test_utils.dart
@@ -205,8 +205,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderSearchPage(String query, List<PackageVersion> stableVersions,
-      List<PackageVersion> devVersions, PageLinks pageLinks) {
+  String renderSearchPage(SearchResultPage resultPage, PageLinks pageLinks) {
     return Response;
   }
 
@@ -230,8 +229,7 @@ class SearchServiceMock implements SearchService {
   SearchServiceMock(this.searchFun);
 
   @override
-  Future<SearchResultPage> search(
-      String query, int offset, int numResults) async {
-    return searchFun(query, offset, numResults);
+  Future<SearchResultPage> search(SearchQuery query) async {
+    return searchFun(query);
   }
 }

--- a/app/test/templates_test.dart
+++ b/app/test/templates_test.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/templates.dart';
+import 'package:pub_dartlang_org/search_service.dart'
+    show SearchQuery, SearchResultPage;
 
 import 'utils.dart';
 
@@ -75,11 +77,14 @@ void main() {
     });
 
     test('search page', () {
-      final String html = templates.renderSearchPage(
-          'foobar',
+      final query = new SearchQuery('foobar', offset: 0);
+      final resultPage = new SearchResultPage(
+          query,
+          2,
           [testPackageVersion, flutterPackageVersion],
-          [testPackageVersion, flutterPackageVersion],
-          new SearchLinks('foobar', 0, 1));
+          [testPackageVersion, flutterPackageVersion]);
+      final String html =
+          templates.renderSearchPage(resultPage, new SearchLinks(query, 2));
       expectGoldenFile(html, 'search_page.html');
     });
 


### PR DESCRIPTION
... in preparation for additional filtering logic. The idea there is that list of filtered types goes to the `SearchQuery` object as well, and we need to use that info in `PageLinks`, and also in some formatting of the search result page too.