### PR TITLE
Index package dependencies and trigger re-analysis of packages

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -221,6 +221,12 @@ class AnalysisBackend {
       }
     }
   }
+
+  Future<String> getLatestStableVersion(String package) async {
+    final Package p =
+        (await db.lookup([db.emptyKey.append(Package, id: package)])).single;
+    return p?.latestVersion ?? p?.latestDevVersion;
+  }
 }
 
 class BackendAnalysisStatus {

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -81,10 +81,11 @@ class SearchBackend {
         package: pv.package,
         version: p.latestVersion,
         devVersion: p.latestDevVersion,
-        detectedTypes: pv.detectedTypes,
         description: compactDescription(pv.pubspec.description),
         lastUpdated: pv.shortCreated,
         readme: compactReadme(pv.readmeContent),
+        detectedTypes: pv.detectedTypes,
+        transitiveDeps: analysisView.getDependencies(),
         health: analysisView.health,
         popularity: mockScores[pv.package] ?? 0.0,
       );

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -25,6 +25,8 @@ Future<shelf.Response> searchServiceHandler(shelf.Request request) async {
     return handler(request);
   } else if (path.startsWith('/packages/')) {
     return packageHandler(request);
+  } else if (path.startsWith('/dependees/')) {
+    return dependeesHandler(request);
   } else {
     return notFoundHandler(request);
   }
@@ -49,6 +51,22 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
   final PackageSearchResult result = await packageIndex.search(
       new PackageQuery.fromServiceQueryParameters(request.url.queryParameters));
   return jsonResponse(result.toJson(), indent: indent);
+}
+
+/// Handles /dependees requests.
+Future<shelf.Response> dependeesHandler(shelf.Request request) async {
+  if (!packageIndex.isReady) {
+    return htmlResponse(searchIndexNotReadyText,
+        status: searchIndexNotReadyCode);
+  }
+  final String path = request.requestedUri.path.substring('/dependees/'.length);
+  final String packageName = path;
+  final bool indent = request.url.queryParameters['indent'] == 'true';
+
+  final packages = await packageIndex.listDependeePackages(packageName);
+  return jsonResponse({
+    'packages': packages,
+  }, indent: indent);
 }
 
 /// Handles requests for:

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -141,6 +141,17 @@ class SimplePackageIndex implements PackageIndex {
   }
 
   @override
+  Future<List<String>> listDependeePackages(String package) async {
+    final List<String> list = _documents.values
+        .where((pd) =>
+            pd.transitiveDeps != null && pd.transitiveDeps.contains(package))
+        .map((pd) => pd.package)
+        .toList();
+    list.sort();
+    return list;
+  }
+
+  @override
   Future merge() async {
     _isReady = true;
     _lastUpdated = new DateTime.now().toUtc();

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -91,7 +91,9 @@ class AnalysisView {
   }
 
   List<String> getDependencies() {
-    final List<String> list = _summary.pubSummary.packageVersions.keys.toList();
+    final packageVersions = _summary?.pubSummary?.packageVersions;
+    if (packageVersions == null) return null;
+    final List<String> list = packageVersions.keys.toList();
     list.remove(_summary.packageName);
     list.sort();
     return list;

--- a/app/lib/shared/search_client.dart
+++ b/app/lib/shared/search_client.dart
@@ -51,6 +51,20 @@ class SearchClient {
     return result;
   }
 
+  /// List packages that have [package] as their transitive dependency.
+  Future<List<String>> listDependeePackages(String package) async {
+    final String httpHostPort = activeConfiguration.searchServicePrefix;
+    final String serviceUrl = '$httpHostPort/dependees/$package';
+    final http.Response response = await _httpClient.get(serviceUrl);
+    if (response.statusCode != 200) {
+      // There has been an issue with the service
+      throw new Exception(
+          'Service call on /dependees/ returned status code ${response.statusCode}');
+    }
+    final Map result = JSON.decode(response.body);
+    return result['packages'];
+  }
+
   Future close() async {
     _httpClient.close();
   }

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -26,6 +26,8 @@ abstract class PackageIndex {
   Future removeUrl(String url);
   Future merge();
   Future<PackageSearchResult> search(PackageQuery query);
+  /// List packages that have [package] as their transitive dependency.
+  Future<List<String>> listDependeePackages(String package);
 }
 
 /// A summary information about a package that goes into the search index.
@@ -44,6 +46,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
   final String readme;
 
   final List<String> detectedTypes;
+  final List<String> transitiveDeps;
 
   final double health;
   final double popularity;
@@ -57,6 +60,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
     this.lastUpdated,
     this.readme,
     this.detectedTypes,
+    this.transitiveDeps,
     this.health,
     this.popularity,
   });

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -171,6 +171,11 @@ class MockAnalysisBackend implements AnalysisBackend {
   Future deleteObsoleteAnalysisEntries() {
     throw 'Not implemented yet.';
   }
+
+  @override
+  Future<String> getLatestStableVersion(String package) {
+    throw 'Not implemented yet.';
+  }
 }
 
 final Analysis testAnalysis = new Analysis()

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -130,6 +130,22 @@ void main() {
       });
     });
   });
+
+  group('lookups', () {
+    Future setUpInServiceScope() async {
+      registerSearchBackend(new MockSearchBackend());
+      registerPackageIndex(new SimplePackageIndex());
+      await packageIndex.addAll(await searchBackend.loadDocuments(['pkg_foo']));
+      await packageIndex.merge();
+    }
+
+    scopedTest('dependees lookup', () async {
+      await setUpInServiceScope();
+      expectJsonResponse(await issueGet('/dependees/http'), body: {
+        'packages': ['pkg_foo'],
+      });
+    });
+  });
 }
 
 class MockSearchBackend implements SearchBackend {
@@ -146,6 +162,7 @@ class MockSearchBackend implements SearchBackend {
         detectedTypes: ['browser'],
         description: 'Foo package about nothing really. Maybe JSON.',
         readme: 'Some JSON to XML mapping.',
+        transitiveDeps: ['async', 'http', 'json', 'xml'],
         popularity: 0.1,
       );
     }).toList();

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -102,6 +102,7 @@ void main() {
           A composable, Future-based library for making HTTP requests.
           This package contains a set of high-level functions and classes that make it easy to consume HTTP resources. It's platform-independent, and can be used on both the command-line and the browser. Currently the global utility functions are unsupported on the browser; see "Using on the Browser" below.''',
         lastUpdated: 'Jul 20, 2017',
+        transitiveDeps: ['async', 'path'],
         popularity: 0.7,
         health: 1.0,
       ));
@@ -258,6 +259,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           },
         ]
       });
+    });
+
+    test('list transitive dependees', () async {
+      expect(await index.listDependeePackages('unknown'), []);
+      expect(await index.listDependeePackages('async'), ['http']);
     });
   });
 }


### PR DESCRIPTION
The name `dependee` and the REST URL for it is a bit weird for me, but I couldn't come up with a better name - suggestions welcome :)

In an early version I've cached the dependees, but it is cheap to re-compute and we don't need to maintain another cache invalidation there.