### PR TITLE
Use pubspec to decide which favicon and install to render

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -264,9 +264,9 @@ class TemplateService {
     final bool should_show =
         selectedVersion != latestStableVersion || should_show_dev;
 
-    final bool isFlutterPlugin = latestStableVersion.detectedTypes
-            ?.contains(BuiltinTypes.flutterPlugin) ==
-        true;
+    final bool isFlutterPlugin =
+        latestStableVersion.pubspec.dependsOnFlutterSdk ||
+            latestStableVersion.pubspec.hasFlutterPlugin;
 
     final List<Map<String, String>> tabs = <Map<String, String>>[];
     void addFileTab(String id, String title, String content) {


### PR DESCRIPTION
One less dependency on `detectedType`. We could use `analysis` here too, but as we have the info in pubspec, it seems better to use it.