### PR TITLE
No-surpise Analysis GC

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -67,6 +67,12 @@ class PanaRunner implements TaskRunner {
 
     final backendStatus = await _analysisBackend.storeAnalysis(analysis);
 
+    try {
+      await _analysisBackend.deleteObsoleteAnalysis(task.package, task.version);
+    } catch (e) {
+      _logger.warning('Analysis GC failed: $task', e);
+    }
+
     if (backendStatus.isNewVersion) {
       // TODO: trigger re-analysis of packages depending on this one
     }

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -168,7 +168,7 @@ class MockAnalysisBackend implements AnalysisBackend {
   }
 
   @override
-  Future deleteObsoleteAnalysisEntries() {
+  Future deleteObsoleteAnalysis(String package, String version) {
     throw 'Not implemented yet.';
   }
 }


### PR DESCRIPTION
Instead of doing a long cleanup, which may be never triggered if Appengine keeps restarting the instances every few days, we can do a quick, focused cleanup just after we store a new `Analysis`. My staging experiment showed that it is cheap to do.