### PR TITLE
Index and search the analysis's platform instead of the pubspec detectedType

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -14,6 +14,7 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/analyzer_client.dart';
 import '../shared/handlers.dart';
+import '../shared/platform.dart';
 import '../shared/search_service.dart' show maxSearchResults;
 import '../shared/utils.dart';
 
@@ -174,7 +175,7 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
     queryText,
     offset: PageLinks.RESULTS_PER_PAGE * (page - 1),
     limit: PageLinks.RESULTS_PER_PAGE,
-    type: request.url.queryParameters['type'],
+    platformPredicate: new PlatformPredicate.fromUri(request.url),
     packagePrefix: packagePrefix,
     bias: expBias,
   );

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -14,6 +14,7 @@ import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:logging/logging.dart';
 import 'package:http/http.dart' as http;
 
+import '../shared/platform.dart';
 import '../shared/search_client.dart';
 import '../shared/search_service.dart';
 
@@ -46,7 +47,7 @@ class SearchService {
     try {
       final PackageQuery packageQuery = new PackageQuery(
         query.text,
-        type: query.type,
+        platformPredicate: query.platformPredicate,
         packagePrefix: query.packagePrefix,
         offset: query.offset,
         limit: query.limit,
@@ -114,8 +115,8 @@ class SearchQuery {
   /// The maximum number of items queried when search.
   final int limit;
 
-  /// Filter the results for this type.
-  final String type;
+  /// Filter the results for this platform.
+  final PlatformPredicate platformPredicate;
 
   /// Filter the results for this package prefix phrase.
   final String packagePrefix;
@@ -127,7 +128,7 @@ class SearchQuery {
     this.text, {
     this.offset: 0,
     this.limit: 10,
-    this.type,
+    this.platformPredicate,
     this.packagePrefix,
     this.bias,
   });
@@ -135,7 +136,6 @@ class SearchQuery {
   /// Whether the query object can be used for running a search using the custom
   /// search api.
   bool get isValid {
-    if (type != null && !BuiltinTypes.isKnownType(type)) return false;
     if ((text == null || text.isEmpty) &&
         (packagePrefix == null || packagePrefix.isEmpty)) return false;
     return true;

--- a/app/lib/frontend/search_service_cse.dart
+++ b/app/lib/frontend/search_service_cse.dart
@@ -84,11 +84,11 @@ String buildCseQueryText(SearchQuery query) {
   if (query.packagePrefix != null) {
     queryText += ' ${query.packagePrefix}';
   }
-  if (query.type != null && query.type.isNotEmpty) {
+  query.platformPredicate?.required?.forEach((String platform) {
     // Corresponds with the <PageMap> entry in views/layout.mustache.
     queryText +=
-        ' more:pagemap:${CseTokens.pageMapDocument}-${CseTokens.detectedType(query.type)}:1';
-  }
+        ' more:pagemap:${CseTokens.pageMapDocument}-${CseTokens.detectedType(platform)}:1';
+  });
   return queryText;
 }
 

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -634,8 +634,8 @@ class SearchLinks extends PageLinks {
       'q': query.text,
       'page': page.toString(),
     };
-    if (query.type != null) {
-      params['type'] = query.type;
+    if (query.platformPredicate != null && query.platformPredicate.isNotEmpty) {
+      params['platforms'] = query.platformPredicate.toQueryParamValue();
     }
     return new Uri(path: '/search', queryParameters: params).toString();
   }

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -18,6 +18,7 @@ import 'package:json_serializable/annotations.dart';
 import '../frontend/models.dart';
 import '../shared/analyzer_client.dart';
 import '../shared/mock_scores.dart';
+import '../shared/platform.dart';
 import '../shared/search_service.dart';
 
 import 'text_utils.dart';
@@ -89,7 +90,7 @@ class SearchBackend {
         package: pv.package,
         version: p.latestVersion,
         devVersion: p.latestDevVersion,
-        detectedTypes: pv.detectedTypes,
+        platforms: indexDartPlatform(analysisView.platform),
         description: compactDescription(pv.pubspec.description),
         lastUpdated: pv.shortCreated,
         readme: compactReadme(pv.readmeContent),

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -46,8 +46,8 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
         status: searchIndexNotReadyCode);
   }
   final bool indent = request.url.queryParameters['indent'] == 'true';
-  final PackageSearchResult result = await packageIndex.search(
-      new PackageQuery.fromServiceQueryParameters(request.url.queryParameters));
+  final PackageSearchResult result =
+      await packageIndex.search(new PackageQuery.fromServiceUrl(request.url));
   return jsonResponse(result.toJson(), indent: indent);
 }
 

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -102,10 +102,9 @@ class SimplePackageIndex implements PackageIndex {
     for (String url in total.keys) {
       final PackageDocument doc = _documents[url];
 
-      // filter on type
-      if (query.type != null &&
-          (doc.detectedTypes == null ||
-              !doc.detectedTypes.contains(query.type))) {
+      // filter on platform
+      if (query.platformPredicate != null &&
+          !query.platformPredicate.matches(doc.platforms)) {
         continue;
       }
 

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -82,6 +82,8 @@ class AnalysisView {
   DateTime get timestamp => _data.timestamp;
   AnalysisStatus get analysisStatus => _data.analysisStatus;
 
+  DartPlatform get platform => _summary?.platform;
+
   String get licenseText {
     final String text = _summary?.license?.toString();
     if (text == LicenseNames.unknown || text == LicenseNames.missing) {

--- a/app/lib/shared/platform.dart
+++ b/app/lib/shared/platform.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/pana.dart';
+
+abstract class KnownPlatforms {
+  static const String flutter = PlatformNames.flutter;
+  static const String server = PlatformNames.server;
+  static const String web = PlatformNames.web;
+  static const List<String> all = const [flutter, server, web];
+
+  static bool isKnownPlatform(String platform) => all.contains(platform);
+}
+
+List<String> indexDartPlatform(DartPlatform platform) {
+  if (platform == null) {
+    return null;
+  }
+  if (platform.worksEverywhere) {
+    return KnownPlatforms.all;
+  }
+  if (platform.restrictedTo == null || platform.restrictedTo.isEmpty) {
+    return null;
+  }
+  return new List.from(platform.restrictedTo);
+}
+
+class PlatformPredicate {
+  final List<String> required;
+  final List<String> prohibited;
+
+  PlatformPredicate._(this.required, this.prohibited);
+
+  factory PlatformPredicate({List<String> required, List<String> prohibited}) {
+    List<String> reduce(List<String> platforms) {
+      final List<String> list = platforms
+          ?.where((p) => p != null && p.isNotEmpty)
+          ?.where(KnownPlatforms.isKnownPlatform)
+          ?.toList();
+      return (list != null && list.isNotEmpty) ? list : null;
+    }
+
+    return new PlatformPredicate._(reduce(required), reduce(prohibited));
+  }
+
+  factory PlatformPredicate.fromUri(Uri uri) {
+    final String pluralStr = uri.queryParameters['platforms'];
+    List<String> platforms;
+    if (pluralStr != null && pluralStr.isNotEmpty) {
+      platforms = pluralStr.split(',');
+    } else {
+      platforms = uri.queryParametersAll['platform'];
+    }
+    final List<String> required = <String>[];
+    final List<String> prohibited = <String>[];
+    platforms?.forEach((String p) {
+      if (p.startsWith('-') || p.startsWith('!')) {
+        prohibited.add(p.substring(1).trim());
+      } else {
+        required.add(p.trim());
+      }
+    });
+    return new PlatformPredicate(required: required, prohibited: prohibited);
+  }
+
+  bool get isNotEmpty => required != null || prohibited != null;
+
+  bool matches(List<String> platforms) {
+    if (required != null) {
+      if (platforms == null || platforms.isEmpty) return false;
+      if (required.any((p) => !platforms.contains(p))) return false;
+    }
+    if (prohibited != null &&
+        platforms != null &&
+        prohibited.any(platforms.contains)) {
+      return false;
+    }
+    return true;
+  }
+
+  String toQueryParamValue() {
+    final List<String> parts = <String>[];
+    required?.forEach(parts.add);
+    prohibited?.forEach((p) => parts.add('!$p'));
+    final String value = parts.join(',');
+    return value.isEmpty ? null : value;
+  }
+}

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -15,8 +15,8 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
         description: json['description'] as String,
         lastUpdated: json['lastUpdated'] as String,
         readme: json['readme'] as String,
-        detectedTypes:
-            (json['detectedTypes'] as List)?.map((e) => e as String)?.toList(),
+        platforms:
+            (json['platforms'] as List)?.map((e) => e as String)?.toList(),
         health: (json['health'] as num)?.toDouble(),
         popularity: (json['popularity'] as num)?.toDouble(),
         timestamp: json['timestamp'] == null
@@ -31,7 +31,7 @@ abstract class _$PackageDocumentSerializerMixin {
   String get description;
   String get lastUpdated;
   String get readme;
-  List<String> get detectedTypes;
+  List<String> get platforms;
   double get health;
   double get popularity;
   DateTime get timestamp;
@@ -43,7 +43,7 @@ abstract class _$PackageDocumentSerializerMixin {
         'description': description,
         'lastUpdated': lastUpdated,
         'readme': readme,
-        'detectedTypes': detectedTypes,
+        'platforms': platforms,
         'health': health,
         'popularity': popularity,
         'timestamp': timestamp?.toIso8601String()

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -6,9 +6,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:html/parser.dart';
+import 'package:pana/src/platform.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart'
     show
@@ -240,9 +242,10 @@ void main() {
       var query = new SearchQuery('web framework');
       expect(buildCseQueryText(query), 'web framework');
 
-      query = new SearchQuery('web framework', type: 'pkg_type');
+      query = new SearchQuery('web framework',
+          platformPredicate: new PlatformPredicate(required: ['server']));
       expect(buildCseQueryText(query),
-          'web framework more:pagemap:document-dt_pkg_type:1');
+          'web framework more:pagemap:document-dt_server:1');
     });
 
     test('CSE sort parameter', () {
@@ -262,12 +265,13 @@ void main() {
     });
 
     test('SearchLinks with type', () {
-      final query = new SearchQuery('web framework', type: 'pkg_type');
+      final query = new SearchQuery('web framework',
+          platformPredicate: new PlatformPredicate(required: ['server']));
       final SearchLinks links = new SearchLinks(query, 100);
-      expect(
-          links.formatHref(1), '/search?q=web+framework&page=1&type=pkg_type');
-      expect(
-          links.formatHref(2), '/search?q=web+framework&page=2&type=pkg_type');
+      expect(links.formatHref(1),
+          '/search?q=web+framework&page=1&platforms=server');
+      expect(links.formatHref(2),
+          '/search?q=web+framework&page=2&platforms=server');
     });
   });
 }
@@ -290,4 +294,7 @@ class MockAnalysisView implements AnalysisView {
 
   @override
   DateTime timestamp;
+
+  @override
+  DartPlatform get platform => null;
 }

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -143,7 +143,7 @@ class MockSearchBackend implements SearchBackend {
         package: package,
         version: '1.0.1',
         devVersion: '1.0.1-dev',
-        detectedTypes: ['browser'],
+        platforms: ['server', 'web'],
         description: 'Foo package about nothing really. Maybe JSON.',
         readme: 'Some JSON to XML mapping.',
         popularity: 0.1,


### PR DESCRIPTION
Both the frontend and the search service supports the notation for "package must run on X and must not run on Y":
- `?platform=X&platform=!Y` (for form-submissions)
- `?platforms=X,!Y` (for simplified URL where multiple values are not supported)

This will allow us to distinguish between the following cases:
- `?platforms=flutter`: show me packages that I can use on flutter
- `?platforms=flutter,web`: show me packages that I can use both on flutter and on the web
- `?platforms=flutter,!server,!web`: show me the packages that are flutter-only
- `?platforms=!flutter,!server,!web`: show me the packages that have platform conflicts