### PR TITLE
Search results load versions from package, and don't trust the service-provided ones.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -32,7 +32,6 @@ RegExp _packageRegexp =
 
 // Non-revealing metrics to monitor the search service behavior from outside.
 final _searchBackendTracker = new LastNTracker<String>();
-final _searchBackendLatencyTracker = new LastNTracker<Duration>();
 final _searchOverallLatencyTracker = new LastNTracker<Duration>();
 
 /// Handler for the whole URL space of pub.dartlang.org
@@ -84,7 +83,6 @@ Future<shelf.Response> debugHandler(shelf.Request request) async {
   return jsonResponse({
     'search': {
       'backend_counts': _searchBackendTracker.toCounts(),
-      'backend_latency': _searchBackendLatencyTracker.median?.inMilliseconds,
       'overall_latency': _searchOverallLatencyTracker.median?.inMilliseconds,
     },
   }, indent: true);
@@ -177,7 +175,6 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
   final String content = templateService.renderSearchPage(resultPage, links);
 
   _searchBackendTracker.add(resultPage.backend);
-  _searchBackendLatencyTracker.add(resultPage.latency);
   _searchOverallLatencyTracker.add(sw.elapsed);
 
   await searchMemcache?.setUiSearchPage(cacheUrl, content);

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -465,7 +465,6 @@ class TemplateService {
       'pagination': renderPagination(pageLinks),
       'hasResults': results.length > 0,
       'search_service': resultPage.backend == 'service',
-      'latency_ms': resultPage.latency.inMilliseconds,
     };
     return _renderPage('search', values,
         title: 'Search results for $queryText.', searchQuery: queryText);

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -193,7 +193,6 @@ void main() {
             [testPackageVersion],
             [testPackageVersion],
             'service',
-            Duration.ZERO,
           );
         }));
         await expectHtmlResponse(await issueGet('/search?q=foobar'),
@@ -211,7 +210,6 @@ void main() {
             [testPackageVersion],
             [testPackageVersion],
             'service',
-            Duration.ZERO,
           );
         }));
         await expectHtmlResponse(await issueGet('/search?q=foobar&page=2'));

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -113,7 +113,6 @@ void main() {
         [testPackageVersion, flutterPackageVersion],
         [testPackageVersion, flutterPackageVersion],
         'service',
-        Duration.ZERO,
       );
       final String html =
           templates.renderSearchPage(resultPage, new SearchLinks(query, 2));


### PR DESCRIPTION
Previously I've considered the lack of package lookup as a feature, but it turns out we have a good reason to keep it around. This could have also prevented #269.

I'm removing the service-latency tracker, because in practice there isn't much difference between the service and the total (which is a good thing), and it simplifies the code.