### PR TITLE
Store analysis content in gzipped blob

### DIFF
--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:shelf/shelf.dart' as shelf;
@@ -68,7 +67,7 @@ Future<shelf.Response> packageHandler(shelf.Request request) async {
     }
     Map analysisContent;
     if (!onlyMeta) {
-      analysisContent = JSON.decode(analysis.analysisJsonContent);
+      analysisContent = analysis.analysisJson;
     }
     return jsonResponse(new AnalysisData(
             packageName: analysis.packageName,

--- a/app/lib/analyzer/models.dart
+++ b/app/lib/analyzer/models.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:gcloud/db.dart' as db;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -117,8 +120,8 @@ class Analysis extends db.ExpandoModel {
   @AnalysisStatusProperty()
   AnalysisStatus analysisStatus;
 
-  @db.StringProperty(indexed: false)
-  String analysisJsonContent;
+  @db.BlobProperty()
+  List<int> analysisJsonGz;
 
   /// Empty constructor only for appengine.
   Analysis();
@@ -130,4 +133,14 @@ class Analysis extends db.ExpandoModel {
         .append(PackageAnalysis, id: packageName)
         .append(PackageVersionAnalysis, id: packageVersion);
   }
+
+  Map get analysisJson {
+    return JSON.decode(UTF8.decode(_gzipCodec.decode(analysisJsonGz)));
+  }
+
+  set analysisJson(Map map) {
+    analysisJsonGz = _gzipCodec.encode(UTF8.encode(JSON.encode(map)));
+  }
 }
+
+final GZipCodec _gzipCodec = new GZipCodec();

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:logging/logging.dart';
 import 'package:pana/pana.dart';
@@ -56,7 +55,7 @@ class PanaRunner {
       } else {
         analysis.analysisStatus = AnalysisStatus.failure;
       }
-      analysis.analysisJsonContent = JSON.encode(summary.toJson());
+      analysis.analysisJson = summary.toJson();
     }
 
     await _analysisBackend.storeAnalysis(analysis);

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -180,4 +180,4 @@ final Analysis testAnalysis = new Analysis()
   ..analysisStatus = AnalysisStatus.success
   ..analysisVersion = '0.2.0'
   ..timestamp = new DateTime(2017, 06, 26, 12, 48, 00)
-  ..analysisJsonContent = '{"content": "from-pana"}';
+  ..analysisJson = {'content': 'from-pana'};


### PR DESCRIPTION
Reasons:
- Datastore is not able to store fields larger than 1MB
- for example: `package:googleapis` total analysis is roughly 1.6MB in text, and compresses to 50k gzip
- We will be well within safe margins when gzipping the json content.

I'll wipe out staging's analysis data and re-do it once this merges.