### PR TITLE
Search order implementation with additional tests.

### DIFF
--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -184,12 +184,14 @@ class SearchQuery {
   /// Sanity check, whether the query object is to be expected a valid result.
   bool get isValid {
     final bool hasText = text != null && text.isNotEmpty;
-    final bool hasPackagePrefix =
-        packagePrefix != null && packagePrefix.isNotEmpty;
-    final bool hasNonTextOrdering = order != null &&
-        order != SearchOrder.overall &&
-        order != SearchOrder.text;
-    return hasText || hasPackagePrefix || hasNonTextOrdering;
+    final bool hasNonTextOrdering = order != SearchOrder.text;
+    final bool isEmpty = !hasText &&
+        order == null &&
+        packagePrefix == null &&
+        (platformPredicate == null || !platformPredicate.isNotEmpty);
+    if (isEmpty) return false;
+
+    return hasText || hasNonTextOrdering;
   }
 }
 
@@ -221,6 +223,8 @@ class PackageSearchResult extends Object
 class PackageScore extends Object with _$PackageScoreSerializerMixin {
   final String url;
   final String package;
+
+  @JsonKey(includeIfNull: false)
   final double score;
 
   PackageScore({

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -83,6 +83,19 @@ abstract class _$PackageScoreSerializerMixin {
   String get url;
   String get package;
   double get score;
-  Map<String, dynamic> toJson() =>
-      <String, dynamic>{'url': url, 'package': package, 'score': score};
+  Map<String, dynamic> toJson() {
+    var val = <String, dynamic>{
+      'url': url,
+      'package': package,
+    };
+
+    void writeNotNull(String key, dynamic value) {
+      if (value != null) {
+        val[key] = value;
+      }
+    }
+
+    writeNotNull('score', score);
+    return val;
+  }
 }

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -59,7 +59,7 @@ void main() {
             {
               'url': 'https://pub.domain/packages/pkg_foo',
               'package': 'pkg_foo',
-              'score': closeTo(71.1, 0.1),
+              'score': closeTo(70.9, 0.1),
             }
           ],
         });
@@ -105,7 +105,7 @@ void main() {
             {
               'url': 'https://pub.domain/packages/pkg_foo',
               'package': 'pkg_foo',
-              'score': closeTo(13.3, 0.1),
+              'score': closeTo(1.0, 0.1),
             }
           ],
         });

--- a/app/test/shared/search_service_test.dart
+++ b/app/test/shared/search_service_test.dart
@@ -39,7 +39,7 @@ void main() {
     });
 
     test('has text-based ordering', () {
-      expect(new SearchQuery('', order: SearchOrder.overall).isValid, isFalse);
+      expect(new SearchQuery('', order: SearchOrder.overall).isValid, isTrue);
       expect(new SearchQuery('', order: SearchOrder.text).isValid, isFalse);
 
       expect(
@@ -61,7 +61,7 @@ void main() {
             order: SearchOrder.text,
           )
               .isValid,
-          isTrue);
+          isFalse);
     });
 
     test('has non-text-based ordering', () {


### PR DESCRIPTION
There is one side-effect for the text-search: there is a clipping where we remove low score values from the results, and this happens earlier (before adding the quality and health scores). The result is fewer results, which have roughly the same score as before.

Some examples:
- ['game' order by health](https://20170919t153718-dot-search-dot-dartlang-pub-dev.appspot.com/search?q=game&order=health&indent=true)
- ['game' order by updated](https://20170919t153718-dot-search-dot-dartlang-pub-dev.appspot.com/search?q=game&order=updated&indent=true)
- ['game' order by text](https://20170919t153718-dot-search-dot-dartlang-pub-dev.appspot.com/search?q=game&order=text&indent=true)
