### PR TITLE
Fix analyzer async initialization.

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -50,7 +50,7 @@ void _runScheduler(List<SendPort> sendPorts) {
   mainSendPort.send(taskReceivePort.sendPort);
 
   withAppEngineServices(() async {
-    withCorrectDatastore(() async {
+    await withCorrectDatastore(() async {
       _registerServices();
       final PanaRunner runner = new PanaRunner(analysisBackend);
       await new TaskScheduler(runner.runTask, [


### PR DESCRIPTION
For some cryptic reason it was working locally, but not on staging, causing a service_scope exception that got swallowed without any trace in the logs. Took a bit of try-and-fail until I narrowed it down.