### PR TITLE
Expose analyzer stats through /debug handler.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -64,7 +64,7 @@ void _main(int isolateId) {
       await batchIndexUpdater.initSnapshot();
 
       final scheduler = new TaskScheduler(
-        batchIndexUpdater.updateIndex,
+        batchIndexUpdater,
         [
           new ManualTriggerTaskSource(taskReceivePort),
           new IndexUpdateTaskSource(batchIndexUpdater),

--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -14,6 +14,14 @@ import '../shared/task_client.dart';
 import 'backend.dart';
 import 'models.dart';
 
+Map _latestStats;
+
+void registerSchedulerStatsStream(Stream<Map> stream) {
+  stream.listen((stats) {
+    _latestStats = stats;
+  });
+}
+
 /// Handlers for the analyzer service.
 Future<shelf.Response> analyzerServiceHandler(shelf.Request request) async {
   final path = request.requestedUri.path;
@@ -35,6 +43,7 @@ Future<shelf.Response> debugHandler(shelf.Request request) async {
   return jsonResponse({
     'currentRss': ProcessInfo.currentRss,
     'maxRss': ProcessInfo.maxRss,
+    'scheduler': _latestStats,
   }, indent: true);
 }
 

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -36,7 +36,7 @@ class IndexUpdateTaskSource implements TaskSource {
   }
 }
 
-class BatchIndexUpdater {
+class BatchIndexUpdater implements TaskRunner {
   final List<Task> _batch = [];
   Timer _batchUpdateTimer;
   Future _ongoingBatchUpdate;
@@ -85,7 +85,14 @@ class BatchIndexUpdater {
     }
   }
 
-  Future updateIndex(Task task) async {
+  @override
+  Future<bool> hasCompletedRecently(Task task) async {
+    // re-running indexing is not expensive, better to be on the latest
+    return false;
+  }
+
+  @override
+  Future<bool> runTask(Task task) async {
     while (_ongoingBatchUpdate != null) {
       await _ongoingBatchUpdate;
     }
@@ -97,6 +104,8 @@ class BatchIndexUpdater {
     } else {
       await _updateBatch();
     }
+    // no race here
+    return false;
   }
 
   Future _updateBatch() async {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -258,10 +258,35 @@ class LastNTracker<T extends Comparable<T>> {
     });
   }
 
+  double get average {
+    if (_lastItems.isEmpty) return 0.0;
+    final double sum = _lastItems
+        .where((item) => item is num)
+        .fold(0.0, (a, b) => a + (b as num));
+    return sum / _lastItems.length;
+  }
+
   T _getP(double p) {
     if (_lastItems.isEmpty) return null;
     final List<T> list = new List.from(_lastItems);
     list.sort();
     return list[(list.length * p).floor()];
   }
+}
+
+String formatDuration(Duration d) {
+  final List<String> parts = [];
+  int minutes = d.inMinutes;
+  if (minutes == 0) return '0 mins';
+
+  int hours = minutes ~/ 60;
+  minutes = minutes % 60;
+  final int days = hours ~/ 24;
+  hours = hours % 24;
+
+  if (days > 0) parts.add('$days days');
+  if (hours > 0) parts.add('$hours hours');
+  if (minutes > 0) parts.add('$minutes mins');
+
+  return parts.join(' ');
 }

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -161,13 +161,14 @@ class MockAnalysisBackend implements AnalysisBackend {
   }
 
   @override
-  Future storeAnalysis(Analysis analysis) async {
+  Future<bool> storeAnalysis(Analysis analysis) async {
     final String key = [
       analysis.packageName,
       analysis.packageVersion,
       analysis.analysis,
     ].join('/');
     _map[key] = analysis;
+    return false;
   }
 
   @override


### PR DESCRIPTION
Example output:

```
  "scheduler": {
    "pending": 23791,
    "status": {
      "skip": 325,
      "normal": 166,
      "race": 9
    },
    "taskPerHour": 279.7442418608048,
    "remaining": "1 days 1 hours 6 mins"
  }
```

There are a couple of caveats:
- Each isolate sends its stats to the main isolate, if there are more than one, only one of them will be reported.
- Metrics and estimates are far from exact, and if you hit the main host's `/debug` URL, you will see different numbers.