### PR TITLE
Use update time in Task, to better control re-analyze rules.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -25,7 +25,8 @@ class PanaRunner implements TaskRunner {
 
   @override
   Future<bool> hasCompletedRecently(Task task) async {
-    return !(await _analysisBackend.isValidTarget(task.package, task.version));
+    return !(await _analysisBackend.isValidTarget(
+        task.package, task.version, task.updated));
   }
 
   @override

--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -59,12 +59,12 @@ class DatastoreHistoryTaskSource implements TaskSource {
         final Query packageQuery = _db.query(Package)..order('-updated');
         await for (Package p in packageQuery.run()) {
           if (await _requiresUpdate(p.name, p.latestVersion)) {
-            yield new Task(p.name, p.latestVersion);
+            yield new Task(p.name, p.latestVersion, p.updated);
           }
 
           if (p.latestVersion != p.latestDevVersion &&
               await _requiresUpdate(p.name, p.latestDevVersion)) {
-            yield new Task(p.name, p.latestDevVersion);
+            yield new Task(p.name, p.latestDevVersion, p.updated);
           }
         }
 
@@ -73,7 +73,7 @@ class DatastoreHistoryTaskSource implements TaskSource {
         final Query versionQuery = _db.query(PackageVersion)..order('-created');
         await for (PackageVersion pv in versionQuery.run()) {
           if (await _requiresUpdate(pv.package, pv.version)) {
-            yield new Task(pv.package, pv.version);
+            yield new Task(pv.package, pv.version, pv.created);
           }
         }
       } catch (e, st) {

--- a/app/lib/shared/task_client.dart
+++ b/app/lib/shared/task_client.dart
@@ -24,7 +24,7 @@ void registerTaskSendPort(SendPort taskSendPort) {
 /// Triggers task processing via sending tasks to the [Scheduler] in the other
 /// isolate.
 void triggerTask(String package, String version) {
-  final Task task = new Task(package, version);
+  final Task task = new Task.now(package, version);
   if (_taskSendPort == null) {
     _taskQueue.add(task);
   } else {

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -101,8 +101,12 @@ class TaskScheduler {
 class Task {
   final String package;
   final String version;
+  final DateTime updated;
 
-  Task(this.package, this.version);
+  Task(this.package, this.version, this.updated);
+
+  Task.now(this.package, this.version)
+      : updated = new DateTime.now().toUtc();
 
   @override
   String toString() => '$package $version';
@@ -113,10 +117,12 @@ class Task {
       other is Task &&
           runtimeType == other.runtimeType &&
           package == other.package &&
-          version == other.version;
+          version == other.version &&
+          updated == other.updated;
 
   @override
-  int get hashCode => package.hashCode ^ version.hashCode;
+  int get hashCode =>
+      package.hashCode ^ version.hashCode ^ updated.hashCode;
 }
 
 /// A pull-based interface for accessing events from multiple streams, in the

--- a/app/lib/shared/task_sources.dart
+++ b/app/lib/shared/task_sources.dart
@@ -75,7 +75,8 @@ class DatastoreVersionsHeadTaskSource implements TaskSource {
     }
     int count = 0;
     await for (Package p in q.run()) {
-      final task = new Task(p.name, p.latestVersion ?? p.latestDevVersion);
+      final task =
+          new Task(p.name, p.latestVersion ?? p.latestDevVersion, p.updated);
       if (await shouldYieldTask(task)) {
         count++;
         yield task;
@@ -91,7 +92,7 @@ class DatastoreVersionsHeadTaskSource implements TaskSource {
     }
     int count = 0;
     await for (PackageVersion pv in q.run()) {
-      final task = new Task(pv.package, pv.version);
+      final task = new Task(pv.package, pv.version, pv.created);
       if (await shouldYieldTask(task)) {
         count++;
         yield task;

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -163,7 +163,8 @@ class MockAnalysisBackend implements AnalysisBackend {
   }
 
   @override
-  Future<bool> isValidTarget(String packageName, String packageVersion) {
+  Future<bool> isValidTarget(
+      String packageName, String packageVersion, DateTime updated) {
     throw 'Not implemented yet.';
   }
 


### PR DESCRIPTION
This is to make sure that dependees triggered by https://github.com/dart-lang/pub-dartlang-dart/pull/388 will get analyzed, even if they had been analyzed in the past hour.