### PR TITLE
Fix analyzer notification url.

### DIFF
--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -168,8 +168,8 @@ List<List<T>> sliceList<T>(List<T> list, int limit) {
 
 void notifyAnalyzer(String package, String version) {
   try {
-    final String host = activeConfiguration.analyzerServicePrefix;
-    final String uri = 'https://$host/packages/$package/$version';
+    final String httpHostPort = activeConfiguration.analyzerServicePrefix;
+    final String uri = '$httpHostPort/packages/$package/$version';
     _doNotify(uri);
   } catch (e) {
     // we are running in travis


### PR DESCRIPTION
I'm not sure why this wasn't ported the same way as `notifySearch`, maybe I got it wrong during a merge, or just forget about it.