### PR TITLE
Use analyzed data in search ranking

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -423,13 +423,8 @@ Future<shelf.Response> packageVersionHandlerHtml(
       final Stopwatch serviceSw = new Stopwatch()..start();
       final AnalysisData analysisData = await analyzerClient.getAnalysisData(
           selectedVersion.package, selectedVersion.version);
-      analysisView = (analysisData != null &&
-              analysisData.analysisStatus != AnalysisStatus.aborted)
-          ? new AnalysisView(analysisData)
-          : null;
-      analysisTabContent = analysisView == null
-          ? null
-          : templateService.renderAnalysisTab(analysisView);
+      analysisView = new AnalysisView(analysisData);
+      analysisTabContent = templateService.renderAnalysisTab(analysisView);
       _packageAnalysisLatencyTracker.add(serviceSw.elapsed);
     }
 

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -116,7 +116,7 @@ class TemplateService {
 
   /// Renders the `views/pkg/analysis_tab.mustache` template.
   String renderAnalysisTab(AnalysisView analysis) {
-    if (analysis == null) return null;
+    if (analysis == null || !analysis.hasAnalysisData) return null;
 
     String statusText;
     switch (analysis.analysisStatus) {

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -12,6 +12,7 @@ import 'package:gcloud/storage.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 
 import '../frontend/models.dart';
+import '../shared/analyzer_client.dart';
 import '../shared/mock_scores.dart';
 import '../shared/search_service.dart';
 
@@ -66,6 +67,9 @@ class SearchBackend {
       final PackageVersion pv = versions[p.name];
       if (pv == null) continue;
 
+      final analysisView = new AnalysisView(
+          await analyzerClient.getAnalysisData(pv.package, pv.version));
+
       results[i] = new PackageDocument(
         url: _toUrl(pv.package),
         package: pv.package,
@@ -75,6 +79,7 @@ class SearchBackend {
         description: compactDescription(pv.pubspec.description),
         lastUpdated: pv.shortCreated,
         readme: compactReadme(pv.readmeContent),
+        health: analysisView.health,
         popularity: mockScores[pv.package] ?? 0.0,
       );
     }

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:http/http.dart' as http;
@@ -53,8 +54,28 @@ class AnalysisView {
   final AnalysisData _data;
   final Summary _summary;
 
-  AnalysisView(this._data)
-      : _summary = new Summary.fromJson(_data.analysisContent);
+  AnalysisView._(this._data, this._summary);
+
+  factory AnalysisView(AnalysisData data) {
+    Summary summary;
+    try {
+      if (data != null &&
+          data.analysisStatus != AnalysisStatus.aborted &&
+          data.analysisContent != null) {
+        summary = new Summary.fromJson(data.analysisContent);
+      }
+    } catch (e, st) {
+      // don't block on faulty serialization
+      _logger.warning(
+          'Unable to read analysis content for package: '
+          '${data.packageName} ${data.packageVersion}',
+          e,
+          st);
+    }
+    return new AnalysisView._(data, summary);
+  }
+
+  bool get hasAnalysisData => _summary != null;
 
   DateTime get timestamp => _data.timestamp;
   AnalysisStatus get analysisStatus => _data.analysisStatus;
@@ -72,5 +93,49 @@ class AnalysisView {
     list.remove(_summary.packageName);
     list.sort();
     return list;
+  }
+
+  /// Returns the raw health score between -1.0 and 1.0
+  /// These need to be normalized for search and frontend purposes.
+  /// TODO: backport to pana (https://github.com/dart-lang/pana/issues/64)
+  double get health {
+    if (_data == null) return 0.0; // missing analysis
+    if (!hasAnalysisData) return -1.0; // aborted analysis
+
+    // Starting out with max.
+    double score = 1.0;
+
+    // Penalty for each major issue, like unable to run `pub`, `dartfmt` or
+    // `dartanalyzer`.
+    if (_summary.issues != null && _summary.issues.isNotEmpty) {
+      score -= _summary.issues.length * 0.2;
+    }
+
+    // Larger packages with longer files will likely get more penalty, because
+    // we don't take file count or file sizes into account. Both ignoring and
+    // normalizing on these metrics makes sense. TODO: decide which to use.
+    if (_summary.dartFiles != null) {
+      for (DartFileSummary dfs in _summary.dartFiles.values) {
+        // Penalties applied only on files inside the library.
+        if (!dfs.isInLib) continue;
+
+        // Penalty for bad formatting.
+        if (!dfs.isFormatted != true) {
+          score -= 0.001;
+        }
+
+        // Penalty for analyzer errors/warnings.
+        if (dfs.analyzerItems != null) {
+          score -= dfs.analyzerItems.length * 0.01;
+        }
+
+        // Penalty for conflicting platform information.
+        if (dfs.platform != null && dfs.platform.hasConflict) {
+          score -= 0.1;
+        }
+      }
+    }
+
+    return max(-1.0, min(1.0, score));
   }
 }

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -36,6 +36,8 @@ class PackageDocument {
   final String readme;
 
   final List<String> detectedTypes;
+
+  final double health;
   final double popularity;
 
   PackageDocument({
@@ -47,6 +49,7 @@ class PackageDocument {
     this.lastUpdated,
     this.readme,
     this.detectedTypes,
+    this.health,
     this.popularity,
   });
 
@@ -59,6 +62,7 @@ class PackageDocument {
         lastUpdated: json['lastUpdated'],
         readme: json['readme'],
         detectedTypes: json['detectedTypes'],
+        health: json['health'] ?? 0.0,
         popularity: json['popularity'],
       );
 
@@ -71,6 +75,7 @@ class PackageDocument {
         'lastUpdated': lastUpdated,
         'readme': readme,
         'detectedTypes': detectedTypes,
+        'health': health,
         'popularity': popularity,
       };
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -274,10 +274,16 @@ void main() {
 
 class MockAnalysisView implements AnalysisView {
   @override
+  bool hasAnalysisData = true;
+
+  @override
   AnalysisStatus analysisStatus;
 
   @override
   List<String> getDependencies() => throw 'Not implemented';
+
+  @override
+  double health;
 
   @override
   String licenseText;

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -70,7 +70,7 @@ void main() {
               'package': 'pkg_foo',
               'version': '1.0.1',
               'devVersion': '1.0.1-dev',
-              'score': closeTo(80.6, 0.1),
+              'score': closeTo(75.6, 0.1),
             }
           ],
         });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -103,6 +103,7 @@ void main() {
           This package contains a set of high-level functions and classes that make it easy to consume HTTP resources. It's platform-independent, and can be used on both the command-line and the browser. Currently the global utility functions are unsupported on the browser; see "Using on the Browser" below.''',
         lastUpdated: 'Jul 20, 2017',
         popularity: 0.7,
+        health: 1.0,
       ));
       await index.add(new PackageDocument(
         url: 'uri://async',
@@ -119,6 +120,7 @@ The CancelableOperation class defines an operation that can be canceled by its c
 The delegating wrapper classes allow users to easily add functionality on top of existing instances of core types from dart:async. These include DelegatingFuture, DelegatingStream, DelegatingStreamSubscription, DelegatingStreamConsumer, DelegatingSink, DelegatingEventSink, and DelegatingStreamSink.''',
         lastUpdated: 'May 17, 2017',
         popularity: 0.8,
+        health: 1.0,
       ));
       await index.add(new PackageDocument(
         url: 'uri://chrome_net',
@@ -131,8 +133,31 @@ tcp.dart contains abstractions over chrome.sockets to aid in working with TCP cl
 server.dart adds a small, prescriptive server (PicoServer) that can be configured with different handlers for HTTP requests.''',
         lastUpdated: 'Sep 17, 2014',
         popularity: 0.0,
+        health: 0.5,
       ));
       await index.merge();
+    });
+
+    test('normalized health scores', () {
+      expect(
+          index.getHealthScore(
+              ['uri://http', 'uri://async', 'uri://chrome_net']),
+          {
+            'uri://http': 100.0,
+            'uri://async': 100.0,
+            'uri://chrome_net': 0.0,
+          });
+    });
+
+    test('popularity scores', () {
+      expect(
+          index.getPopularityScore(
+              ['uri://http', 'uri://async', 'uri://chrome_net']),
+          {
+            'uri://http': 70.0,
+            'uri://async': 80.0,
+            'uri://chrome_net': 0.0,
+          });
     });
 
     test('package name match: async', () async {
@@ -154,7 +179,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'http',
             'version': '0.11.3+14',
             'devVersion': '0.11.3+14',
-            'score': closeTo(3.5116, 0.0001),
+            'score': closeTo(8.5115, 0.0001),
           },
         ]
       });
