### PR TITLE
Increase randomization, reduce race a lot.

### DIFF
--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -218,7 +218,7 @@ List<String> exampleFileCandidates(String package) => [
 Stream<T> randomizeStream<T>(
   Stream<T> stream, {
   Duration duration: const Duration(minutes: 1),
-  int maxPositionDiff: 100,
+  int maxPositionDiff: 1000,
   Random random,
 }) {
   random ??= new Random.secure();


### PR DESCRIPTION
- The original measurement was roughly 10% race (with 5 concurrent analyzer instance).
- Doubling that reduced the race to roughly 5%
- This should make it around 1%.