### PR TITLE
Poor man's priority stream merger, removing the need for manual stream throttle.

### DIFF
--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -64,13 +64,11 @@ class DatastoreHistoryTaskSource implements TaskSource {
   final DatastoreDB _db;
   final int afterDays;
   final String analysisVersion;
-  final Duration period;
 
   DatastoreHistoryTaskSource(
     this._db, {
     this.afterDays: 30,
     this.analysisVersion,
-    this.period: const Duration(seconds: 30),
   });
 
   @override
@@ -85,9 +83,6 @@ class DatastoreHistoryTaskSource implements TaskSource {
                 .append(PackageVersionAnalysis, id: pv.version)
           ]);
           if (list.first == null) {
-            // Waiting to throttle the historical tasks. If there is a newly
-            // uploaded package, give it a chance before continuing with these.
-            await new Future.delayed(const Duration(seconds: 30));
             yield new Task(pv.package, pv.version);
             continue;
           }
@@ -99,9 +94,6 @@ class DatastoreHistoryTaskSource implements TaskSource {
               version.analysisVersion != analysisVersion;
 
           if (versionDiffers || diff.inDays >= afterDays) {
-            // Waiting to throttle the historical tasks. If there is a newly
-            // uploaded package, give it a chance before continuing with these.
-            await new Future.delayed(const Duration(seconds: 30));
             yield new Task(version.packageName, version.packageVersion);
           }
         }


### PR DESCRIPTION
I've been looking into `async` and similar packages, but couldn't find anything that does it similarly to our needs. `StreamQueue` came close, but it lack a synchronous `hasPending` or similar indication whether the queue has anything immediate, and without it the code was more complex than the current PR.

At this point I think we could remove the `StreamSource` interface altogether, and use streams only, but keeping that to a follow-up, once we are settled with this one.