@@ -172,14 +197,14 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'http',
             'version': '0.11.3+14',
             'devVersion': '0.11.3+14',
-            'score': closeTo(7.4149, 0.0001),
+            'score': closeTo(12.41463, 0.0001),
           },
           {
             'url': 'uri://async',
             'package': 'async',
             'version': '1.13.3',
             'devVersion': '1.13.3',
-            'score': closeTo(4.0258, 0.0001),
+            'score': closeTo(9.0247, 0.0001),
           },
         ]
       });
@@ -197,21 +222,21 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
             'package': 'chrome_net',
             'version': '0.1.0',
             'devVersion': '0.1.0',
-            'score': closeTo(33.5032, 0.0001),
+            'score': closeTo(31.4848, 0.0001),
           },
           {
             'url': 'uri://async',
             'package': 'async',
             'version': '1.13.3',
             'devVersion': '1.13.3',
-            'score': closeTo(4.0155, 0.0001),
+            'score': closeTo(9.0149, 0.0001),
           },
           {
             'url': 'uri://http',
             'package': 'http',
             'version': '0.11.3+14',
             'devVersion': '0.11.3+14',
-            'score': closeTo(3.5291, 0.0001),
+            'score': closeTo(8.5279, 0.0001),
           },
         ]
       });


### PR DESCRIPTION
-  Package health is 5% of the total score.
- Using bezier scoring for both popularity and health.

This is the first step of the chicken-and-egg problem of using bezier (relative) scores for package health (where you need to have some synchronization and get to know all the scores). The search index needs all the raw numbers to calculate the relative score, so it will fetch it from analyzer, and stores it in the snapshot.

Later on either the frontend or the analyzer will need to know about the score of a particular package, so most likely they will turn to the search index for the calculation.
