### PR TITLE
Point README's relative links to the package homepage. Fixes #221.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -9,25 +9,13 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:markdown/markdown.dart';
 import 'package:mustache/mustache.dart' as mustache;
 
+import '../shared/markdown.dart';
 import '../shared/mock_scores.dart';
 
 import 'models.dart';
 import 'search_service.dart' show CseTokens, SearchQuery, SearchResultPage;
-
-final List<BlockSyntax> _blockSyntaxes =
-    ExtensionSet.gitHub.blockSyntaxes.toList();
-
-final List<InlineSyntax> _inlineSyntaxes = ExtensionSet.gitHub.inlineSyntaxes
-    .where((s) => s is! InlineHtmlSyntax)
-    .toList();
-
-String _markdownToHtml(String text) => markdownToHtml(text,
-    extensionSet: ExtensionSet.none,
-    blockSyntaxes: _blockSyntaxes,
-    inlineSyntaxes: _inlineSyntaxes);
 
 String _escapeAngleBrackets(String msg) =>
     const HtmlEscape(HtmlEscapeMode.ELEMENT).convert(msg);
@@ -168,15 +156,15 @@ class TemplateService {
     }
 
     String renderDartCode(String text) {
-      return _markdownToHtml('````dart\n${text.trim()}\n````\n');
+      return markdownToHtml('````dart\n${text.trim()}\n````\n', null);
     }
 
