### PR TITLE
Remove SearchBias and merge the two search query class

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -15,7 +15,7 @@ import 'package:shelf/shelf.dart' as shelf;
 import '../shared/analyzer_client.dart';
 import '../shared/handlers.dart';
 import '../shared/platform.dart';
-import '../shared/search_service.dart' show maxSearchResults;
+import '../shared/search_service.dart' show SearchQuery, maxSearchResults;
 import '../shared/utils.dart';
 
 import 'atom_feed.dart';

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -168,8 +168,6 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
 
   final int page = _pageFromUrl(request.url,
       maxPages: maxSearchResults ~/ PageLinks.RESULTS_PER_PAGE);
-  final SearchBias expBias =
-      parseExperimentalBias(request.url.queryParameters['experimental-bias']);
 
   final SearchQuery query = new SearchQuery(
     queryText,
@@ -177,7 +175,6 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
     limit: PageLinks.RESULTS_PER_PAGE,
     platformPredicate: new PlatformPredicate.fromUri(request.url),
     packagePrefix: packagePrefix,
-    bias: expBias,
   );
   if (!query.isValid) {
     return htmlResponse(templateService.renderSearchPage(

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -14,7 +14,6 @@ import 'package:googleapis_auth/auth_io.dart' as auth;
 import 'package:logging/logging.dart';
 import 'package:http/http.dart' as http;
 
-import '../shared/platform.dart';
 import '../shared/search_client.dart';
 import '../shared/search_service.dart';
 
@@ -45,15 +44,7 @@ class SearchService {
   /// max [numResults].
   Future<SearchResultPage> search(SearchQuery query) async {
     try {
-      final PackageQuery packageQuery = new PackageQuery(
-        query.text,
-        platformPredicate: query.platformPredicate,
-        packagePrefix: query.packagePrefix,
-        offset: query.offset,
-        limit: query.limit,
-      );
-
-      final result = await searchClient.search(packageQuery).timeout(
+      final result = await searchClient.search(query).timeout(
         searchServiceTimeout,
         onTimeout: () async {
           _logger.warning('Search service exceeded timeout.');
@@ -102,39 +93,6 @@ Future<SearchResultPage> _loadResultForPackages(SearchQuery query,
         query, totalCount, versions, devVersions, backend);
   } else {
     return new SearchResultPage(query, 0, [], [], backend);
-  }
-}
-
-class SearchQuery {
-  /// The query string used for the search.
-  final String text;
-
-  /// The offset used for the search.
-  final int offset;
-
-  /// The maximum number of items queried when search.
-  final int limit;
-
-  /// Filter the results for this platform.
-  final PlatformPredicate platformPredicate;
-
-  /// Filter the results for this package prefix phrase.
-  final String packagePrefix;
-
-  SearchQuery(
-    this.text, {
-    this.offset: 0,
-    this.limit: 10,
-    this.platformPredicate,
-    this.packagePrefix,
-  });
-
-  /// Whether the query object can be used for running a search using the custom
-  /// search api.
-  bool get isValid {
-    if ((text == null || text.isEmpty) &&
-        (packagePrefix == null || packagePrefix.isEmpty)) return false;
-    return true;
   }
 }
 

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -121,16 +121,12 @@ class SearchQuery {
   /// Filter the results for this package prefix phrase.
   final String packagePrefix;
 
-  /// Bias responses and use score to adjust response order.
-  final SearchBias bias;
-
   SearchQuery(
     this.text, {
     this.offset: 0,
     this.limit: 10,
     this.platformPredicate,
     this.packagePrefix,
-    this.bias,
   });
 
   /// Whether the query object can be used for running a search using the custom

--- a/app/lib/frontend/search_service_cse.dart
+++ b/app/lib/frontend/search_service_cse.dart
@@ -49,8 +49,7 @@ class _GoogleCseClient {
     final search = await csearch.cse.list(buildCseQueryText(query),
         cx: _CUSTOM_SEARCH_ID,
         num: query.limit,
-        start: 1 + query.offset,
-        sort: buildCseSort(query.bias));
+        start: 1 + query.offset);
     if (search.items != null) {
       final List<String> packages = search.items
           .map((item) {
@@ -67,17 +66,6 @@ class _GoogleCseClient {
   }
 }
 
-// https://developers.google.com/custom-search/docs/structured_search#bias-by-attribute
-enum SearchBias { hard, strong, weak }
-
-SearchBias parseExperimentalBias(String value) {
-  if (value == null) return null;
-  if (value == 'hard') return SearchBias.hard;
-  if (value == 'strong') return SearchBias.strong;
-  if (value == 'weak') return SearchBias.weak;
-  return null;
-}
-
 /// Returns the query text to use in CSE.
 String buildCseQueryText(SearchQuery query) {
   String queryText = query.text;
@@ -90,25 +78,4 @@ String buildCseQueryText(SearchQuery query) {
         ' more:pagemap:${CseTokens.pageMapDocument}-${CseTokens.detectedType(platform)}:1';
   });
   return queryText;
-}
-
-/// Returns the sort attribute to use in CSE.
-/// https://developers.google.com/custom-search/docs/structured_search#bias-by-attribute
-String buildCseSort(SearchBias bias) {
-  if (bias != null) {
-    String suffix;
-    switch (bias) {
-      case SearchBias.hard:
-        suffix = 'h';
-        break;
-      case SearchBias.strong:
-        suffix = 's';
-        break;
-      case SearchBias.weak:
-        suffix = 'w';
-        break;
-    }
-    return '${CseTokens.pageMapDocument}-${CseTokens.experimentalScore}:d:$suffix';
-  }
-  return null;
 }

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -15,9 +15,10 @@ import 'package:mustache/mustache.dart' as mustache;
 import '../shared/analyzer_client.dart';
 import '../shared/markdown.dart';
 import '../shared/mock_scores.dart';
+import '../shared/search_service.dart' show SearchQuery;
 
 import 'models.dart';
-import 'search_service.dart' show CseTokens, SearchQuery, SearchResultPage;
+import 'search_service.dart' show CseTokens, SearchResultPage;
 
 final Logger _logger = new Logger('pub.templates');
 

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -47,7 +47,7 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
   }
   final bool indent = request.url.queryParameters['indent'] == 'true';
   final PackageSearchResult result =
-      await packageIndex.search(new PackageQuery.fromServiceUrl(request.url));
+      await packageIndex.search(new SearchQuery.fromServiceUrl(request.url));
   return jsonResponse(result.toJson(), indent: indent);
 }
 

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -75,7 +75,7 @@ class SimplePackageIndex implements PackageIndex {
   }
 
   @override
-  Future<PackageSearchResult> search(PackageQuery query) async {
+  Future<PackageSearchResult> search(SearchQuery query) async {
     final Map<String, double> total = <String, double>{};
     void addAll(Map<String, double> scores, double weight) {
       scores?.forEach((String url, double score) {

--- a/app/lib/shared/search_client.dart
+++ b/app/lib/shared/search_client.dart
@@ -27,7 +27,7 @@ class SearchClient {
   /// The HTTP client used for making calls to our search service.
   final http.Client _httpClient = new http.Client();
 
-  Future<PackageSearchResult> search(PackageQuery query) async {
+  Future<PackageSearchResult> search(SearchQuery query) async {
     final String httpHostPort = activeConfiguration.searchServicePrefix;
     final String serviceUrlParams =
         new Uri(queryParameters: query.toServiceQueryParameters()).toString();

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -29,7 +29,7 @@ abstract class PackageIndex {
   Future addAll(Iterable<PackageDocument> documents);
   Future removeUrl(String url);
   Future merge();
-  Future<PackageSearchResult> search(PackageQuery query);
+  Future<PackageSearchResult> search(SearchQuery query);
 }
 
 /// A summary information about a package that goes into the search index.
@@ -73,22 +73,22 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
       _$PackageDocumentFromJson(json);
 }
 
-class PackageQuery {
+class SearchQuery {
   final String text;
   final PlatformPredicate platformPredicate;
   final String packagePrefix;
   final int offset;
   final int limit;
 
-  PackageQuery(
+  SearchQuery(
     this.text, {
     this.platformPredicate,
     this.packagePrefix,
-    this.offset,
-    this.limit,
+    this.offset: 0,
+    this.limit: 10,
   });
 
-  factory PackageQuery.fromServiceUrl(Uri uri) {
+  factory SearchQuery.fromServiceUrl(Uri uri) {
     final String text = uri.queryParameters['q'];
     final platform = new PlatformPredicate.fromUri(uri);
     String type = uri.queryParameters['type'];
@@ -104,7 +104,7 @@ class PackageQuery {
     offset = max(0, offset);
     limit = max(minSearchLimit, limit);
 
-    return new PackageQuery(
+    return new SearchQuery(
       text,
       platformPredicate: platform,
       packagePrefix: packagePrefix,
@@ -124,6 +124,14 @@ class PackageQuery {
       map['pkg-prefix'] = packagePrefix;
     }
     return map;
+  }
+
+  /// Sanity check, whether the query object is to be expected a valid result.
+  bool get isValid {
+    final bool hasText = text != null && text.isNotEmpty;
+    final bool hasPackagePrefix =
+        packagePrefix != null && packagePrefix.isNotEmpty;
+    return hasText || hasPackagePrefix;
   }
 }
 

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -15,6 +15,7 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/search_service.dart';
 
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -15,6 +15,7 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/search_service.dart';
 
 Future<shelf.Response> issueGet(String path) async {
   final uri = 'https://pub.dartlang.org$path';

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -13,12 +13,7 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart'
-    show
-        SearchBias,
-        SearchQuery,
-        SearchResultPage,
-        buildCseQueryText,
-        buildCseSort;
+    show SearchQuery, SearchResultPage, buildCseQueryText;
 
 import 'utils.dart';
 
@@ -246,15 +241,6 @@ void main() {
           platformPredicate: new PlatformPredicate(required: ['server']));
       expect(buildCseQueryText(query),
           'web framework more:pagemap:document-dt_server:1');
-    });
-
-    test('CSE sort parameter', () {
-      var query = new SearchQuery('query');
-      expect(buildCseSort(query.bias), isNull);
-      query = new SearchQuery('query', bias: SearchBias.weak);
-      expect(buildCseSort(query.bias), 'document-exp_score:d:w');
-      query = new SearchQuery('query', bias: SearchBias.strong);
-      expect(buildCseSort(query.bias), 'document-exp_score:d:s');
     });
 
     test('SearchLinks defaults', () {

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -11,9 +11,10 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/shared/platform.dart';
+import 'package:pub_dartlang_org/shared/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart'
-    show SearchQuery, SearchResultPage, buildCseQueryText;
+    show SearchResultPage, buildCseQueryText;
 
 import 'utils.dart';
 

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -162,7 +162,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package name match: async', () async {
       final PackageSearchResult result =
-          await index.search(new PackageQuery('async'));
+          await index.search(new SearchQuery('async'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -187,7 +187,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('description match: composable', () async {
       final PackageSearchResult result =
-          await index.search(new PackageQuery('composable'));
+          await index.search(new SearchQuery('composable'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -212,7 +212,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('readme match: chrome.sockets', () async {
       final PackageSearchResult result =
-          await index.search(new PackageQuery('chrome.sockets'));
+          await index.search(new SearchQuery('chrome.sockets'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -244,7 +244,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package prefix: chrome', () async {
       final PackageSearchResult result =
-          await index.search(new PackageQuery('', packagePrefix: 'chrome'));
+          await index.search(new SearchQuery('', packagePrefix: 'chrome'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,


### PR DESCRIPTION
- `SearchBias` was used only for old search, no longer relevant (and fallback is non-existent as far as I know)
- without the bias, the two query classes are the same, merging them reduces clutter