### PR TITLE
Replace PackageDocument.lastUpdated (String) with updated (DateTime)

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -92,7 +92,7 @@ class SearchBackend {
         devVersion: p.latestDevVersion,
         platforms: indexDartPlatform(analysisView.platform),
         description: compactDescription(pv.pubspec.description),
-        lastUpdated: pv.shortCreated,
+        updated: pv.created,
         readme: compactReadme(pv.readmeContent),
         health: analysisView.health,
         popularity: mockScores[pv.package] ?? 0.0,

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -44,7 +44,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
   final String version;
   final String devVersion;
   final String description;
-  final String lastUpdated;
+  final DateTime updated;
   final String readme;
 
   final List<String> platforms;
@@ -61,7 +61,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
     this.version,
     this.devVersion,
     this.description,
-    this.lastUpdated,
+    this.updated,
     this.readme,
     this.platforms,
     this.health,

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -13,7 +13,9 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
         version: json['version'] as String,
         devVersion: json['devVersion'] as String,
         description: json['description'] as String,
-        lastUpdated: json['lastUpdated'] as String,
+        updated: json['updated'] == null
+            ? null
+            : DateTime.parse(json['updated'] as String),
         readme: json['readme'] as String,
         platforms:
             (json['platforms'] as List)?.map((e) => e as String)?.toList(),
@@ -29,7 +31,7 @@ abstract class _$PackageDocumentSerializerMixin {
   String get version;
   String get devVersion;
   String get description;
-  String get lastUpdated;
+  DateTime get updated;
   String get readme;
   List<String> get platforms;
   double get health;
@@ -41,7 +43,7 @@ abstract class _$PackageDocumentSerializerMixin {
         'version': version,
         'devVersion': devVersion,
         'description': description,
-        'lastUpdated': lastUpdated,
+        'updated': updated?.toIso8601String(),
         'readme': readme,
         'platforms': platforms,
         'health': health,

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -101,7 +101,7 @@ void main() {
         readme: '''http
           A composable, Future-based library for making HTTP requests.
           This package contains a set of high-level functions and classes that make it easy to consume HTTP resources. It's platform-independent, and can be used on both the command-line and the browser. Currently the global utility functions are unsupported on the browser; see "Using on the Browser" below.''',
-        lastUpdated: 'Jul 20, 2017',
+        updated: new DateTime.utc(2017, 07, 20),
         popularity: 0.7,
         health: 1.0,
       ));
@@ -118,7 +118,7 @@ The AsyncCache class allows expensive asynchronous computations values to be cac
 The AsyncMemoizer class makes it easy to only run an asynchronous operation once on demand.
 The CancelableOperation class defines an operation that can be canceled by its consumer. The producer can then listen for this cancellation and stop producing the future when it's received. It can be created using a CancelableCompleter.
 The delegating wrapper classes allow users to easily add functionality on top of existing instances of core types from dart:async. These include DelegatingFuture, DelegatingStream, DelegatingStreamSubscription, DelegatingStreamConsumer, DelegatingSink, DelegatingEventSink, and DelegatingStreamSink.''',
-        lastUpdated: 'May 17, 2017',
+        updated: new DateTime.utc(2017, 05, 17),
         popularity: 0.8,
         health: 1.0,
       ));
@@ -131,7 +131,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
         readme: '''TCP client and server libraries for Dart based Chrome Apps.
 tcp.dart contains abstractions over chrome.sockets to aid in working with TCP client sockets and server sockets (TcpClient and TcpServer).
 server.dart adds a small, prescriptive server (PicoServer) that can be configured with different handlers for HTTP requests.''',
-        lastUpdated: 'Sep 17, 2014',
+        updated: new DateTime.utc(2014, 09, 17),
         popularity: 0.0,
         health: 0.5,
       ));


### PR DESCRIPTION
This is a breaking change without any risk, because we haven't used that field yet, but we'll need the full DateTime for reverse chronological ordering.