### PR TITLE
Remove maximum search offset.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -15,7 +15,7 @@ import 'package:shelf/shelf.dart' as shelf;
 import '../shared/analyzer_client.dart';
 import '../shared/handlers.dart';
 import '../shared/platform.dart';
-import '../shared/search_service.dart' show SearchQuery, maxSearchResults;
+import '../shared/search_service.dart' show SearchQuery;
 import '../shared/utils.dart';
 
 import 'atom_feed.dart';
@@ -166,8 +166,7 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
     queryText = queryText.replaceFirst(_packageRegexp, ' ').trim();
   }
 
-  final int page = _pageFromUrl(request.url,
-      maxPages: maxSearchResults ~/ PageLinks.RESULTS_PER_PAGE);
+  final int page = _pageFromUrl(request.url);
 
   final SearchQuery query = new SearchQuery(
     queryText,
@@ -572,9 +571,8 @@ shelf.Response _formattedNotFoundHandler(shelf.Request request) {
 
 /// Extracts the 'page' query parameter from [url].
 ///
-/// Returns a valid positive integer. If [maxPages] is given, the result is
-/// clamped to [maxPages].
-int _pageFromUrl(Uri url, {int maxPages}) {
+/// Returns a valid positive integer.
+int _pageFromUrl(Uri url) {
   final pageAsString = url.queryParameters['page'];
   int pageAsInt = 1;
   if (pageAsString != null) {
@@ -582,8 +580,6 @@ int _pageFromUrl(Uri url, {int maxPages}) {
       pageAsInt = max(int.parse(pageAsString), 1);
     } catch (_, __) {}
   }
-
-  if (maxPages != null && pageAsInt > maxPages) pageAsInt = maxPages;
   return pageAsInt;
 }
 

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -6,7 +6,7 @@
 library pub_dartlang_org.shared.search_service;
 
 import 'dart:async';
-import 'dart:math' show min, max;
+import 'dart:math' show max;
 
 import 'package:json_serializable/annotations.dart';
 
@@ -16,7 +16,6 @@ part 'search_service.g.dart';
 
 const int defaultSearchLimit = 100;
 const int minSearchLimit = 10;
-const int maxSearchResults = 500;
 const int searchIndexNotReadyCode = 600;
 const String searchIndexNotReadyText = 'Not ready yet.';
 
@@ -149,7 +148,6 @@ class SearchQuery {
     int limit = int.parse(uri.queryParameters['limit'] ?? '0',
         onError: (_) => defaultSearchLimit);
 
-    offset = min(maxSearchResults - minSearchLimit, offset);
     offset = max(0, offset);
     limit = max(minSearchLimit, limit);
 


### PR DESCRIPTION
It has no performance-related impact, it just limits the number of results, which is not good for platform-related listings like `/flutter/packages`, unless we are fine with limiting the paginated view to a certain number of pages.