### PR TITLE
API refactor: analyzer defaults to return full pana data.

### DIFF
--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -44,7 +44,7 @@ Future<shelf.Response> debugHandler(shelf.Request request) async {
 ///   - /packages/<package>/<version>
 ///   - /packages/<package>/<version>/<analysis>
 Future<shelf.Response> packageHandler(shelf.Request request) async {
-  final bool isFull = request.url.queryParameters['full'] == 'true';
+  final bool onlyMeta = request.url.queryParameters['only-meta'] == 'true';
   final String path = request.requestedUri.path.substring('/packages/'.length);
   final List<String> pathParts = path.split('/');
   if (path.length == 0 || pathParts.length > 3) {
@@ -67,7 +67,7 @@ Future<shelf.Response> packageHandler(shelf.Request request) async {
       return notFoundHandler(request);
     }
     Map analysisContent;
-    if (isFull) {
+    if (!onlyMeta) {
       analysisContent = JSON.decode(analysis.analysisJsonContent);
     }
     return jsonResponse(new AnalysisData(

--- a/app/lib/analyzer/models.dart
+++ b/app/lib/analyzer/models.dart
@@ -119,10 +119,6 @@ class Analysis extends db.ExpandoModel {
   @db.StringProperty(indexed: false)
   String analysisJsonContent;
 
-  // Report fields contain our interpretation and relevant extracts of the pana
-  // analysis output.
-  // TODO: add report fields
-
   /// Empty constructor only for appengine.
   Analysis();
 

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -59,8 +59,6 @@ class PanaRunner {
       analysis.analysisJsonContent = JSON.encode(summary.toJson());
     }
 
-    // TODO: add custom report fields
-
     await _analysisBackend.storeAnalysis(analysis);
   }
 }

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -66,13 +66,14 @@ void main() {
           'timestamp': '2017-06-26T12:48:00.000',
           'analysisVersion': '0.2.0',
           'analysisStatus': 'success',
-          'analysisContent': null
+          'analysisContent': {'content': 'from-pana'}
         });
       });
 
-      scopedTest('/packages/pkg_foo?full=true', () async {
+      scopedTest('/packages/pkg_foo?only-meta=true', () async {
         registerAnalysisBackend(new MockAnalysisBackend());
-        await expectJsonResponse(await issueGet('/packages/pkg_foo?full=true'),
+        await expectJsonResponse(
+            await issueGet('/packages/pkg_foo?only-meta=true'),
             body: {
               'packageName': 'pkg_foo',
               'packageVersion': '1.2.3',
@@ -80,7 +81,7 @@ void main() {
               'timestamp': '2017-06-26T12:48:00.000',
               'analysisVersion': '0.2.0',
               'analysisStatus': 'success',
-              'analysisContent': {'content': 'from-pana'},
+              'analysisContent': null,
             });
       });
 
@@ -94,7 +95,7 @@ void main() {
               'timestamp': '2017-06-26T12:48:00.000',
               'analysisVersion': '0.2.0',
               'analysisStatus': 'success',
-              'analysisContent': null
+              'analysisContent': {'content': 'from-pana'}
             });
       });
 
@@ -109,7 +110,7 @@ void main() {
               'timestamp': '2017-06-26T12:48:00.000',
               'analysisVersion': '0.2.0',
               'analysisStatus': 'success',
-              'analysisContent': null
+              'analysisContent': {'content': 'from-pana'}
             });
       });
     });
@@ -166,8 +167,8 @@ class MockAnalysisBackend implements AnalysisBackend {
   }
 
   @override
-  Future<bool> isValidTarget(String packageName, String packageVersion,
-      String analysisVersion) {
+  Future<bool> isValidTarget(
+      String packageName, String packageVersion, String analysisVersion) {
     throw 'Not implemented yet.';
   }
 }


### PR DESCRIPTION
The reason is: I was planning to extract further summary and analysis from the report, but figured that it introduces (a) a re-analysis latency if we want to extend it (b) an additional class hierarchy that we need to maintain in its serialized form.

If both frontend and search works directly on the output of the pana analysis, there is no need to store such additional report, but then it should be the default to return it via the http handler.