### PR TITLE
Make PrioritizedAsyncIterator more like AsyncIterator

### DIFF
--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -39,8 +39,8 @@ class TaskScheduler {
     final PrioritizedAsyncIterator<Task> taskIterator =
         new PrioritizedAsyncIterator(
             sources.map((TaskSource ts) => ts.startStreaming()).toList());
-    while (await taskIterator.hasNext) {
-      final Task task = await taskIterator.next;
+    while (await taskIterator.moveNext()) {
+      final Task task = taskIterator.current;
       try {
         await taskRunner(task);
       } catch (e, st) {
@@ -78,9 +78,10 @@ class Task {
 class PrioritizedAsyncIterator<T> {
   List<Queue<T>> _priorityQueues;
   List<StreamSubscription> _subscriptions;
+  bool _hasMoved = false;
   bool _isClosed = false;
+  T _current;
   Completer<bool> _hasNextCompleter;
-  Completer<T> _nextCompleter;
 
   PrioritizedAsyncIterator(List<Stream<T>> sources) {
     _priorityQueues = new List.generate(sources.length, (_) => new Queue());
@@ -104,18 +105,17 @@ class PrioritizedAsyncIterator<T> {
     }
   }
 
-  /// Whether the iterator has any immediately available item.
-  bool get hasAvailable {
-    final Queue<T> queue = _firstQueue();
-    return queue != null;
-  }
-
-  /// Whether the iterator has another item.
-  Future<bool> get hasNext async {
-    if (_hasNextCompleter != null) return _hasNextCompleter.future;
+  /// Moves to the next element.
+  /// Returns whether the iterator has another item.
+  Future<bool> moveNext() async {
+    if (_hasNextCompleter != null) {
+      throw new StateError('Another moveNext() is underway.');
+    }
     if (_isClosed) return false;
     final Queue<T> queue = _firstQueue();
     if (queue != null) {
+      _current = queue.removeFirst();
+      _hasMoved = true;
       return true;
     } else {
       _hasNextCompleter ??= new Completer();
@@ -124,17 +124,11 @@ class PrioritizedAsyncIterator<T> {
     }
   }
 
-  /// The next item in the iterator.
-  Future<T> get next async {
-    if (_nextCompleter != null) return _nextCompleter.future;
-    final Queue<T> queue = _firstQueue();
-    if (queue != null) {
-      return queue.removeFirst();
-    } else {
-      _nextCompleter ??= new Completer();
-      _closeWhenAllDone();
-      return _nextCompleter.future;
-    }
+  // The current element in the iterator.
+  T get current {
+    if (_isClosed) throw new StateError('AsyncIterator closed.');
+    if (!_hasMoved) throw new StateError('moveNext() has not been called.');
+    return _current;
   }
 
   /// Close the source streams and don't accept new requests.
@@ -142,10 +136,6 @@ class PrioritizedAsyncIterator<T> {
     if (_hasNextCompleter != null) {
       _hasNextCompleter.complete(false);
       _hasNextCompleter = null;
-    }
-    if (_nextCompleter != null) {
-      _nextCompleter.completeError('PrioritizedStreamQueue close() called.');
-      _nextCompleter = null;
     }
     for (int i = 0; i < _subscriptions.length; i++) {
       final StreamSubscription s = _subscriptions[i];
@@ -159,22 +149,18 @@ class PrioritizedAsyncIterator<T> {
 
   Queue<T> _firstQueue() {
     if (_isClosed) {
-      throw new Exception('PrioritizedStreamQueue closed');
+      throw new StateError('AsyncIterator closed');
     }
     return _priorityQueues.firstWhere((q) => q.isNotEmpty, orElse: () => null);
   }
 
   void _triggerComplete() {
     if (_hasNextCompleter != null) {
+      final Queue<T> queue = _firstQueue();
+      _current = queue.removeFirst();
+      _hasMoved = true;
       _hasNextCompleter.complete(true);
       _hasNextCompleter = null;
-    }
-    if (_nextCompleter != null) {
-      final Queue<T> queue = _firstQueue();
-      if (queue != null) {
-        _nextCompleter.complete(queue.removeFirst());
-      }
-      _nextCompleter = null;
     }
     _closeWhenAllDone();
   }

--- a/app/test/shared/async_iterator_test.dart
+++ b/app/test/shared/async_iterator_test.dart
@@ -12,6 +12,34 @@ void main() {
   final Duration millis10 = new Duration(milliseconds: 10);
   final Duration millis100 = new Duration(milliseconds: 100);
 
+  group('Initialization', () {
+    test('Calling current without moveNext().', () async {
+      final Completer c = new Completer();
+      final iterator = new PrioritizedAsyncIterator([
+        new Stream.fromFutures([c.future]),
+      ]);
+      expect(() => iterator.current, throwsStateError);
+      c.complete();
+      expect(() => iterator.current, throwsStateError);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, isNull);
+      expect(await iterator.moveNext(), isFalse);
+    });
+
+    test('Calling moveNext() while another is being evaluated.', () async {
+      final Completer c = new Completer();
+      final iterator = new PrioritizedAsyncIterator([
+        new Stream.fromFutures([c.future]),
+      ]);
+      final Future f = iterator.moveNext();
+      expect(() => iterator.moveNext(), throwsStateError);
+      c.complete();
+      expect(await f, isTrue);
+      expect(iterator.current, isNull);
+      expect(await iterator.moveNext(), isFalse);
+    });
+  });
+
   group('Completes', () {
     test('single stream', () async {
       final iterator = new PrioritizedAsyncIterator([
@@ -20,12 +48,12 @@ void main() {
           new Future.delayed(millis10, () => 2),
         ])
       ]);
-      expect(await iterator.hasNext, isTrue);
-      expect(await iterator.next, 1);
-      expect(await iterator.hasNext, isTrue);
-      expect(await iterator.next, 2);
-      expect(await iterator.hasNext, isFalse);
-      expect(() => iterator.next, throwsA(isException));
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 1);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 2);
+      expect(await iterator.moveNext(), isFalse);
+      expect(() => iterator.current, throwsStateError);
     });
 
     test('two streams', () async {
@@ -38,15 +66,15 @@ void main() {
           new Future.delayed(millis100, () => 100),
         ]),
       ]);
-      expect(await iterator.hasNext, isTrue);
-      expect(await iterator.next, 1);
-      expect(await iterator.hasNext, isTrue);
-      expect(await iterator.next, 2);
-      expect(await iterator.hasNext, isTrue);
-      expect(await iterator.next, 100);
-      expect(await iterator.hasNext, isFalse);
-      expect(await iterator.hasNext, isFalse);
-      expect(() => iterator.next, throwsA(isException));
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 1);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 2);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 100);
+      expect(await iterator.moveNext(), isFalse);
+      expect(await iterator.moveNext(), isFalse);
+      expect(() => iterator.current, throwsStateError);
     });
   });
 
@@ -59,16 +87,16 @@ void main() {
         new Stream.fromFutures([c1.future]),
         new Stream.fromFutures([c2.future, c3.future]),
       ]);
-      expect(iterator.hasAvailable, isFalse);
       c2.complete(1);
-      expect(await iterator.hasNext, isTrue);
-      expect(iterator.hasAvailable, isTrue);
       c1.complete(100);
       c3.complete(2);
-      expect(await iterator.next, 100);
-      expect(await iterator.next, 1);
-      expect(await iterator.next, 2);
-      expect(await iterator.hasNext, isFalse);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 100);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 1);
+      expect(await iterator.moveNext(), isTrue);
+      expect(iterator.current, 2);
+      expect(await iterator.moveNext(), isFalse);
     });
   });
 }

