### PR TITLE
WIP: Running pana more frequently (don't merge yet)

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -24,7 +24,7 @@ AnalysisBackend get analysisBackend => ss.lookup(#_analysisBackend);
 
 final Logger _logger = new Logger('pub.analyzer.backend');
 
-const Duration freshThreshold = const Duration(hours: 12);
+const Duration freshThreshold = const Duration(hours: 22);
 const Duration obsoleteThreshold = const Duration(days: 180);
 
 /// Datastore-related access methods for the analyzer service
@@ -194,7 +194,7 @@ class AnalysisBackend {
           '${versionAnalysis.flutterVersion} - $flutterVersion');
     }
 
-    // Is latest analysis older than 4 hours?
+    // Is latest analysis older than 1 hour?
     final DateTime now = new DateTime.now().toUtc();
     if (now.difference(versionAnalysis.analysisTimestamp) < freshThreshold) {
       return false;

--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' show max;
 
 import 'package:gcloud/db.dart';
 import 'package:logging/logging.dart';
@@ -42,49 +43,68 @@ class DatastoreHeadTaskSource extends DatastoreVersionsHeadTaskSource {
 /// newer and creates a task if needed.
 class DatastoreHistoryTaskSource implements TaskSource {
   final DatastoreDB _db;
-  final int afterDays;
 
-  DatastoreHistoryTaskSource(
-    this._db, {
-    this.afterDays: 30,
-  });
+  DatastoreHistoryTaskSource(this._db);
 
   @override
   Stream<Task> startStreaming() => randomizeStream(_startStreaming());
 
   Stream<Task> _startStreaming() async* {
+    final Duration packageScanPeriod = new Duration(hours: 1);
+    final Duration versionScanPeriod = new Duration(days: 1);
+    DateTime lastPackageScan;
+    DateTime lastVersionScan;
     for (;;) {
+      bool scanned = false;
       try {
-        // Check and schedule the latest stable version of each package.
-        final Query packageQuery = _db.query(Package)..order('-updated');
-        await for (Package p in packageQuery.run()) {
-          if (await _requiresUpdate(p.name, p.latestVersion)) {
-            yield new Task(p.name, p.latestVersion);
-          }
+        final bool shouldScanPackages = lastPackageScan == null ||
+            new DateTime.now().difference(lastPackageScan) > packageScanPeriod;
+        if (shouldScanPackages) {
+          // Check and schedule the latest stable version of each package.
+          final Query packageQuery = _db.query(Package)..order('-updated');
+          await for (Package p in packageQuery.run()) {
+            if (await _requiresUpdate(
+                p.name, p.latestVersion, true, p.updated)) {
+              yield new Task(p.name, p.latestVersion);
+            }
 
-          if (p.latestVersion != p.latestDevVersion &&
-              await _requiresUpdate(p.name, p.latestDevVersion)) {
-            yield new Task(p.name, p.latestDevVersion);
+            if (p.latestVersion != p.latestDevVersion &&
+                await _requiresUpdate(
+                    p.name, p.latestDevVersion, false, p.updated)) {
+              yield new Task(p.name, p.latestDevVersion);
+            }
           }
+          scanned = true;
+          lastPackageScan = new DateTime.now();
         }
 
-        // After we are done with the most important versions, let's check all
-        // of the older versions too.
-        final Query versionQuery = _db.query(PackageVersion)..order('-created');
-        await for (PackageVersion pv in versionQuery.run()) {
-          if (await _requiresUpdate(pv.package, pv.version)) {
-            yield new Task(pv.package, pv.version);
+        final bool shouldScanVersions = lastVersionScan == null ||
+            new DateTime.now().difference(lastVersionScan) > versionScanPeriod;
+        if (shouldScanVersions) {
+          // After we are done with the most important versions, let's check all
+          // of the older versions too.
+          final Query versionQuery = _db.query(PackageVersion)
+            ..order('-created');
+          await for (PackageVersion pv in versionQuery.run()) {
+            if (await _requiresUpdate(
+                pv.package, pv.version, false, pv.created)) {
+              yield new Task(pv.package, pv.version);
+            }
           }
+          scanned = true;
+          lastVersionScan = new DateTime.now();
         }
       } catch (e, st) {
         _logger.severe('Error polling history.', e, st);
       }
-      await new Future.delayed(const Duration(days: 1));
+      if (!scanned) {
+        await new Future.delayed(const Duration(minutes: 20));
+      }
     }
   }
 
-  Future<bool> _requiresUpdate(
-      String packageName, String packageVersion) async {
+  Future<bool> _requiresUpdate(String packageName, String packageVersion,
+      bool isLatestStable, DateTime created) async {
     final List<PackageVersionAnalysis> list = await _db.lookup([
       _db.emptyKey
           .append(PackageAnalysis, id: packageName)
@@ -98,9 +118,26 @@ class DatastoreHistoryTaskSource implements TaskSource {
       return true;
     }
 
-    final Duration diff =
-        new DateTime.now().toUtc().difference(version.analysisTimestamp);
-    if (diff.inDays >= afterDays) return true;
+    final DateTime now = new DateTime.now().toUtc();
+    final DateTime threshold = now;
+    // Latest stable versions have a one-day re-analysis cycle, while the rest
+    // is done less frequently, depending on how old the package is.
+    if (isLatestStable) {
+      // Polling period is 1 hour, threshold of 23 hours keeps it within a day.
+      threshold.subtract(const Duration(hours: 23));
+    } else {
+      // The older the package, the less frequent we want to re-analyze it.
+      // With the current settings, the following periods will be set:
+      // - 3 months old: around once a week
+      // - 1 year old: once a month
+      // - 2 years old: every two months
+      final int ageInHours = now.difference(created).inHours;
+      final int hoursToSubstract = max(24, ageInHours * 30 ~/ 365);
+      threshold.subtract(new Duration(hours: hoursToSubstract));
+    }
+    if (version.analysisTimestamp.isBefore(threshold)) {
+      return true;
+    }
 
     return false;
   }


### PR DESCRIPTION
The goal here is to re-run analysis on the latest versions every day, and on the rest less frequently: as they age and reach one-year we re-run it only once a month, after that even less frequently.
Of course we re-run analysis if pana/flutter version changes, regardless of age.

I'm still observing how this behaves on staging (don't merge it yet), but I thing the code is ready for a review.