### PR TITLE
Display license information without experimental flag

### DIFF
--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -14,6 +14,7 @@ import 'package:pub_dartlang_org/frontend/handlers_redirects.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
+import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';
@@ -94,6 +95,7 @@ void main() {
           return Uri.parse('http://blobstore/$package/$version');
         });
         registerBackend(backend);
+        registerAnalyzerClient(new AnalyzerClientMock());
         await expectHtmlResponse(await issueGet('/packages/foobar_pkg'));
       });
 

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -207,3 +207,14 @@ class SearchServiceMock implements SearchService {
   @override
   Future close() async => null;
 }
+
+class AnalyzerClientMock implements AnalyzerClient {
+  AnalysisData mockAnalysisData;
+
+  @override
+  Future<AnalysisData> getAnalysisData(String package, String version) async =>
+      mockAnalysisData;
+
+  @override
+  Future close() async => null;
+}


### PR DESCRIPTION
I'm hoping that we'll get reassuring latency numbers after this change gets live, as we'll do a lot of analyzer lookup, and also collect their latencies.

- The 'analysis tab' remains behind experimental flag.
- The memcache behavior is the same: the analysis tab is not cached, otherwise the page gets cached.
