### PR TITLE
Experimental search service.

### DIFF
--- a/app/bin/server.dart
+++ b/app/bin/server.dart
@@ -6,6 +6,7 @@ import 'package:pub_dartlang_org/shared/configuration.dart';
 
 import 'service/analyzer.dart' as analyzer;
 import 'service/frontend.dart' as frontend;
+import 'service/search.dart' as search;
 
 void main() {
   switch (envConfig.gaeService) {
@@ -14,6 +15,9 @@ void main() {
       break;
     case 'default':
       frontend.main();
+      break;
+    case 'search':
+      search.main();
       break;
     default:
       throw new StateError(

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+
+import 'package:pub_dartlang_org/shared/configuration.dart';
+import 'package:pub_dartlang_org/shared/service_utils.dart';
+
+import 'package:pub_dartlang_org/search/handlers.dart';
+import 'package:pub_dartlang_org/search/index_ducene.dart';
+import 'package:pub_dartlang_org/search/updater.dart';
+
+void main() {
+  useLoggingPackageAdaptor();
+
+  withAppEngineServices(() async {
+    return withCorrectDatastore(() async {
+      registerPackageIndex(new DucenePackageIndex());
+      if (envConfig.duceneDir == null) {
+        // Don't push too much info into the in-memory index.
+        new PackageIndexUpdater(packageIndex).update(limit: 300);
+      } else {
+        // TODO: move the indexing into a different isolate.
+        new PackageIndexUpdater(packageIndex).startPolling();
+      }
+
+      await runAppEngine((HttpRequest request) =>
+          shelf_io.handleRequest(request, searchServiceHandler));
+    });
+  });
+}

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -115,6 +115,9 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
   final SearchBias expBias =
       parseExperimentalBias(request.url.queryParameters['experimental-bias']);
 
+  final bool useService =
+      request.url.queryParameters['experimental-service'] == 'true';
+
   final SearchQuery query = new SearchQuery(
     queryText,
     offset: PageLinks.RESULTS_PER_PAGE * (page - 1),
@@ -127,7 +130,7 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
         new SearchResultPage.empty(query), new SearchLinks.empty(query)));
   }
 
-  final resultPage = await searchService.search(query);
+  final resultPage = await searchService.search(query, useService);
   final links = new SearchLinks(query, resultPage.totalCount);
   return htmlResponse(templateService.renderSearchPage(resultPage, links));
 }

--- a/app/lib/frontend/service_utils.dart
+++ b/app/lib/frontend/service_utils.dart
@@ -51,6 +51,7 @@ Future initSearchService() async {
   final searchService = await searchServiceViaApiKeyFromDb();
   registerSearchService(searchService);
   registerScopeExitCallback(searchService.httpClient.close);
+  registerScopeExitCallback(searchService.searchServiceClient.close);
 }
 
 void initBackend({UIPackageCache cache}) {

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../shared/handlers.dart';
+import '../shared/search_service.dart';
+
+import 'index_ducene.dart';
+
+/// Handlers for the search service.
+Future<shelf.Response> searchServiceHandler(shelf.Request request) async {
+  final path = request.requestedUri.path;
+  final handler = {
+    '/debug': debugHandler,
+    '/search': searchHandler,
+    // TODO: add handler for update notification
+  }[path];
+
+  if (handler != null) {
+    return handler(request);
+  } else {
+    return notFoundHandler(request);
+  }
+}
+
+/// Handler /debug requests
+Future<shelf.Response> debugHandler(shelf.Request request) async {
+  return jsonResponse({
+    'ready': packageIndex.isReady,
+    'indexSize': await packageIndex.indexSize(),
+    'currentRss': ProcessInfo.currentRss,
+    'maxRss': ProcessInfo.maxRss,
+  }, indent: true);
+}
+
+/// Handles /search requests.
+Future<shelf.Response> searchHandler(shelf.Request request) async {
+  if (!packageIndex.isReady) {
+    return htmlResponse(searchIndexNotReadyText,
+        status: searchIndexNotReadyCode);
+  }
+  final bool indent = request.url.queryParameters['indent'] == 'true';
+  final PackageSearchResult result = await packageIndex.search(
+      new PackageQuery.fromServiceQueryParameters(request.url.queryParameters));
+  return jsonResponse(result.toJson(), indent: indent);
+}

--- a/app/lib/search/index_ducene.dart
+++ b/app/lib/search/index_ducene.dart
@@ -1,0 +1,243 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:ducene/analysis.dart';
+import 'package:ducene/document.dart';
+import 'package:ducene/search.dart';
+import 'package:ducene/util.dart';
+import 'package:gcloud/service_scope.dart' as ss;
+
+import '../shared/configuration.dart';
+import '../shared/search_service.dart';
+
+/// The [PackageIndex] registered in the current service scope.
+PackageIndex get packageIndex => ss.lookup(#packageIndexService);
+
+/// Register a new [PackageIndex] in the current service scope.
+void registerPackageIndex(PackageIndex index) =>
+    ss.register(#packageIndexService, index);
+
+class DucenePackageIndex implements PackageIndex {
+  final _MultiNgramAnalyzer _analyzer = new _MultiNgramAnalyzer(3);
+  Directory _fsDir;
+  IndexHolder _index;
+  DateTime _lastUpdated;
+  Future _initFuture;
+
+  Future _init() async {
+    if (_initFuture != null) return _initFuture;
+    assert(_index == null);
+    _initFuture = new Future(() async {
+      IndexHolderDirectory indexDir;
+      if (envConfig.duceneDir != null) {
+        // Temporarily everything is in memory, because ducene is not using async
+        // IO, and that blocks appengine's health checks, killing the machine
+        // before it got any chance to setup.
+        // TODO: fix ducene to handle async FS properly
+        // _fsDir = new Directory(envConfig.duceneDir);
+        // indexDir = new FSIndexHolderDirectory(_fsDir);
+        indexDir = new RAMIndexHolderDirectory();
+      } else {
+        indexDir = new RAMIndexHolderDirectory();
+      }
+      _index = await DirectoryHolder.open(indexDir);
+    });
+    return _initFuture;
+  }
+
+  @override
+  bool get isReady => _lastUpdated != null;
+
+  @override
+  Future<int> indexSize() async {
+    if (_fsDir == null) return -1;
+    return _fsDir.list(recursive: true).asyncMap((FileSystemEntity fse) async {
+      if (fse is File) {
+        return fse.length();
+      }
+      return 0;
+    }).fold(0, (int sum, int v) => sum + v);
+  }
+
+  @override
+  Future add(PackageDocument doc) async {
+    await _init();
+    final Document duceneDoc = new Document()
+      ..append('id', doc.url)
+      ..append('package', doc.package, analyzer: _analyzer)
+      ..append('version', doc.version)
+      ..append('devVersion', doc.devVersion)
+      ..append(
+        'description',
+        _normalizeText(doc.description, 500),
+        analyzer: _analyzer,
+        stored: false,
+      )
+      ..append(
+          'originalDescription', _normalizeWhitespaces(doc.description, 500))
+      ..append('lastUpdated', doc.lastUpdated)
+      ..append(
+        'readme',
+        _normalizeText(doc.readme, 2000),
+        analyzer: _analyzer,
+        stored: false,
+      )
+      ..append('popularity', doc.popularity.toString());
+    if (doc.detectedTypes != null && doc.detectedTypes.isNotEmpty) {
+      duceneDoc.append('detectedTypes', doc.detectedTypes);
+    }
+    await _index.updateDocuments([duceneDoc]);
+  }
+
+  @override
+  Future addAll(Iterable<PackageDocument> documents) async {
+    // Adding documents one-by-one, will need to experiment with better batch
+    // size when async disk index is available.
+    for (PackageDocument doc in documents) {
+      await add(doc);
+    }
+  }
+
+  @override
+  Future contains(String url, String version, String devVersion) async {
+    if (!isReady) return false;
+    final IndexSearcher searcher = _index.newRealTimeIndexSearcher();
+    final query = new BoolQuery(Op.and)
+      ..append('id', url)
+      ..append('version', version)
+      ..append('devVersion', devVersion);
+    final TopDocs topDocs = await searcher.search(query, 1);
+    return topDocs.scoreDocs.length == 1;
+  }
+
+  @override
+  Future removeUrl(String url) async {
+    await _init();
+    await _index.deleteDocuments(new BoolQuery()..append('id', url));
+  }
+
+  @override
+  Future merge() async {
+    await _init();
+    await _index.forceMerge();
+    _lastUpdated = new DateTime.now().toUtc();
+  }
+
+  @override
+  Future<PackageSearchResult> search(PackageQuery query) async {
+    if (!isReady) return new PackageSearchResult.notReady();
+
+    await _init();
+    final IndexSearcher searcher = _index.newRealTimeIndexSearcher();
+    final String queryText = _normalizeText(query.text, 200);
+    final duceneQuery = new BoolQuery()
+      ..append('package', queryText, analyzer: _analyzer, boost: 4.0)
+      ..append('description', queryText, analyzer: _analyzer, boost: 2.0)
+      ..append('readme', queryText, analyzer: _analyzer);
+    if (query.type != null) {
+      duceneQuery
+          .addFilter(new TermQuery(new Term('detectedTypes', query.type)));
+    }
+
+    final int offset = query.offset ?? 0;
+    final int limit = max(minSearchLimit, query.limit ?? 100);
+
+    final TopDocs topPackages = await searcher.search(
+      duceneQuery,
+      maxSearchResults + minSearchLimit, // additional results for extended bias
+      scoreSort: new TFIDFScoreSort(),
+    );
+
+    List<PackageScore> packages = [];
+    for (ScoreDoc sd in topPackages.scoreDocs) {
+      final Document doc = await searcher.doc(sd.doc);
+      final double bias = double.parse(doc.get('popularity')) * 20;
+
+      packages.add(new PackageScore(
+        url: doc.get('id'),
+        package: doc.get('package'),
+        version: doc.get('version'),
+        devVersion: doc.get('devVersion'),
+        // TODO: normalize values and calibrate bias weight
+        score: sd.score + bias,
+      ));
+    }
+    packages.sort((a, b) => -a.score.compareTo(b.score));
+    if (packages.length > maxSearchResults) {
+      packages = packages.sublist(0, maxSearchResults);
+    }
+    final int totalCount = packages.length;
+
+    if (packages.length <= offset) {
+      packages = [];
+    } else {
+      packages = packages.sublist(offset);
+    }
+    if (packages.length > limit) {
+      packages = packages.sublist(0, limit);
+    }
+
+    assert(_lastUpdated.isUtc);
+    return new PackageSearchResult(
+      indexUpdated: _lastUpdated.toIso8601String(),
+      totalCount: totalCount,
+      packages: packages,
+    );
+  }
+
+  String _normalizeWhitespaces(String text, int maxLength) {
+    if (text == null) return '';
+    String t = text.replaceAll(_multiWhitespaceRegExp, ' ').trim();
+    if (t.length > maxLength) {
+      t = t.substring(0, maxLength);
+    }
+    return t;
+  }
+
+  String _normalizeText(String text, int maxLength) {
+    if (text == null) return '';
+    String t = text
+        .toLowerCase()
+        .replaceAll(_nonCharacterRegExp, ' ')
+        .replaceAll(_multiWhitespaceRegExp, ' ')
+        .trim();
+    if (t.length > maxLength) {
+      t = t.substring(0, maxLength);
+    }
+    return ' ' + t + ' ';
+  }
+}
+
+final RegExp _nonCharacterRegExp = new RegExp('\\W');
+final RegExp _multiWhitespaceRegExp = new RegExp('\\s+');
+
+class _MultiNgramAnalyzer extends Analyzer {
+  _MultiNgramAnalyzer(int n) {
+    tokenizer = new _MultiNgramTokenizer(n);
+  }
+}
+
+class _MultiNgramTokenizer extends Tokenizer {
+  final int _n;
+  _MultiNgramTokenizer(this._n);
+
+  @override
+  Iterable<String> tokenize(String text) {
+    final Set<String> ngrams = new Set();
+    for (int ngramLength = 1; ngramLength <= _n; ngramLength++) {
+      if (text.length <= ngramLength) {
+        ngrams.add(text);
+      } else {
+        for (int i = 0; i <= text.length - ngramLength; i++) {
+          ngrams.add(text.substring(i, i + ngramLength));
+        }
+      }
+    }
+    return ngrams;
+  }
+}

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -1,0 +1,95 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcloud/db.dart';
+import 'package:logging/logging.dart';
+
+import '../frontend/models.dart';
+import '../shared/mock_scores.dart';
+import '../shared/search_service.dart';
+import '../shared/utils.dart' show sliceList;
+
+Logger _logger = new Logger('pub.search.updater');
+
+class PackageIndexUpdater {
+  final PackageIndex index;
+  Timer _timer;
+  bool _updating = false;
+
+  PackageIndexUpdater(this.index);
+
+  Future update({int limit}) async {
+    if (_updating) {
+      _logger.warning('Update called before previous round completed.');
+      return;
+    }
+    try {
+      _updating = true;
+      await _doUpdate(limit);
+    } catch (e, st) {
+      _logger.severe('Error while updating search index.', e, st);
+    } finally {
+      _updating = false;
+    }
+  }
+
+  Future _doUpdate(int limit) async {
+    final List<Key> versionKeys = [];
+    final Map<String, String> devVersions = {};
+
+    _logger.info('Polling packages for changes.');
+    int count = 0;
+    await for (Package p in dbService.query(Package).run()) {
+      final bool inIndex = await index.contains(
+          _toUrl(p.name), p.latestVersion, p.latestDevVersion);
+      if (inIndex) continue;
+      versionKeys.add(p.latestVersionKey);
+      devVersions[p.name] = p.latestDevVersion;
+      count++;
+      if (limit != null && limit <= count) break;
+    }
+    _logger.info('Found ${versionKeys.length} packages to update.');
+    if (versionKeys.isEmpty) return;
+
+    for (List<Key> slices in sliceList(versionKeys, 20)) {
+      final Key firstKey = slices.first;
+      final String firstPkg = firstKey.parent.id;
+      final String firstVersion = firstKey.id;
+      _logger.info('Updating packages staring with $firstPkg $firstVersion');
+      final List<PackageVersion> versions = await dbService.lookup(slices);
+      final List<PackageDocument> documents = versions
+          .map((pv) => new PackageDocument(
+                url: _toUrl(pv.package),
+                package: pv.package,
+                version: pv.version,
+                devVersion: devVersions[pv.package],
+                detectedTypes: pv.detectedTypes,
+                description: pv.pubspec.description,
+                lastUpdated: pv.shortCreated,
+                readme: pv.readmeContent,
+                popularity: mockScores[pv.package] ?? 0.0,
+              ))
+          .toList();
+      await index.addAll(documents);
+      _logger.info('Updated ${slices.length} packages.');
+    }
+
+    _logger.info('Calling index.merge() ...');
+    await index.merge();
+    _logger.info('index.merge() completed.');
+  }
+
+  void startPolling() {
+    if (_timer == null) {
+      _timer = new Timer.periodic(new Duration(hours: 4), (_) {
+        update();
+      });
+      update();
+    }
+  }
+}
+
+String _toUrl(String package) => 'https://pub.dartlang.org/packages/$package';

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -21,6 +21,9 @@ class Configuration {
   /// Datastore and/or Cloud Storage
   final String projectId;
 
+  /// The host name for the search service.
+  final String searchServiceHost;
+
   auth.ServiceAccountCredentials _credentials;
 
   /// Credentials to use for API calls if not reading the credentials from
@@ -42,12 +45,14 @@ class Configuration {
   /// Storage is retrieved from the Datastore.
   Configuration._prod()
       : projectId = 'dartlang-pub',
-        packageBucketName = 'pub-packages';
+        packageBucketName = 'pub-packages',
+        searchServiceHost = 'search-dot-dartlang-pub.appspot.com';
 
   /// Create a configuration for development/staging deployment.
   Configuration._dev()
       : projectId = 'dartlang-pub-dev',
-        packageBucketName = 'dartlang-pub-dev--pub-packages';
+        packageBucketName = 'dartlang-pub-dev--pub-packages',
+        searchServiceHost = 'search-dot-dartlang-pub-dev.appspot.com';
 
   /// Create a configuration based on the environment variables.
   factory Configuration.fromEnv(EnvConfig env) {
@@ -61,13 +66,14 @@ class Configuration {
 
 /// Configuration from the environment variables.
 class EnvConfig {
+  final String duceneDir;
   final String gaeService;
   final String gcloudKey;
   final String gcloudProject;
   final String flutterSdkDir;
 
-  EnvConfig._(
-      this.gaeService, this.gcloudProject, this.gcloudKey, this.flutterSdkDir) {
+  EnvConfig._(this.duceneDir, this.gaeService, this.gcloudProject,
+      this.gcloudKey, this.flutterSdkDir) {
     if (this.gcloudProject == null) {
       throw new Exception('GCLOUD_PROJECT needs to be set!');
     }
@@ -75,6 +81,7 @@ class EnvConfig {
 
   factory EnvConfig._detect() {
     return new EnvConfig._(
+      Platform.environment['DUCENE_DIR'],
       Platform.environment['GAE_SERVICE'],
       Platform.environment['GCLOUD_PROJECT'],
       Platform.environment['GCLOUD_KEY'],

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -1,0 +1,167 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' show min, max;
+
+const int defaultSearchLimit = 100;
+const int minSearchLimit = 10;
+const int maxSearchResults = 500;
+const int searchIndexNotReadyCode = 600;
+const String searchIndexNotReadyText = 'Not ready yet.';
+
+/// Package search index and lookup.
+abstract class PackageIndex {
+  bool get isReady;
+  Future<int> indexSize();
+  Future add(PackageDocument doc);
+  Future addAll(Iterable<PackageDocument> documents);
+  Future contains(String url, String version, String devVersion);
+  Future removeUrl(String url);
+  Future merge();
+  Future<PackageSearchResult> search(PackageQuery query);
+}
+
+/// A summary information about a package that goes into the search index.
+///
+/// It is also part of the data structure returned by a search query, except for
+/// the [readme] and [popularity] fields, which are excluded when returning the
+/// results.
+class PackageDocument {
+  final String url;
+  final String package;
+  final String version;
+  final String devVersion;
+  final String description;
+  final String lastUpdated;
+  final String readme;
+
+  final List<String> detectedTypes;
+  final double popularity;
+
+  PackageDocument({
+    this.url,
+    this.package,
+    this.version,
+    this.devVersion,
+    this.description,
+    this.lastUpdated,
+    this.readme,
+    this.detectedTypes,
+    this.popularity,
+  });
+
+  factory PackageDocument.parseJson(Map json) => new PackageDocument(
+        url: json['url'],
+        package: json['package'],
+        version: json['version'],
+        devVersion: json['devVersion'],
+        description: json['description'],
+        lastUpdated: json['lastUpdated'],
+        readme: json['readme'],
+        detectedTypes: json['detectedTypes'],
+        popularity: json['popularity'],
+      );
+
+  Map toJson() => {
+        'url': url,
+        'package': package,
+        'version': version,
+        'devVersion': devVersion,
+        'description': description,
+        'lastUpdated': lastUpdated,
+        'readme': readme,
+        'detectedTypes': detectedTypes,
+        'popularity': popularity,
+      };
+}
+
+class PackageQuery {
+  final String text;
+  final String type;
+  final int offset;
+  final int limit;
+
+  PackageQuery(this.text, {this.type, this.offset, this.limit});
+
+  factory PackageQuery.fromServiceQueryParameters(Map<String, String> params) {
+    final String text = params['q'];
+    String type = params['type'];
+    if (type != null && type.isEmpty) type = null;
+    int offset = int.parse(params['offset'] ?? '0', onError: (_) => 0);
+    int limit =
+        int.parse(params['limit'] ?? '0', onError: (_) => defaultSearchLimit);
+
+    offset = min(maxSearchResults - minSearchLimit, offset);
+    offset = max(0, offset);
+    limit = max(minSearchLimit, limit);
+
+    return new PackageQuery(text, type: type, offset: offset, limit: limit);
+  }
+
+  Map<String, String> toServiceQueryParameters() => {
+        'q': text,
+        'type': type,
+        'offset': offset?.toString(),
+        'limit': limit?.toString(),
+      };
+}
+
+class PackageSearchResult {
+  /// The last update of the search index.
+  final String indexUpdated;
+  final int totalCount;
+  final List<PackageScore> packages;
+
+  PackageSearchResult({this.indexUpdated, this.totalCount, this.packages});
+
+  PackageSearchResult.notReady()
+      : indexUpdated = null,
+        totalCount = 0,
+        packages = [];
+
+  factory PackageSearchResult.fromJson(Map json) => new PackageSearchResult(
+        indexUpdated: json['indexUpdated'],
+        totalCount: json['totalCount'],
+        packages: (json['packages'] ?? [])
+            .map((Map m) => new PackageScore.fromJson(m))
+            .toList(),
+      );
+
+  /// Whether the search service has already updated its index after a startup.
+  bool get isLegit => indexUpdated != null;
+
+  Map toJson() => {
+        'indexUpdated': indexUpdated,
+        'totalCount': totalCount,
+        'packages': packages,
+      };
+}
+
+class PackageScore {
+  final String url;
+  final String package;
+  final String version;
+  final String devVersion;
+  final double score;
+
+  PackageScore(
+      {this.url, this.package, this.version, this.devVersion, this.score});
+
+  factory PackageScore.fromJson(Map json) => new PackageScore(
+        url: json['url'],
+        package: json['package'],
+        version: json['version'],
+        devVersion: json['devVersion'],
+        score: json['score'],
+      );
+
+  Map toJson() => {
+        'url': url,
+        'package': package,
+        'version': version,
+        'devVersion': devVersion,
+        'score': score,
+      };
+}

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -7,6 +7,7 @@ library pub_dartlang_org.utils;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:logging/logging.dart';
 import 'package:pub_semver/pub_semver.dart' as semver;
@@ -118,4 +119,11 @@ void validatePackageName(String name) {
   if (_reservedWords.contains(name.toLowerCase())) {
     throw new Exception('Package name must not be a reserved word in Dart.');
   }
+}
+
+List<List<T>> sliceList<T>(List<T> list, int limit) {
+  if (list.length <= limit) return [list];
+  final int maxPageIndex = (list.length - 1) ~/ limit;
+  return new List.generate(maxPageIndex + 1,
+          (p) => list.sublist(p * limit, min(list.length, (p + 1) * limit)));
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -43,6 +43,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  browser:
+    description:
+      name: browser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.0+2"
   charcode:
     description:
       name: charcode
@@ -79,6 +85,18 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.0"
+  ducene:
+    description:
+      name: ducene
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.0"
+  firebase:
+    description:
+      name: firebase
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.0"
   fixnum:
     description:
       name: fixnum
@@ -91,6 +109,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.0-alpha.4"
+  func:
+    description:
+      name: func
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   gcloud:
     description:
       name: gcloud
@@ -169,6 +193,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  js:
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.1"
   kernel:
     description:
       name: kernel
@@ -265,6 +295,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1+3"
+  sembast:
+    description:
+      name: sembast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.7"
   shelf:
     description:
       name: shelf
@@ -325,6 +361,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  synchronized:
+    description:
+      name: synchronized
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   term_glyph:
     description:
       name: term_glyph

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -19,7 +19,9 @@ dependencies:
   pub_semver: ">=1.2.2 <2.0.0"
   pub_server: ">=0.1.0 <0.2.0"
   shelf: '>=0.5.6 <0.7.0'
-  uuid: ">=0.5.0 <0.5.4"
+  # 3rd-party packages with pinned versions
+  ducene: '0.4.0'
+  uuid: '0.5.3'
 
 dev_dependencies:
   test: ">=0.12.20 <0.13.0"

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -218,12 +218,16 @@ class SearchServiceMock implements SearchService {
   // ignore: always_declare_return_types
   get httpClient => throw 'unexpected httpClient';
 
+  @override
+  // ignore: always_declare_return_types
+  get searchServiceClient => throw 'unexpected searchServiceClient';
+
   final Function searchFun;
 
   SearchServiceMock(this.searchFun);
 
   @override
-  Future<SearchResultPage> search(SearchQuery query) async {
+  Future<SearchResultPage> search(SearchQuery query, bool useService) async {
     return searchFun(query);
   }
 }

--- a/search.yaml
+++ b/search.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+runtime: custom
+env: flex
+service: search
+env_variables:
+  # Needs to be in sync with lib/shared/configuration.dart
+  DUCENE_DIR: '/ducene'
+
+resources:
+  cpu: 1
+  memory_gb: 3.5
+
+manual_scaling:
+  instances: 1
+
+#automatic_scaling:
+#  min_num_instances: 1
+#  max_num_instances: 4
+
+skip_files:
+- ^.*/packages.*$
+- ^\.git/.*$


### PR DESCRIPTION
Try it out:
- [experimental on staging](https://dartlang-pub-dev.appspot.com/search?experimental-service=true&q=json+xml)
- [original on staging](https://dartlang-pub-dev.appspot.com/search?q=json+xml)

The disk-based ducene is commented out, and for the time being we'll use an in-memory index. I've reached out to the project author, who implemented it promptly, but haven't published a new version yet. I'll need to run a few experiments with the proper indexing batch sizing before switching to disk index.

The use of search service is behind the `experimental-service=true` query parameter, and in case it fails, it will switch back to custom search.