### PR TITLE
Simplify show package template.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -196,6 +196,12 @@ class TemplateService {
       exampleFilename = selectedVersion.example.filename;
       renderedExample =
           renderFile(selectedVersion.example, selectedVersion.homepage);
+      if (renderedExample != null) {
+        renderedExample = '<p style="font-family: monospace">'
+            '<b>${_HtmlEscaper.convert(exampleFilename)}</b>'
+            '</p>\n'
+            '$renderedExample';
+      }
     }
 
     final versionsJson = [];
@@ -230,6 +236,22 @@ class TemplateService {
     final bool isFlutterPlugin = latestStableVersion.detectedTypes
             ?.contains(BuiltinTypes.flutterPlugin) ==
         true;
+
+    final List<Map<String, String>> tabs = <Map<String, String>>[];
+    void addFileTab(String id, String title, String content) {
+      if (content != null) {
+        tabs.add({
+          'id': id,
+          'title': title,
+          'content': content,
+        });
+      }
+    }
+
+    addFileTab('readme', readmeFilename, renderedReadme);
+    addFileTab('changelog', changelogFilename, renderedChangelog);
+    addFileTab('example', 'Example', renderedExample);
+    if (tabs.isNotEmpty) tabs.first['class'] = 'active';
 
     final values = {
       'package': {
@@ -267,12 +289,8 @@ class TemplateService {
       },
       'versions': versionsJson,
       'show_versions_link': totalNumberOfVersions > versions.length,
-      'readme': renderedReadme,
-      'readme_filename': readmeFilename,
-      'changelog': renderedChangelog,
-      'changelog_filename': changelogFilename,
-      'example': renderedExample,
-      'example_filename': exampleFilename,
+      'tabs': tabs,
+      'has_no_file_tab': tabs.isEmpty,
       'version_count': '$totalNumberOfVersions',
     };
     return _renderPage(

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -103,15 +103,15 @@
 <div class="row-fluid">
   <div class="span8">
     <ul class="nav nav-tabs">
-        <li class="active">
-          <a href="#pub-pkg-tab-readme" data-toggle="tab">README.md</a>
-        </li>
-        <li class="">
-          <a href="#pub-pkg-tab-changelog" data-toggle="tab">CHANGELOG.md</a>
-        </li>
-        <li class="">
-          <a href="#pub-pkg-tab-example" data-toggle="tab">Example</a>
-        </li>
+      <li class="active">
+        <a href="#pub-pkg-tab-readme" data-toggle="tab">README.md</a>
+      </li>
+      <li class="">
+        <a href="#pub-pkg-tab-changelog" data-toggle="tab">CHANGELOG.md</a>
+      </li>
+      <li class="">
+        <a href="#pub-pkg-tab-example" data-toggle="tab">Example</a>
+      </li>
       <li class="">
         <a href="#pub-pkg-tab-installing" data-toggle="tab">Installing</a>
       </li>
@@ -119,27 +119,27 @@
     </ul>
 
     <div class="tab-content">
-        <div class="tab-pane active" id="pub-pkg-tab-readme">
-          <h1 id="test-package">Test Package</h1>
+      <div class="tab-pane active" id="pub-pkg-tab-readme">
+        <h1 id="test-package">Test Package</h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
 </code></pre>
 
-        </div>
-        <div class="tab-pane " id="pub-pkg-tab-changelog">
-          <h1 id="changelog">Changelog</h1>
+      </div>
+      <div class="tab-pane " id="pub-pkg-tab-changelog">
+        <h1 id="changelog">Changelog</h1>
 <p>0.1.1 - test package</p>
 
-        </div>
-        <div class="tab-pane " id="pub-pkg-tab-example">
-          <p style="font-family: monospace"><b>example&#x2F;lib&#x2F;main.dart</b></p>
-          <pre><code class="language-dart">main() {
+      </div>
+      <div class="tab-pane " id="pub-pkg-tab-example">
+        <p style="font-family: monospace"><b>example&#47;lib&#47;main.dart</b></p>
+<pre><code class="language-dart">main() {
   print('Hello world!');
 }
 </code></pre>
 
-        </div>
+      </div>
       <div class="tab-pane " id="pub-pkg-tab-installing">
         <h3>1. Depend on it</h3>
         <p>Add this to your package's pubspec.yaml file:</p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -105,12 +105,12 @@
 <div class="row-fluid">
   <div class="span8">
     <ul class="nav nav-tabs">
-        <li class="active">
-          <a href="#pub-pkg-tab-readme" data-toggle="tab">README.md</a>
-        </li>
-        <li class="">
-          <a href="#pub-pkg-tab-changelog" data-toggle="tab">CHANGELOG.md</a>
-        </li>
+      <li class="active">
+        <a href="#pub-pkg-tab-readme" data-toggle="tab">README.md</a>
+      </li>
+      <li class="">
+        <a href="#pub-pkg-tab-changelog" data-toggle="tab">CHANGELOG.md</a>
+      </li>
       <li class="">
         <a href="#pub-pkg-tab-installing" data-toggle="tab">Installing</a>
       </li>
@@ -118,19 +118,19 @@
     </ul>
 
     <div class="tab-content">
-        <div class="tab-pane active" id="pub-pkg-tab-readme">
-          <h1 id="test-package">Test Package</h1>
+      <div class="tab-pane active" id="pub-pkg-tab-readme">
+        <h1 id="test-package">Test Package</h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
 </code></pre>
 
-        </div>
-        <div class="tab-pane " id="pub-pkg-tab-changelog">
-          <h1 id="changelog">Changelog</h1>
+      </div>
+      <div class="tab-pane " id="pub-pkg-tab-changelog">
+        <h1 id="changelog">Changelog</h1>
 <p>0.1.1 - test package</p>
 
-        </div>
+      </div>
       <div class="tab-pane " id="pub-pkg-tab-installing">
         <h3>1. Depend on it</h3>
         <p>Add this to your package's pubspec.yaml file:</p>

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -20,45 +20,24 @@
 <div class="row-fluid">
   <div class="span8">
     <ul class="nav nav-tabs">
-      {{#readme}}
-        <li class="active">
-          <a href="#pub-pkg-tab-readme" data-toggle="tab">{{readme_filename}}</a>
-        </li>
-      {{/readme}}
-      {{#changelog}}
-        <li class="{{^readme}}active{{/readme}}">
-          <a href="#pub-pkg-tab-changelog" data-toggle="tab">{{changelog_filename}}</a>
-        </li>
-      {{/changelog}}
-      {{#example}}
-        <li class="{{^readme}}{{^changelog}}active{{/changelog}}{{/readme}}">
-          <a href="#pub-pkg-tab-example" data-toggle="tab">Example</a>
-        </li>
-      {{/example}}
-      <li class="{{^readme}}{{^changelog}}{{^example}}active{{/example}}{{/changelog}}{{/readme}}">
+      {{#tabs}}
+      <li class="{{class}}">
+        <a href="#pub-pkg-tab-{{id}}" data-toggle="tab">{{title}}</a>
+      </li>
+      {{/tabs}}
+      <li class="{{#has_no_file_tab}}active{{/has_no_file_tab}}">
         <a href="#pub-pkg-tab-installing" data-toggle="tab">Installing</a>
       </li>
       <li><a href="#pub-pkg-tab-versions" data-toggle="tab">Versions</a></li>
     </ul>
 
     <div class="tab-content">
-      {{#readme}}
-        <div class="tab-pane active" id="pub-pkg-tab-readme">
-          {{&readme}}
-        </div>
-      {{/readme}}
-      {{#changelog}}
-        <div class="tab-pane {{^readme}}active{{/readme}}" id="pub-pkg-tab-changelog">
-          {{&changelog}}
-        </div>
-      {{/changelog}}
-      {{#example}}
-        <div class="tab-pane {{^readme}}{{^changelog}}active{{/changelog}}{{/readme}}" id="pub-pkg-tab-example">
-          <p style="font-family: monospace"><b>{{example_filename}}</b></p>
-          {{&example}}
-        </div>
-      {{/example}}
-      <div class="tab-pane {{^readme}}{{^changelog}}{{^example}}active{{/example}}{{/changelog}}{{/readme}}" id="pub-pkg-tab-installing">
+      {{#tabs}}
+      <div class="tab-pane {{class}}" id="pub-pkg-tab-{{id}}">
+        {{&content}}
+      </div>
+      {{/tabs}}
+      <div class="tab-pane {{#has_no_file_tab}}active{{/has_no_file_tab}}" id="pub-pkg-tab-installing">
         <h3>1. Depend on it</h3>
         <p>Add this to your package's pubspec.yaml file:</p>
 <pre>


### PR DESCRIPTION
The logic around the `active` class was no longer scalable. With this change, https://github.com/dart-lang/pub-dartlang-dart/issues/220 becomes easier to consider and try out.