### PR TITLE
Removing versions and platform information from search API's results

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -119,9 +119,6 @@ class SimplePackageIndex implements PackageIndex {
       results.add(new PackageScore(
         url: doc.url,
         package: doc.package,
-        version: doc.version,
-        devVersion: doc.devVersion,
-        platforms: doc.platforms,
         score: total[url],
       ));
     }

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -163,20 +163,11 @@ class PackageSearchResult extends Object
 class PackageScore extends Object with _$PackageScoreSerializerMixin {
   final String url;
   final String package;
-  final String version;
-  final String devVersion;
-
-  @JsonKey(includeIfNull: false)
-  final List<String> platforms;
-
   final double score;
 
   PackageScore({
     this.url,
     this.package,
-    this.version,
-    this.devVersion,
-    this.platforms,
     this.score,
   });
 

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -77,35 +77,12 @@ PackageScore _$PackageScoreFromJson(Map<String, dynamic> json) =>
     new PackageScore(
         url: json['url'] as String,
         package: json['package'] as String,
-        version: json['version'] as String,
-        devVersion: json['devVersion'] as String,
-        platforms:
-            (json['platforms'] as List)?.map((e) => e as String)?.toList(),
         score: (json['score'] as num)?.toDouble());
 
 abstract class _$PackageScoreSerializerMixin {
   String get url;
   String get package;
-  String get version;
-  String get devVersion;
-  List<String> get platforms;
   double get score;
-  Map<String, dynamic> toJson() {
-    var val = <String, dynamic>{
-      'url': url,
-      'package': package,
-      'version': version,
-      'devVersion': devVersion,
-    };
-
-    void writeNotNull(String key, dynamic value) {
-      if (value != null) {
-        val[key] = value;
-      }
-    }
-
-    writeNotNull('platforms', platforms);
-    val['score'] = score;
-    return val;
-  }
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'url': url, 'package': package, 'score': score};
 }

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -59,9 +59,6 @@ void main() {
             {
               'url': 'https://pub.domain/packages/pkg_foo',
               'package': 'pkg_foo',
-              'version': '1.0.1',
-              'devVersion': '1.0.1-dev',
-              'platforms': ['server', 'web'],
               'score': closeTo(71.1, 0.1),
             }
           ],
@@ -77,9 +74,6 @@ void main() {
             {
               'url': 'https://pub.domain/packages/pkg_foo',
               'package': 'pkg_foo',
-              'version': '1.0.1',
-              'devVersion': '1.0.1-dev',
-              'platforms': ['server', 'web'],
               'score': closeTo(2.4, 0.1),
             }
           ],
@@ -96,9 +90,6 @@ void main() {
                 {
                   'url': 'https://pub.domain/packages/pkg_foo',
                   'package': 'pkg_foo',
-                  'version': '1.0.1',
-                  'devVersion': '1.0.1-dev',
-                  'platforms': ['server', 'web'],
                   'score': closeTo(2.4, 0.1),
                 }
               ],
@@ -114,9 +105,6 @@ void main() {
             {
               'url': 'https://pub.domain/packages/pkg_foo',
               'package': 'pkg_foo',
-              'version': '1.0.1',
-              'devVersion': '1.0.1-dev',
-              'platforms': ['server', 'web'],
               'score': closeTo(13.3, 0.1),
             }
           ],

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -170,15 +170,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {
             'url': 'uri://async',
             'package': 'async',
-            'version': '1.13.3',
-            'devVersion': '1.13.3',
             'score': closeTo(83.4, 0.1),
           },
           {
             'url': 'uri://http',
             'package': 'http',
-            'version': '0.11.3+14',
-            'devVersion': '0.11.3+14',
             'score': closeTo(12.0, 0.1),
           },
         ]
@@ -195,15 +191,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {
             'url': 'uri://http',
             'package': 'http',
-            'version': '0.11.3+14',
-            'devVersion': '0.11.3+14',
             'score': closeTo(15.9, 0.1),
           },
           {
             'url': 'uri://async',
             'package': 'async',
-            'version': '1.13.3',
-            'devVersion': '1.13.3',
             'score': closeTo(13.0, 0.1),
           },
         ]
@@ -220,22 +212,16 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {
             'url': 'uri://chrome_net',
             'package': 'chrome_net',
-            'version': '0.1.0',
-            'devVersion': '0.1.0',
             'score': closeTo(29.4, 0.1),
           },
           {
             'url': 'uri://async',
             'package': 'async',
-            'version': '1.13.3',
-            'devVersion': '1.13.3',
             'score': closeTo(13.0, 0.1),
           },
           {
             'url': 'uri://http',
             'package': 'http',
-            'version': '0.11.3+14',
-            'devVersion': '0.11.3+14',
             'score': closeTo(12.0, 0.1),
           },
         ]
@@ -252,8 +238,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {
             'url': 'uri://chrome_net',
             'package': 'chrome_net',
-            'version': '0.1.0',
-            'devVersion': '0.1.0',
             'score': closeTo(71.2139, 0.0001),
           },
         ]


### PR DESCRIPTION
Keeps the results simple and focused, and removes the temptation to use it for anything else.