### PR TITLE
Reduce backend load of re-indexing fresh data

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -77,7 +77,7 @@ class SearchBackend {
           await analyzerClient.getAnalysisData(pv.package, pv.version));
 
       results[i] = new PackageDocument(
-        url: _toUrl(pv.package),
+        url: pubUrlOfPackage(pv.package),
         package: pv.package,
         version: p.latestVersion,
         devVersion: p.latestDevVersion,
@@ -87,13 +87,12 @@ class SearchBackend {
         readme: compactReadme(pv.readmeContent),
         health: analysisView.health,
         popularity: mockScores[pv.package] ?? 0.0,
+        timestamp: new DateTime.now().toUtc(),
       );
     }
     return results;
   }
 }
-
-String _toUrl(String package) => 'https://pub.dartlang.org/packages/$package';
 
 class SnapshotStorage {
   final Storage storage;

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -33,6 +33,21 @@ class SimplePackageIndex implements PackageIndex {
   bool get isReady => _isReady;
 
   @override
+  Future<bool> containsPackage(String package,
+      {String version, Duration maxAge}) async {
+    final String url = pubUrlOfPackage(package);
+    final PackageDocument doc = _documents[url];
+    if (doc == null) return false;
+    if (version != null && doc.version != version) return false;
+    if (maxAge != null &&
+        (doc.timestamp == null ||
+            new DateTime.now().toUtc().difference(doc.timestamp) > maxAge)) {
+      return false;
+    }
+    return true;
+  }
+
+  @override
   Future add(PackageDocument doc) async {
     await removeUrl(doc.url);
     _documents[doc.url] = doc;

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -21,6 +21,8 @@ const String searchIndexNotReadyText = 'Not ready yet.';
 /// Package search index and lookup.
 abstract class PackageIndex {
   bool get isReady;
+  Future<bool> containsPackage(String package,
+      {String version, Duration maxAge});
   Future add(PackageDocument doc);
   Future addAll(Iterable<PackageDocument> documents);
   Future removeUrl(String url);
@@ -48,6 +50,9 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
   final double health;
   final double popularity;
 
+  /// The creation timestamp of this document.
+  final DateTime timestamp;
+
   PackageDocument({
     this.url,
     this.package,
@@ -59,6 +64,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
     this.detectedTypes,
     this.health,
     this.popularity,
+    this.timestamp,
   });
 
   factory PackageDocument.fromJson(Map<String, dynamic> json) =>
@@ -152,3 +158,6 @@ class PackageScore extends Object with _$PackageScoreSerializerMixin {
   factory PackageScore.fromJson(Map<String, dynamic> json) =>
       _$PackageScoreFromJson(json);
 }
+
+String pubUrlOfPackage(String package) =>
+    'https://pub.dartlang.org/packages/$package';

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -18,7 +18,10 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
         detectedTypes:
             (json['detectedTypes'] as List)?.map((e) => e as String)?.toList(),
         health: (json['health'] as num)?.toDouble(),
-        popularity: (json['popularity'] as num)?.toDouble());
+        popularity: (json['popularity'] as num)?.toDouble(),
+        timestamp: json['timestamp'] == null
+            ? null
+            : DateTime.parse(json['timestamp'] as String));
 
 abstract class _$PackageDocumentSerializerMixin {
   String get url;
@@ -31,6 +34,7 @@ abstract class _$PackageDocumentSerializerMixin {
   List<String> get detectedTypes;
   double get health;
   double get popularity;
+  DateTime get timestamp;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'url': url,
         'package': package,
@@ -41,7 +45,8 @@ abstract class _$PackageDocumentSerializerMixin {
         'readme': readme,
         'detectedTypes': detectedTypes,
         'health': health,
-        'popularity': popularity
+        'popularity': popularity,
+        'timestamp': timestamp?.toIso8601String()
       };
 }
 


### PR DESCRIPTION
Since search is using `analyzer`, it is no longer super-cheap to re-index packages, better to restrict too frequent updates.