### PR TITLE
Use /flutter/packages instead of plugins. Fixes #143.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -658,11 +658,15 @@ Future<models.PackageVersion> parseAndValidateUpload(
 /// Automatically detects the built-in types.
 /// The returned list should be alphabetically sorted.
 List<String> detectTypes(Pubspec pubspec) {
-  final List<String> detectedTypes = [];
+  final Set<String> detectedTypes = new Set();
   if (pubspec.hasFlutterPlugin) {
+    detectedTypes.add(models.BuiltinTypes.flutterPackage);
     detectedTypes.add(models.BuiltinTypes.flutterPlugin);
   }
-  return detectedTypes;
+  if (pubspec.dependsOnFlutterSdk) {
+    detectedTypes.add(models.BuiltinTypes.flutterPackage);
+  }
+  return detectedTypes.toList()..sort();
 }
 
 /// Helper utility class for interfacing with Cloud Storage for storing

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -41,9 +41,10 @@ Future<shelf.Response> appHandler(
     '/search': searchHandler,
     '/packages': packagesHandler,
     '/packages.json': packagesHandler,
-    '/flutter': flutterHandler,
-    '/flutter/': flutterHandler,
-    '/flutter/plugins': flutterPluginsHandler,
+    '/flutter': redirectToFlutterPackages,
+    '/flutter/': redirectToFlutterPackages,
+    '/flutter/packages': flutterPackagesHandler,
+    '/flutter/plugins': redirectToFlutterPackages,
   }[path];
 
   if (handler != null) {
@@ -199,7 +200,7 @@ Future<shelf.Response> packagesHandlerJson(
   return jsonResponse(json);
 }
 
-/// Handles requests for `/packages` (default behavior) or `/flutter/plugins`
+/// Handles requests for `/packages` (default behavior) or `/flutter/packages`
 /// (when [basePath] is specified) - HTML
 Future<shelf.Response> packagesHandlerHtml(
   shelf.Request request,
@@ -465,21 +466,21 @@ Future<shelf.Response> apiPackagesHandler(shelf.Request request) async {
   return jsonResponse(json);
 }
 
-/// Handles requests for /flutter (redirects to /flutter/plugins).
-shelf.Response flutterHandler(shelf.Request request) =>
-    redirectResponse('/flutter/plugins');
+/// Handles requests for /flutter (redirects to /flutter/packages).
+shelf.Response redirectToFlutterPackages(shelf.Request request) =>
+    redirectResponse('/flutter/packages');
 
-/// Handles requests for /flutter/plugins
-Future<shelf.Response> flutterPluginsHandler(shelf.Request request) async {
+/// Handles requests for /flutter/packages
+Future<shelf.Response> flutterPackagesHandler(shelf.Request request) async {
   final int page = _pageFromUrl(request.url);
   return packagesHandlerHtml(
     request,
     page,
-    basePath: '/flutter/plugins',
-    detectedType: BuiltinTypes.flutterPlugin,
-    title: 'Flutter Plugins',
+    basePath: '/flutter/packages',
+    detectedType: BuiltinTypes.flutterPackage,
+    title: 'Flutter Packages',
     faviconUrl: LogoUrls.flutterLogo32x32,
-    descriptionHtml: flutterPluginsDescriptionHtml,
+    descriptionHtml: flutterPackagesDescriptionHtml,
   );
 }
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -295,10 +295,14 @@ class BuiltinTypes {
   /// Package is related to angular.
   static final String angular = 'angular';
 
-  /// Package is related to flutter and it is a plugin.
+  /// Package is related to Flutter: is a plugin, or depends on the Flutter SDK.
+  static final String flutterPackage = 'flutter_package';
+
+  /// Package is related to Flutter and it is a plugin.
   static final String flutterPlugin = 'flutter_plugin';
 
   static final Set<String> _used = new Set.from([
+    BuiltinTypes.flutterPackage,
     BuiltinTypes.flutterPlugin,
   ]);
 

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -426,14 +426,13 @@ class TemplateService {
   List _mapIconsData(PackageVersion version) {
     final List icons = [];
     if (version.detectedTypes != null) {
-      for (String type in version.detectedTypes) {
-        if (type == BuiltinTypes.flutterPlugin) {
-          icons.add({
-            'src': LogoUrls.flutterLogo32x32,
-            'label': 'Flutter plugin',
-            'href': '/flutter/plugins',
-          });
-        }
+      if (version.detectedTypes.contains(BuiltinTypes.flutterPackage) ||
+          version.detectedTypes.contains(BuiltinTypes.flutterPlugin)) {
+        icons.add({
+          'src': LogoUrls.flutterLogo32x32,
+          'label': 'Flutter package',
+          'href': '/flutter/packages',
+        });
       }
     }
     return icons;
@@ -579,6 +578,7 @@ abstract class LogoUrls {
   static const String flutterLogo32x32 = '/static/img/flutter-logo-32x32.png';
 }
 
-const String flutterPluginsDescriptionHtml =
-    '<p><a href="https://flutter.io/platform-plugins/">'
-    'Learn more about Flutter plugins.</a></p>';
+// Pointing to the Flutter main page until Flutter creates documentation about
+// their pub use. See https://github.com/flutter/flutter/issues/10070
+const String flutterPackagesDescriptionHtml =
+    '<p><a href="https://flutter.io/">Learn more about Flutter.</a></p>';

--- a/app/test/frontend/golden/flutter_packages_index_page2.html
+++ b/app/test/frontend/golden/flutter_packages_index_page2.html
@@ -2,7 +2,7 @@
 <!doctype html>
 <html lang="en-us" >
   <head>
-    <title>Page 2 | Flutter Plugins</title>
+    <title>Page 2 | Flutter Packages</title>
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png">
     <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png" />
       <meta name="description" content="Pub is a package manager for the
@@ -85,8 +85,8 @@
       <div id="header">
       </div>
       
-<h1>Flutter Plugins</h1>
-<p><a href="https://flutter.io/platform-plugins/">Learn more about Flutter plugins.</a></p>
+<h1>Flutter Packages</h1>
+<p><a href="https://flutter.io/">Learn more about Flutter.</a></p>
 <table>
   <thead>
     <tr>
@@ -99,7 +99,7 @@
   </thead>
   <tbody>
       <tr>
-        <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter plugin" title="Flutter plugin"/>
+        <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter package" title="Flutter package"/>
 </td>
         <td><strong><a href="/packages/foobar_pkg">foobar_pkg</a></strong></td>
         <td>my package description</td>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -108,8 +108,8 @@
     <a class="get-started" href="https://flutter.io/">
       Try Flutter!
     </a>
-    <a class="get-started" href="/flutter/plugins/">
-      Flutter Plugins
+    <a class="get-started" href="/flutter/packages/">
+      Flutter Packages
     </a>
     <br/>
     &nbsp;
@@ -146,7 +146,7 @@
         <td>Jan 1, 2014</td>
       </tr>
       <tr>
-        <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter plugin" title="Flutter plugin"/>
+        <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter package" title="Flutter package"/>
 </td>
         <th><a href="/packages/foobar_pkg">foobar_pkg</a></th>
         <td><span class="version">0.1.1</span></td>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -106,7 +106,7 @@
         <td>Jan 1, 2014</td>
       </tr>
       <tr>
-        <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter plugin" title="Flutter plugin"/>
+        <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter package" title="Flutter package"/>
 </td>
         <td><strong><a href="/packages/foobar_pkg">foobar_pkg</a></strong></td>
         <td>my package description</td>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -26,6 +26,7 @@
     <!--
     <PageMap>
       <DataObject type="document">
+        <Attribute name="dt_flutter_package">1</Attribute>
         <Attribute name="dt_flutter_plugin">1</Attribute>
         <Attribute name="exp_score">10</Attribute>
       </DataObject>
@@ -189,8 +190,8 @@ $ <strong>flutter packages get</strong>
     <div class="package-icons">
     <div class="package-icon">
       <img src="/static/img/flutter-logo-32x32.png" class="package-icon-img" />
-        <a href="/flutter/plugins">
-          <span class="package-icon-label">Flutter plugin</span>
+        <a href="/flutter/packages">
+          <span class="package-icon-label">Flutter package</span>
         </a>
     </div>
 </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -102,7 +102,7 @@
   </td>
   </tr>
   <tr>
-    <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter plugin" title="Flutter plugin"/>
+    <td><img src="/static/img/flutter-logo-32x32.png" class="tablecol-icons-img" alt="Flutter package" title="Flutter package"/>
 </td>
   <td>
   <h3>

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -125,16 +125,19 @@ void main() {
       });
 
       tScopedTest('/flutter', () async {
-        expectRedirectResponse(await issueGet('/flutter'), '/flutter/plugins');
-        expectRedirectResponse(await issueGet('/flutter/'), '/flutter/plugins');
+        expectRedirectResponse(await issueGet('/flutter'), '/flutter/packages');
+        expectRedirectResponse(
+            await issueGet('/flutter/'), '/flutter/packages');
+        expectRedirectResponse(
+            await issueGet('/flutter/plugins'), '/flutter/packages');
       });
 
-      tScopedTest('/flutter/plugins', () async {
+      tScopedTest('/flutter/packages', () async {
         final backend =
             new BackendMock(latestPackagesFun: ({offset, limit, detectedType}) {
           expect(offset, 0);
           expect(limit, greaterThan(PageSize));
-          expect(detectedType, BuiltinTypes.flutterPlugin);
+          expect(detectedType, BuiltinTypes.flutterPackage);
           return [testPackage];
         }, lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
@@ -142,15 +145,15 @@ void main() {
           return [testPackageVersion];
         });
         registerBackend(backend);
-        expectHtmlResponse(await issueGet('/flutter/plugins'));
+        expectHtmlResponse(await issueGet('/flutter/packages'));
       });
 
-      tScopedTest('/flutter/plugins&page=2', () async {
+      tScopedTest('/flutter/packages&page=2', () async {
         final backend =
             new BackendMock(latestPackagesFun: ({offset, limit, detectedType}) {
           expect(offset, PageSize);
           expect(limit, greaterThan(PageSize));
-          expect(detectedType, BuiltinTypes.flutterPlugin);
+          expect(detectedType, BuiltinTypes.flutterPackage);
           return [testPackage];
         }, lookupLatestVersionsFun: (List<Package> packages) {
           expect(packages.length, 1);
@@ -158,7 +161,7 @@ void main() {
           return [testPackageVersion];
         });
         registerBackend(backend);
-        expectHtmlResponse(await issueGet('/flutter/plugins?page=2'));
+        expectHtmlResponse(await issueGet('/flutter/packages?page=2'));
       });
 
       tScopedTest('/doc', () async {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -74,17 +74,17 @@ void main() {
       expectGoldenFile(html, 'pkg_versions_page.html');
     });
 
-    test('flutter plugins - index page #2', () {
+    test('flutter packages - index page #2', () {
       final String html = templates.renderPkgIndexPage(
         [testPackage],
         [flutterPackageVersion],
         new PackageLinks(
             PackageLinks.RESULTS_PER_PAGE, PackageLinks.RESULTS_PER_PAGE + 1),
-        title: 'Flutter Plugins',
+        title: 'Flutter Packages',
         faviconUrl: LogoUrls.flutterLogo32x32,
-        descriptionHtml: flutterPluginsDescriptionHtml,
+        descriptionHtml: flutterPackagesDescriptionHtml,
       );
-      expectGoldenFile(html, 'flutter_plugins_index_page2.html');
+      expectGoldenFile(html, 'flutter_packages_index_page2.html');
     });
 
     test('search page', () {

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -60,7 +60,10 @@ final PackageVersion testPackageVersion = new PackageVersion()
 
 final PackageVersion flutterPackageVersion =
     clonePackageVersion(testPackageVersion)
-      ..detectedTypes = [BuiltinTypes.flutterPlugin]
+      ..detectedTypes = [
+        BuiltinTypes.flutterPackage,
+        BuiltinTypes.flutterPlugin,
+      ]
       ..pubspec = new Pubspec.fromYaml(TestPackagePubspec +
           '''
 flutter:

--- a/app/views/index.mustache
+++ b/app/views/index.mustache
@@ -25,8 +25,8 @@
     <a class="get-started" href="https://flutter.io/">
       Try Flutter!
     </a>
-    <a class="get-started" href="/flutter/plugins/">
-      Flutter Plugins
+    <a class="get-started" href="/flutter/packages/">
+      Flutter Packages
     </a>
     <br/>
     &nbsp;


### PR DESCRIPTION
The work is based on instructions from: https://github.com/dart-lang/pub-dartlang-dart/issues/143#issuecomment-305508387

@mkustermann: `bin/tools/backfill_search_fields.dart` must run in prod before promoting this to live.