-    String renderFile(FileObject file) {
+    String renderFile(FileObject file, String baseUrl) {
       final filename = file.filename;
       final content = file.text;
       if (content != null) {
         if (isMarkdownFile(filename)) {
-          return _markdownToHtml(content);
+          return markdownToHtml(content, baseUrl);
         } else if (isDartFile(filename)) {
           return renderDartCode(content);
         } else {
@@ -190,21 +178,24 @@ class TemplateService {
     var renderedReadme;
     if (selectedVersion.readme != null) {
       readmeFilename = selectedVersion.readme.filename;
-      renderedReadme = renderFile(selectedVersion.readme);
+      renderedReadme =
+          renderFile(selectedVersion.readme, selectedVersion.homepage);
     }
 
     var changelogFilename;
     var renderedChangelog;
     if (selectedVersion.changelog != null) {
       changelogFilename = selectedVersion.changelog.filename;
-      renderedChangelog = renderFile(selectedVersion.changelog);
+      renderedChangelog =
+          renderFile(selectedVersion.changelog, selectedVersion.homepage);
     }
 
     String exampleFilename;
     String renderedExample;
     if (selectedVersion.example != null) {
       exampleFilename = selectedVersion.example.filename;
-      renderedExample = renderFile(selectedVersion.example);
+      renderedExample =
+          renderFile(selectedVersion.example, selectedVersion.homepage);
     }
 
     final versionsJson = [];

--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:markdown/markdown.dart' as m;
+import 'package:path/path.dart' as p;
+
+final List<m.BlockSyntax> _blockSyntaxes =
+    m.ExtensionSet.gitHub.blockSyntaxes.toList();
+
+final List<m.InlineSyntax> _inlineSyntaxes = m
+    .ExtensionSet.gitHub.inlineSyntaxes
+    .where((s) => s is! m.InlineHtmlSyntax)
+    .toList();
+
+String markdownToHtml(String text, String baseUrl) {
+  return m.markdownToHtml(
+    text,
+    extensionSet: _createCustomExtension(baseUrl),
+    blockSyntaxes: _blockSyntaxes,
+    inlineSyntaxes: _inlineSyntaxes,
+  );
+}
+
+class _RelativeLinkSyntax extends m.LinkSyntax {
+  final Uri baseUri;
+  _RelativeLinkSyntax(this.baseUri);
+
+  static _RelativeLinkSyntax parse(String url) {
+    try {
+      final Uri uri = Uri.parse(url);
+      if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+      if (uri.host == null || uri.host.isEmpty || !uri.host.contains('.'))
+        return null;
+      return new _RelativeLinkSyntax(uri);
+    } catch (e) {
+      // url is user-provided, may be malicious, ignoring errors.
+    }
+    return null;
+  }
+
+  @override
+  m.Link getLink(m.InlineParser parser, Match match, m.TagState state) {
+    final m.Link link = super.getLink(parser, match, state);
+    if (_isRelativePathUrl(link.url)) {
+      final Uri newUri = new Uri(
+        scheme: baseUri.scheme,
+        host: baseUri.host,
+        port: baseUri.port,
+        path: p.join(baseUri.path, link.url),
+      );
+      return new m.Link(link.id, newUri.toString(), link.title);
+    } else {
+      return link;
+    }
+  }
+
+  bool _isRelativePathUrl(String url) =>
+      !url.startsWith('#') && !url.contains(':');
+}
+
+m.ExtensionSet _createCustomExtension(String baseUrl) {
+  final m.InlineSyntax relativeLink = _RelativeLinkSyntax.parse(baseUrl);
+  if (relativeLink == null) return m.ExtensionSet.none;
+  return new _ExtensionSet(inlineSyntaxes: [relativeLink]);
+}
+
+class _ExtensionSet implements m.ExtensionSet {
+  @override
+  final List<m.BlockSyntax> blockSyntaxes;
+
+  @override
+  final List<m.InlineSyntax> inlineSyntaxes;
+
+  _ExtensionSet({this.blockSyntaxes: const [], this.inlineSyntaxes: const []});
+}

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -1,0 +1,77 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/shared/markdown.dart';
+
+void main() {
+  group('Valid custom base URL', () {
+    final String baseUrl = 'https://github.com/example/project';
+
+    test('relative within page', () {
+      expect(markdownToHtml('[text](#relative)', null),
+          '<p><a href="#relative">text</a></p>\n');
+      expect(markdownToHtml('[text](#relative)', baseUrl),
+          '<p><a href="#relative">text</a></p>\n');
+      expect(markdownToHtml('[text](#relative)', '$baseUrl/'),
+          '<p><a href="#relative">text</a></p>\n');
+    });
+
+    test('absolute URL', () {
+      expect(markdownToHtml('[text](http://dartlang.org/)', null),
+          '<p><a href="http://dartlang.org/">text</a></p>\n');
+      expect(markdownToHtml('[text](http://dartlang.org/)', baseUrl),
+          '<p><a href="http://dartlang.org/">text</a></p>\n');
+      expect(markdownToHtml('[text](http://dartlang.org/)', '$baseUrl/'),
+          '<p><a href="http://dartlang.org/">text</a></p>\n');
+    });
+
+    test('sibling within site', () {
+      expect(markdownToHtml('[text](README.md)', null),
+          '<p><a href="README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](README.md)', baseUrl),
+          '<p><a href="https://github.com/example/project/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](README.md)', '$baseUrl/'),
+          '<p><a href="https://github.com/example/project/README.md">text</a></p>\n');
+    });
+
+    test('child within site', () {
+      expect(markdownToHtml('[text](example/README.md)', null),
+          '<p><a href="example/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](example/README.md)', baseUrl),
+          '<p><a href="https://github.com/example/project/example/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](example/README.md)', '$baseUrl/'),
+          '<p><a href="https://github.com/example/project/example/README.md">text</a></p>\n');
+    });
+
+    test('root within site', () {
+      expect(markdownToHtml('[text](/README.md)', null),
+          '<p><a href="/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](example/README.md)', baseUrl),
+          '<p><a href="https://github.com/example/project/example/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](example/README.md)', '$baseUrl/'),
+          '<p><a href="https://github.com/example/project/example/README.md">text</a></p>\n');
+    });
+
+    test('email', () {
+      expect(markdownToHtml('[me](mailto:email@example.com)', null),
+          '<p><a href="mailto:email@example.com">me</a></p>\n');
+      expect(markdownToHtml('[me](mailto:email@example.com)', baseUrl),
+          '<p><a href="mailto:email@example.com">me</a></p>\n');
+    });
+  });
+
+  group('Bad custom base URL', () {
+    test('not http(s)', () {
+      expect(markdownToHtml('[text](README.md)', 'ftp://example.com/blah'),
+          '<p><a href="README.md">text</a></p>\n');
+    });
+
+    test('not valid host', () {
+      expect(markdownToHtml('[text](README.md)', 'http://com/blah'),
+          '<p><a href="README.md">text</a></p>\n');
+    });
+  });
+}


### PR DESCRIPTION
Refactored markdown processing, overriding the inline syntax parser for links.