### PR TITLE
Randomize analyzer tasks to reduce duplicates in case multiple instances are running

### DIFF
--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 
 import '../frontend/models.dart';
 import '../shared/task_scheduler.dart';
+import '../shared/utils.dart';
 
 import 'models.dart';
 
@@ -72,7 +73,9 @@ class DatastoreHistoryTaskSource implements TaskSource {
   });
 
   @override
-  Stream<Task> startStreaming() async* {
+  Stream<Task> startStreaming() => randomizeStream(_startStreaming());
+
+  Stream<Task> _startStreaming() async* {
     for (;;) {
       try {
         final Query query = _db.query(PackageVersion)..order('-created');

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -337,6 +337,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.1"
+  stream_transform:
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.7"
   string_scanner:
     description:
       name: string_scanner

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   pub_semver: ">=1.2.2 <2.0.0"
   pub_server: ">=0.1.0 <0.2.0"
   shelf: '>=0.5.6 <0.7.0'
+  stream_transform: ^0.0.7
   # pana version to be pinned
   pana: '0.2.3'
   # 3rd-party packages with pinned versions

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -1,0 +1,57 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/shared/utils.dart';
+
+void main() {
+  group('Randomize Stream', () {
+    test('Single batch', () async {
+      final Stream<int> randomizedStream = randomizeStream(
+        new Stream.fromIterable(new List.generate(10, (i) => i)),
+        duration: new Duration(milliseconds: 100),
+        random: new Random(123),
+      );
+      expect(await randomizedStream.toList(), [4, 3, 2, 8, 7, 5, 9, 1, 0, 6]);
+    });
+
+    test('Two batches', () async {
+      final StreamController<int> controller = new StreamController<int>();
+      final Stream<int> randomizedStream = randomizeStream(
+        controller.stream,
+        duration: new Duration(milliseconds: 100),
+        random: new Random(123),
+      );
+      final Future<List<int>> valuesFuture = randomizedStream.toList();
+      new List.generate(8, (i) => i).forEach(controller.add);
+      await new Future.delayed(new Duration(milliseconds: 200));
+      new List.generate(8, (i) => i + 10).forEach(controller.add);
+      controller.close();
+      // 0-7, 10-17 in separate batches
+      expect(await valuesFuture,
+          [1, 0, 7, 5, 6, 3, 4, 2, 10, 14, 11, 17, 13, 16, 15, 12]);
+    });
+
+    test('Small slices', () async {
+      final StreamController<int> controller = new StreamController<int>();
+      final Stream<int> randomizedStream = randomizeStream(
+        controller.stream,
+        duration: new Duration(milliseconds: 100),
+        maxPositionDiff: 4,
+        random: new Random(123),
+      );
+      final Future<List<int>> valuesFuture = randomizedStream.toList();
+      new List.generate(8, (i) => i).forEach(controller.add);
+      new List.generate(8, (i) => i + 10).forEach(controller.add);
+      controller.close();
+      // 0-3, 4-7, 10-13, 14-17 in separate batches
+      expect(await valuesFuture,
+          [3, 1, 0, 2, 4, 5, 6, 7, 11, 13, 12, 10, 16, 14, 17, 15]);
+    });
+  });
+}


### PR DESCRIPTION
`stream_transform`'s `buffer` was published ~9 days ago, and it is a perfect fit for us.
There will be collisions (when two instances start to re-analyze everything for a new pana version), but not too many, and if with increasing the slice sizes or the buffer time, it can be reduced further. 