### PR TITLE
Proposed URLs for analyzer service

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -7,8 +7,12 @@ import 'dart:io';
 
 import 'package:appengine/appengine.dart';
 import 'package:logging/logging.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
 
 import 'package:pub_dartlang_org/shared/configuration.dart';
+import 'package:pub_dartlang_org/shared/service_utils.dart';
+
+import 'package:pub_dartlang_org/analyzer/handlers.dart';
 
 final Logger logger = new Logger('pub.analyzer');
 
@@ -19,11 +23,9 @@ Future main() async {
     _initFlutterSdk().then((_) {
       // TODO: flutter SDK initialized, start analyzer background task
     });
-    await runAppEngine((HttpRequest ioRequest) async {
-      // TODO: implement API handlers
-      final HttpResponse response = ioRequest.response;
-      response.statusCode = 200;
-      await response.close();
+    return withCorrectDatastore(() async {
+      await runAppEngine((HttpRequest request) =>
+          shelf_io.handleRequest(request, analyzerServiceHandler));
     });
   });
 }

--- a/app/lib/analyzer/api_handlers.dart
+++ b/app/lib/analyzer/api_handlers.dart
@@ -1,7 +1,0 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
-
-// TODO: implement API handlers:
-// - get analysis data
-// - trigger analysis

--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../shared/handlers.dart';
+
+/// Handlers for the analyzer service.
+Future<shelf.Response> analyzerServiceHandler(shelf.Request request) async {
+  final path = request.requestedUri.path;
+  final handler = {
+    '/debug': debugHandler,
+  }[path];
+
+  if (handler != null) {
+    return handler(request);
+  } else if (path.startsWith('/packages/')) {
+    return packageHandler(request);
+  } else {
+    return notFoundHandler(request);
+  }
+}
+
+/// Handler /debug requests
+Future<shelf.Response> debugHandler(shelf.Request request) async {
+  return jsonResponse({
+    'currentRss': ProcessInfo.currentRss,
+    'maxRss': ProcessInfo.maxRss,
+  }, indent: true);
+}
+
+/// Handles requests for:
+///   - /packages/<package>
+///   - /packages/<package>/<version>
+///   - /packages/<package>/<version>/<analysis>
+Future<shelf.Response> packageHandler(shelf.Request request) async {
+  final String path = request.requestedUri.path.substring('/packages/'.length);
+  final List<String> pathParts = path.split('/');
+  if (path.length == 0 || pathParts.length > 3) {
+    return notFoundHandler(request);
+  }
+  final String package = pathParts[0];
+  final String version = pathParts.length == 1 ? null : pathParts[1];
+  final String analysis = pathParts.length <= 2 ? null : pathParts[2];
+
+  final String requestMethod = request.method?.toUpperCase();
+
+  if (requestMethod == 'GET') {
+    return _getAnalysis(request, package, version, analysis);
+  } else if (requestMethod == 'POST') {
+    if (pathParts.length == 3) {
+      // trigger shouldn't contain analysis id
+      return notFoundHandler(request);
+    }
+    return _triggerAnalysis(request, package, version);
+  }
+
+  return notFoundHandler(request);
+}
+
+Future<shelf.Response> _getAnalysis(shelf.Request request, String package,
+    String version, String analysis) async {
+  // TODO: implement
+  return notFoundHandler(request);
+}
+
+Future<shelf.Response> _triggerAnalysis(
+    shelf.Request request, String package, String version) async {
+  // TODO: implement
+  return notFoundHandler(request);
+}


### PR DESCRIPTION
I think the URLs should do the following:
- GET /packages/[package]: returns the latest analysis of the latest stable version of the package
- GET /packages/[package]/[version]: returns the latest analysis of the given package + version (if exists)
- GET /packages/[package]/[version]/[analysis]: returns the specific analysis of the given package + version (if exists)
- POST /packages/[package]: trigger an asynchronous analysis of the package (latest version will be analyzed)
- POST /packages/[package]/[version]: trigger an asynchronous analysis of the package + version
