### PR TITLE
Use search service by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,6 @@ To view your application in the web browser run:
   $ gcloud app browse
 ```
 
-Similarly, to deploy a new version of the `analyzer` service:
-
-```
-pub-dartlang-dart $ gcloud app deploy --no-promote analyzer.yaml
-```
-
 This will do a remote docker build in the cloud, push the generated docker image layers to a
 GCS bucket and deploy a new version to AppEngine.
 
@@ -122,6 +116,25 @@ deployment.
 pub-dartlang-dart $ git tag -a <version> -m <version>
 pub-dartlang-dart $ git push origin <version>
 ```
+
+### Services
+
+The pub site uses two services:
+- `search` (production ready)
+- `analyzer` (experimental, staging only)
+
+To deploy each, use the following:
+
+```
+pub-dartlang-dart $ gcloud app deploy --no-promote search.yaml
+pub-dartlang-dart $ gcloud app deploy --no-promote analyzer.yaml
+```
+
+Check the following URLs for immediate feedback on the services:
+- `search`: [prod](https://search-dot-dartlang-pub.appspot.com/debug), [staging](https://search-dot-dartlang-pub-dev.appspot.com/debug). Make sure that `ready` flag is `true` before diverting traffic to the new version.
+- `analyzer`: [prod](https://analyzer-dot-dartlang-pub.appspot.com/debug), [staging](https://analyzer-dot-dartlang-pub-dev.appspot.com/debug)
+
+Services can be deployed and updated independently, but version-specific deploy instructions may apply in the PR description.
 
 ## Using custom third-party packages (or any non-published packages)
 

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -157,9 +157,6 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
   final SearchBias expBias =
       parseExperimentalBias(request.url.queryParameters['experimental-bias']);
 
-  final bool useService =
-      request.url.queryParameters['experimental-service'] == 'true';
-
   final SearchQuery query = new SearchQuery(
     queryText,
     offset: PageLinks.RESULTS_PER_PAGE * (page - 1),
@@ -173,7 +170,8 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
         new SearchResultPage.empty(query), new SearchLinks.empty(query)));
   }
 
-  final resultPage = await searchService.search(query, useService);
+  final resultPage =
+      await searchService.search(query, true /* use search service */);
   final links = new SearchLinks(query, resultPage.totalCount);
   final String content = templateService.renderSearchPage(resultPage, links);
 

--- a/search.yaml
+++ b/search.yaml
@@ -10,12 +10,12 @@ resources:
   cpu: 1
   memory_gb: 3.5
 
-manual_scaling:
-  instances: 1
+#manual_scaling:
+#  instances: 1
 
-#automatic_scaling:
-#  min_num_instances: 1
-#  max_num_instances: 4
+automatic_scaling:
+  min_num_instances: 1
+  max_num_instances: 2
 
 skip_files:
 - ^.*/packages.*$


### PR DESCRIPTION
Deployment instructions:
- Deploy `search` service in production. Wait until the the `/debug` url reports back that it is ready.
- Deploy `app` in production.

Demo: https://dartlang-pub-dev.appspot.com/search?q=http
