### PR TITLE
Show example content on package page + model attributes + backfill.

### DIFF
--- a/app/bin/tools/backfill_examples.dart
+++ b/app/bin/tools/backfill_examples.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:archive/archive.dart';
+import 'package:gcloud/db.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/frontend/service_utils.dart';
+import 'package:pub_dartlang_org/shared/utils.dart';
+
+http.Client _httpClient;
+
+Future main(List<String> args) async {
+  int updated = 0;
+  _httpClient = new http.Client();
+  await withProdServices(() async {
+    await for (PackageVersion pv in dbService.query(PackageVersion).run()) {
+      if (pv.exampleFilename == null && pv.exampleContent == null) {
+        try {
+          print('Updating: ${pv.package} ${pv.version}');
+          await _backfill(pv);
+          updated++;
+        } catch (e, st) {
+          print('Failed to update ${pv.package} ${pv.version}, error: $e $st');
+          rethrow;
+        }
+      }
+    }
+  });
+  _httpClient.close();
+  print('Updated: $updated package versions.');
+}
+
+Future _backfill(PackageVersion pv) async {
+  final String uri =
+      'https://storage.googleapis.com/pub-packages/packages/${pv.package}-${pv.version}.tar.gz';
+  final http.Response rs = await _httpClient.get(uri);
+  if (rs.statusCode != 200) {
+    print('Unable to download: $uri');
+    return;
+  }
+
+  final Archive archive = new TarDecoder()
+      .decodeBytes(new GZipDecoder().decodeBytes(rs.bodyBytes, verify: true));
+  ArchiveFile archiveFile;
+  for (String candidate in exampleFileCandidates(pv.package)) {
+    archiveFile = archive.findFile(candidate);
+    if (archiveFile != null) break;
+  }
+  if (archiveFile == null) return;
+
+  final String archiveFilename = archiveFile.name;
+  final String content = UTF8.decode(archiveFile.content, allowMalformed: true);
+  if (content.trim().isEmpty) return;
+
+  await dbService.withTransaction((Transaction t) async {
+    final PackageVersion packageVersion = (await t.lookup([pv.key])).first;
+    packageVersion.exampleFilename = archiveFilename;
+    packageVersion.exampleContent = content;
+    t.queueMutations(inserts: [packageVersion]);
+    await t.commit();
+  });
+}

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -630,12 +630,26 @@ Future<models.PackageVersion> parseAndValidateUpload(
   }
   validatePackageName(pubspec.name);
 
+  var exampleFilename;
+  for (String candidate in exampleFileCandidates(pubspec.name)) {
+    exampleFilename = searchForFile(candidate);
+    if (exampleFilename != null) break;
+  }
+
   final readmeContent = readmeFilename != null
       ? await readTarballFile(filename, readmeFilename)
       : null;
   final changelogContent = changelogFilename != null
       ? await readTarballFile(filename, changelogFilename)
       : null;
+  String exampleContent = exampleFilename != null
+      ? await readTarballFile(filename, exampleFilename)
+      : null;
+
+  if (exampleContent != null && exampleContent.trim().isEmpty) {
+    exampleFilename = null;
+    exampleContent = null;
+  }
 
   final packageKey = db.emptyKey.append(models.Package, id: pubspec.name);
 
