### PR TITLE
Fix Analysis store: its parents objects must exist.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -63,12 +63,10 @@ class AnalysisBackend {
   /// Stores the analysis, and either creates or updates its parent
   /// [PackageAnalysis] and [PackageVersionAnalysis] records.
   Future storeAnalysis(Analysis analysis) async {
-    assert(analysis.id == null);
-    await db.commit(inserts: [analysis]);
-    assert(analysis.id != null);
-
     // update package and version too
     await db.withTransaction((Transaction tx) async {
+      analysis.id =
+          await (tx.db.datastore.allocateIds([analysis.key])).first.id;
       final Key packageKey =
           db.emptyKey.append(PackageAnalysis, id: analysis.packageName);
       final Key packageVersionKey = packageKey.append(PackageVersionAnalysis,
@@ -90,11 +88,7 @@ class AnalysisBackend {
         inserts.add(version);
       }
 
-      if (inserts.isEmpty) {
-        await tx.rollback();
-        return;
-      }
-
+      inserts.add(analysis);
       tx.queueMutations(inserts: inserts);
       await tx.commit();
     });


### PR DESCRIPTION
This is also switching from Datastore-generated ID to manual, using the current timestamp's millis since epoch as ID.

Because both `PackageAnalysis` and `PackageVersionAnalysis` stores the id of the `Analysis`, we either need to create their instance first with null id (with all of the additional error handling that comes with it), or generate the id ourselves.

Using millis since epoch is low risk here, as `Analysis` composite id is prefixed with both package and version.