### PR TITLE
Don't keep the transitive libraries in the stored pana output.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -44,7 +44,7 @@ class PanaRunner implements TaskRunner {
       summary = await analyzer.inspectPackage(
         task.package,
         version: task.version,
-        keepTransitiveLibs: true, // TODO: decide if this is really needed
+        keepTransitiveLibs: false,
       );
     } catch (e, st) {
       _logger.severe('Pana execution failed.', e, st);


### PR DESCRIPTION
The list takes up a huge chunk of the size (thus: adds to latency), and we don't use it for anything and won't be in the mid-term.