@@ -654,6 +668,8 @@ Future<models.PackageVersion> parseAndValidateUpload(
     ..readmeContent = readmeContent
     ..changelogFilename = changelogFilename
     ..changelogContent = changelogContent
+    ..exampleFilename = exampleFilename
+    ..exampleContent = exampleContent
     ..libraries = libraries
     ..downloads = 0
     ..detectedTypes = detectedTypes

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -150,8 +150,9 @@ class PackageVersion extends db.ExpandoModel {
   String readmeContent;
 
   FileObject get readme {
-    if (readmeFilename != null)
+    if (readmeFilename != null) {
       return new FileObject(readmeFilename, readmeContent);
+    }
     return null;
   }
 
@@ -162,8 +163,22 @@ class PackageVersion extends db.ExpandoModel {
   String changelogContent;
 
   FileObject get changelog {
-    if (changelogFilename != null)
+    if (changelogFilename != null) {
       return new FileObject(changelogFilename, changelogContent);
+    }
+    return null;
+  }
+
+  @db.StringProperty(indexed: false)
+  String exampleFilename;
+
+  @db.StringProperty(indexed: false)
+  String exampleContent;
+
+  FileObject get example {
+    if (exampleFilename != null) {
+      return new FileObject(exampleFilename, exampleContent);
+    }
     return null;
   }
 

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -158,9 +158,17 @@ class TemplateService {
       return filename.toLowerCase().endsWith('.md');
     }
 
+    bool isDartFile(String filename) {
+      return filename.toLowerCase().endsWith('.dart');
+    }
+
     String renderPlainText(String text) {
       return '<div class="highlight"><pre>${_escapeAngleBrackets(text)}'
           '</pre></div>';
+    }
+
+    String renderDartCode(String text) {
+      return _markdownToHtml('````dart\n${text.trim()}\n````\n');
     }
 
     String renderFile(FileObject file) {
@@ -169,6 +177,8 @@ class TemplateService {
       if (content != null) {
         if (isMarkdownFile(filename)) {
           return _markdownToHtml(content);
+        } else if (isDartFile(filename)) {
+          return renderDartCode(content);
         } else {
           return renderPlainText(content);
         }
@@ -188,6 +198,13 @@ class TemplateService {
     if (selectedVersion.changelog != null) {
       changelogFilename = selectedVersion.changelog.filename;
       renderedChangelog = renderFile(selectedVersion.changelog);
+    }
+
+    String exampleFilename;
+    String renderedExample;
+    if (selectedVersion.example != null) {
+      exampleFilename = selectedVersion.example.filename;
+      renderedExample = renderFile(selectedVersion.example);
     }
 
     final versionsJson = [];
@@ -263,6 +280,8 @@ class TemplateService {
       'readme_filename': readmeFilename,
       'changelog': renderedChangelog,
       'changelog_filename': changelogFilename,
+      'example': renderedExample,
+      'example_filename': exampleFilename,
       'version_count': '$totalNumberOfVersions',
     };
     return _renderPage(

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -199,3 +199,12 @@ void _doNotify(String uri) {
     _logger.severe('Notification request on $uri aborted: $e');
   });
 }
+
+/// Returns the candidates in priority order to display under the 'Example' tab.
+List<String> exampleFileCandidates(String package) => [
+      'example/lib/main.dart',
+      'example/main.dart',
+      'example/lib/$package.dart',
+      'example/$package.dart',
+      'example/example.dart',
+    ];

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -19,6 +19,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0+3"
+  archive:
+    description:
+      name: archive
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.31"
   args:
     description:
       name: args

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   # pana version to be pinned
   pana: '0.2.3'
   # 3rd-party packages with pinned versions
+  archive: '1.0.31'
   ducene: '0.4.0'
   uuid: '0.5.3'
 

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -109,6 +109,9 @@
         <li class="">
           <a href="#pub-pkg-tab-changelog" data-toggle="tab">CHANGELOG.md</a>
         </li>
+        <li class="">
+          <a href="#pub-pkg-tab-example" data-toggle="tab">Example</a>
+        </li>
       <li class="">
         <a href="#pub-pkg-tab-installing" data-toggle="tab">Installing</a>
       </li>
@@ -124,11 +127,19 @@
 </code></pre>
 
         </div>
-      <div class="tab-pane " id="pub-pkg-tab-changelog">
-        <h1 id="changelog">Changelog</h1>
+        <div class="tab-pane " id="pub-pkg-tab-changelog">
+          <h1 id="changelog">Changelog</h1>
 <p>0.1.1 - test package</p>
 
-      </div>
+        </div>
+        <div class="tab-pane " id="pub-pkg-tab-example">
+          <p style="font-family: monospace"><b>example&#x2F;lib&#x2F;main.dart</b></p>
+          <pre><code class="language-dart">main() {
+  print('Hello world!');
+}
+</code></pre>
+
+        </div>
       <div class="tab-pane " id="pub-pkg-tab-installing">
         <h3>1. Depend on it</h3>
         <p>Add this to your package's pubspec.yaml file:</p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -126,11 +126,11 @@
 </code></pre>
 
         </div>
-      <div class="tab-pane " id="pub-pkg-tab-changelog">
-        <h1 id="changelog">Changelog</h1>
+        <div class="tab-pane " id="pub-pkg-tab-changelog">
+          <h1 id="changelog">Changelog</h1>
 <p>0.1.1 - test package</p>
 
-      </div>
+        </div>
       <div class="tab-pane " id="pub-pkg-tab-installing">
         <h3>1. Depend on it</h3>
         <p>Add this to your package's pubspec.yaml file:</p>

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -53,6 +53,8 @@ final PackageVersion testPackageVersion = new PackageVersion()
   ..readmeContent = TestPackageReadme
   ..changelogFilename = 'CHANGELOG.md'
   ..changelogContent = TestPackageChangelog
+  ..exampleFilename = 'example/lib/main.dart'
+  ..exampleContent = TestPackageExample
   ..sortOrder = -1;
 
 final PackageVersion flutterPackageVersion =
@@ -101,6 +103,12 @@ Changelog
 
 0.1.1 - test package
 
+''';
+
+final String TestPackageExample = '''
+main() {
+  print('Hello world!');
+}
 ''';
 
 final String TestPackagePubspec = '''

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -30,7 +30,12 @@
           <a href="#pub-pkg-tab-changelog" data-toggle="tab">{{changelog_filename}}</a>
         </li>
       {{/changelog}}
-      <li class="{{^readme}}{{^changelog}}active{{/changelog}}{{/readme}}">
+      {{#example}}
+        <li class="{{^readme}}{{^changelog}}active{{/changelog}}{{/readme}}">
+          <a href="#pub-pkg-tab-example" data-toggle="tab">Example</a>
+        </li>
+      {{/example}}
+      <li class="{{^readme}}{{^changelog}}{{^example}}active{{/example}}{{/changelog}}{{/readme}}">
         <a href="#pub-pkg-tab-installing" data-toggle="tab">Installing</a>
       </li>
       <li><a href="#pub-pkg-tab-versions" data-toggle="tab">Versions</a></li>
@@ -43,11 +48,17 @@
         </div>
       {{/readme}}
       {{#changelog}}
-      <div class="tab-pane {{^readme}}active{{/readme}}" id="pub-pkg-tab-changelog">
-        {{&changelog}}
-      </div>
+        <div class="tab-pane {{^readme}}active{{/readme}}" id="pub-pkg-tab-changelog">
+          {{&changelog}}
+        </div>
       {{/changelog}}
-      <div class="tab-pane {{^readme}}{{^changelog}}active{{/changelog}}{{/readme}}" id="pub-pkg-tab-installing">
+      {{#example}}
+        <div class="tab-pane {{^readme}}{{^changelog}}active{{/changelog}}{{/readme}}" id="pub-pkg-tab-example">
+          <p style="font-family: monospace"><b>{{example_filename}}</b></p>
+          {{&example}}
+        </div>
+      {{/example}}
+      <div class="tab-pane {{^readme}}{{^changelog}}{{^example}}active{{/example}}{{/changelog}}{{/readme}}" id="pub-pkg-tab-installing">
         <h3>1. Depend on it</h3>
         <p>Add this to your package's pubspec.yaml file:</p>
 <pre>


### PR DESCRIPTION
The backfill part provides a good testing ground for using the new version of the `archive` package instead of `tar`, this way we'll be sure that everything in the pub repo is extractable by it.