--- a/app/test/shared/async_iterator_test.dart
+++ b/app/test/shared/async_iterator_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/shared/task_scheduler.dart';
+
+void main() {
+  final Duration millis10 = new Duration(milliseconds: 10);
+  final Duration millis100 = new Duration(milliseconds: 100);
+
+  group('Completes', () {
+    test('single stream', () async {
+      final iterator = new PrioritizedAsyncIterator([
+        new Stream.fromFutures([
+          new Future.delayed(millis10, () => 1),
+          new Future.delayed(millis10, () => 2),
+        ])
+      ]);
+      expect(await iterator.hasNext, isTrue);
+      expect(await iterator.next, 1);
+      expect(await iterator.hasNext, isTrue);
+      expect(await iterator.next, 2);
+      expect(await iterator.hasNext, isFalse);
+      expect(() => iterator.next, throwsA(isException));
+    });
+
+    test('two streams', () async {
+      final iterator = new PrioritizedAsyncIterator([
+        new Stream.fromFutures([
+          new Future.delayed(millis10, () => 1),
+          new Future.delayed(millis10, () => 2),
+        ]),
+        new Stream.fromFutures([
+          new Future.delayed(millis100, () => 100),
+        ]),
+      ]);
+      expect(await iterator.hasNext, isTrue);
+      expect(await iterator.next, 1);
+      expect(await iterator.hasNext, isTrue);
+      expect(await iterator.next, 2);
+      expect(await iterator.hasNext, isTrue);
+      expect(await iterator.next, 100);
+      expect(await iterator.hasNext, isFalse);
+      expect(await iterator.hasNext, isFalse);
+      expect(() => iterator.next, throwsA(isException));
+    });
+  });
+
+  group('Priorities', () {
+    test('in mixed order', () async {
+      final Completer c1 = new Completer.sync();
+      final Completer c2 = new Completer.sync();
+      final Completer c3 = new Completer.sync();
+      final iterator = new PrioritizedAsyncIterator([
+        new Stream.fromFutures([c1.future]),
+        new Stream.fromFutures([c2.future, c3.future]),
+      ]);
+      expect(iterator.hasAvailable, isFalse);
+      c2.complete(1);
+      expect(await iterator.hasNext, isTrue);
+      expect(iterator.hasAvailable, isTrue);
+      c1.complete(100);
+      c3.complete(2);
+      expect(await iterator.next, 100);
+      expect(await iterator.next, 1);
+      expect(await iterator.next, 2);
+      expect(await iterator.hasNext, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
This is branched off of https://github.com/dart-lang/pub-dartlang-dart/pull/237

On the weekend I was playing with some async concepts, and figured that nobody created an `AsyncIterator` interface like the following:

```
abstract class AsyncIterator<T> {
  Future<bool> moveNext();
  T get current;
}
```

This is very close to the `Iterator` interface, except `moveNext()` is async. I think it is useful to have a lazy async API like this, and I'm planning to publish it soon.

I've rewritten the pub site's code to conform the same API.
