### PR TITLE
 Cleanup search results preparation and rendering

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -417,22 +417,17 @@ class TemplateService {
     final List results = [];
     for (int i = 0; i < resultPage.packages.length; i++) {
       final resultPkg = resultPage.packages[i];
-      PackageVersion stable = resultPkg.stableVersion;
-      final PackageVersion dev = resultPkg.devVersion ?? stable;
-
-      if (stable == null) {
-        stable = dev;
-        _logger.warning("Stable version `null` for ${dev.package}.");
-      }
+      final PackageVersion stable = resultPkg.version;
+      final showDevVersion = resultPkg.devVersion != null;
 
       results.add({
         'url': '/packages/${stable.packageKey.id}',
         'name': stable.packageKey.id,
         'version': HTML_ESCAPE.convert(stable.id),
-        'show_dev_version': stable.id != dev.id,
-        'dev_version': HTML_ESCAPE.convert(dev.id),
-        'dev_version_href': Uri.encodeComponent(dev.id),
-        'icons': _renderIconsColumnHtml(resultPkg.platforms),
+        'show_dev_version': showDevVersion,
+        'dev_version': HTML_ESCAPE.convert(resultPkg.devVersion ?? ''),
+        'dev_version_href': Uri.encodeComponent(resultPkg.devVersion ?? ''),
+        'icons': _renderIconsColumnHtml(resultPkg.analysis.platforms),
         'last_uploaded': stable.shortCreated,
         'desc': stable.ellipsizedDescription,
       });

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -19,6 +19,7 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
 import '../shared/handlers_test_utils.dart';
+import '../shared/mocks.dart';
 import '../shared/utils.dart';
 
 import 'handlers_test_utils.dart';
@@ -221,7 +222,7 @@ void main() {
             1,
             [
               new PackageVersionView(
-                  testPackageVersion, new MockAnalysisView()),
+                  testPackageVersion, new AnalysisViewMock()),
             ],
           );
         }));
@@ -239,7 +240,7 @@ void main() {
             1,
             [
               new PackageVersionView(
-                  testPackageVersion, new MockAnalysisView()),
+                  testPackageVersion, new AnalysisViewMock()),
             ],
           );
         }));

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -220,8 +220,8 @@ void main() {
             query,
             1,
             [
-              new SearchResultPackage(
-                  testPackageVersion, testPackageVersion, null),
+              new PackageVersionView(
+                  testPackageVersion, new MockAnalysisView()),
             ],
           );
         }));
@@ -238,8 +238,8 @@ void main() {
             query,
             1,
             [
-              new SearchResultPackage(
-                  testPackageVersion, testPackageVersion, null),
+              new PackageVersionView(
+                  testPackageVersion, new MockAnalysisView()),
             ],
           );
         }));

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -6,7 +6,6 @@ library pub_dartlang_org.handlers_test;
 
 import 'dart:async';
 
-import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
@@ -16,7 +15,6 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
-import 'package:pub_dartlang_org/shared/search_service.dart';
 
 Future<shelf.Response> issueGet(String path) async {
   final uri = 'https://pub.dartlang.org$path';
@@ -199,47 +197,4 @@ class TemplateMock implements TemplateService {
   String renderAnalysisTab(analysis) {
     return Response;
   }
-}
-
-class SearchClientMock implements SearchClient {
-  final Function searchFun;
-  SearchClientMock({this.searchFun});
-
-  @override
-  Future<PackageSearchResult> search(SearchQuery query) async {
-    if (searchFun == null) throw 'no searchFun';
-    return searchFun(query);
-  }
-
-  @override
-  Future close() async {}
-}
-
-class SearchServiceMock implements SearchService {
-  final Function searchFun;
-
-  SearchServiceMock(this.searchFun);
-
-  @override
-  Future<SearchResultPage> search(SearchQuery query) async {
-    return searchFun(query);
-  }
-
-  @override
-  Future close() async => null;
-}
-
-class AnalyzerClientMock implements AnalyzerClient {
-  AnalysisData mockAnalysisData;
-
-  @override
-  Future<AnalysisData> getAnalysisData(String package, String version) async =>
-      mockAnalysisData;
-
-  @override
-  Future close() async => null;
-
-  @override
-  Future<AnalysisView> getAnalysisView(String package, String version) async =>
-      new AnalysisView(await getAnalysisData(package, version));
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -15,7 +15,7 @@ import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart'
     show SearchResultPage, PackageVersionView;
 
-import '../shared/utils.dart';
+import '../shared/mocks.dart';
 import 'utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
@@ -42,8 +42,8 @@ void main() {
         testPackageVersion,
         flutterPackageVersion,
       ], [
-        new MockAnalysisView(),
-        new MockAnalysisView(platforms: ['flutter']),
+        new AnalysisViewMock(),
+        new AnalysisViewMock(platforms: ['flutter']),
       ]);
       expectGoldenFile(html, 'index_page.html');
     });
@@ -57,7 +57,7 @@ void main() {
           testPackageVersion,
           testPackageVersion,
           1,
-          new MockAnalysisView()..licenseText = 'BSD',
+          new AnalysisViewMock()..licenseText = 'BSD',
           'Mock analysis tab content.');
       expectGoldenFile(html, 'pkg_show_page.html');
     });
@@ -71,7 +71,7 @@ void main() {
           flutterPackageVersion,
           flutterPackageVersion,
           1,
-          new MockAnalysisView()..platforms = ['flutter'],
+          new AnalysisViewMock()..platforms = ['flutter'],
           null);
       expectGoldenFile(html, 'pkg_show_page_flutter_plugin.html');
     });
@@ -96,8 +96,8 @@ void main() {
         testPackageVersion,
         flutterPackageVersion
       ], [
-        new MockAnalysisView(),
-        new MockAnalysisView(platforms: ['flutter']),
+        new AnalysisViewMock(),
+        new AnalysisViewMock(platforms: ['flutter']),
       ], new PackageLinks.empty());
       expectGoldenFile(html, 'pkg_index_page.html');
     });
@@ -113,7 +113,7 @@ void main() {
         [testPackage],
         [flutterPackageVersion],
         [
-          new MockAnalysisView(platforms: ['flutter']),
+          new AnalysisViewMock(platforms: ['flutter']),
         ],
         new PackageLinks(
             PackageLinks.RESULTS_PER_PAGE, PackageLinks.RESULTS_PER_PAGE + 1),
@@ -130,9 +130,9 @@ void main() {
         query,
         2,
         [
-          new PackageVersionView(testPackageVersion, new MockAnalysisView()),
+          new PackageVersionView(testPackageVersion, new AnalysisViewMock()),
           new PackageVersionView(flutterPackageVersion,
-              new MockAnalysisView(platforms: ['flutter'])),
+              new AnalysisViewMock(platforms: ['flutter'])),
         ],
       );
       final String html =

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -13,8 +13,9 @@ import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart'
-    show SearchResultPage, SearchResultPackage;
+    show SearchResultPage, PackageVersionView;
 
+import '../shared/utils.dart';
 import 'utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
@@ -129,9 +130,9 @@ void main() {
         query,
         2,
         [
-          new SearchResultPackage(testPackageVersion, testPackageVersion, null),
-          new SearchResultPackage(
-              flutterPackageVersion, flutterPackageVersion, ['flutter']),
+          new PackageVersionView(testPackageVersion, new MockAnalysisView()),
+          new PackageVersionView(flutterPackageVersion,
+              new MockAnalysisView(platforms: ['flutter'])),
         ],
       );
       final String html =
@@ -266,29 +267,4 @@ void main() {
           '/search?q=web+framework&page=2&platforms=server');
     });
   });
-}
-
-class MockAnalysisView implements AnalysisView {
-  @override
-  bool hasAnalysisData = true;
-
-  @override
-  AnalysisStatus analysisStatus;
-
-  @override
-  List<String> getTransitiveDependencies() => throw 'Not implemented';
-
-  @override
-  double health;
-
-  @override
-  String licenseText;
-
-  @override
-  DateTime timestamp;
-
-  @override
-  List<String> platforms;
-
-  MockAnalysisView({this.platforms});
 }

--- a/app/test/shared/mocks.dart
+++ b/app/test/shared/mocks.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:pub_dartlang_org/frontend/search_service.dart';
+import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/search_client.dart';
+import 'package:pub_dartlang_org/shared/search_service.dart';
+
+class SearchClientMock implements SearchClient {
+  final Function searchFun;
+  SearchClientMock({this.searchFun});
+
+  @override
+  Future<PackageSearchResult> search(SearchQuery query) async {
+    if (searchFun == null) throw 'no searchFun';
+    return searchFun(query);
+  }
+
+  @override
+  Future close() async {}
+}
+
+class SearchServiceMock implements SearchService {
+  final Function searchFun;
+
+  SearchServiceMock(this.searchFun);
+
+  @override
+  Future<SearchResultPage> search(SearchQuery query) async {
+    return searchFun(query);
+  }
+
+  @override
+  Future close() async => null;
+}
+
+class AnalyzerClientMock implements AnalyzerClient {
+  AnalysisData mockAnalysisData;
+
+  @override
+  Future<AnalysisData> getAnalysisData(String package, String version) async =>
+      mockAnalysisData;
+
+  @override
+  Future close() async => null;
+
+  @override
+  Future<AnalysisView> getAnalysisView(String package, String version) async =>
+      new AnalysisView(await getAnalysisData(package, version));
+}
+
+class AnalysisViewMock implements AnalysisView {
+  @override
+  bool hasAnalysisData = true;
+
+  @override
+  AnalysisStatus analysisStatus;
+
+  @override
+  List<String> getTransitiveDependencies() => throw 'Not implemented';
+
+  @override
+  double health;
+
+  @override
+  String licenseText;
+
+  @override
+  DateTime timestamp;
+
+  @override
+  List<String> platforms;
+
+  AnalysisViewMock({this.platforms});
+}

--- a/app/test/shared/utils.dart
+++ b/app/test/shared/utils.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import 'package:gcloud/service_scope.dart';
 import 'package:test/test.dart';
 
-import 'package:pub_dartlang_org/shared/analyzer_client.dart';
-
 Future scoped(func()) {
   return fork(() async {
     return func();
@@ -21,29 +19,4 @@ void scopedTest(String name, func(), {Timeout timeout}) {
       return func();
     });
   }, timeout: timeout);
-}
-
-class MockAnalysisView implements AnalysisView {
-  @override
-  bool hasAnalysisData = true;
-
-  @override
-  AnalysisStatus analysisStatus;
-
-  @override
-  List<String> getTransitiveDependencies() => throw 'Not implemented';
-
-  @override
-  double health;
-
-  @override
-  String licenseText;
-
-  @override
-  DateTime timestamp;
-
-  @override
-  List<String> platforms;
-
-  MockAnalysisView({this.platforms});
 }

--- a/app/test/shared/utils.dart
+++ b/app/test/shared/utils.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:gcloud/service_scope.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+
 Future scoped(func()) {
   return fork(() async {
     return func();
@@ -19,4 +21,29 @@ void scopedTest(String name, func(), {Timeout timeout}) {
       return func();
     });
   }, timeout: timeout);
+}
+
+class MockAnalysisView implements AnalysisView {
+  @override
+  bool hasAnalysisData = true;
+
+  @override
+  AnalysisStatus analysisStatus;
+
+  @override
+  List<String> getTransitiveDependencies() => throw 'Not implemented';
+
+  @override
+  double health;
+
+  @override
+  String licenseText;
+
+  @override
+  DateTime timestamp;
+
+  @override
+  List<String> platforms;
+
+  MockAnalysisView({this.platforms});
 }


### PR DESCRIPTION
- There is no need to query the latest dev versions, as we don't display any data off of them. If we worry about data consistency, I'd rather put a periodic job up there to check the Datastore for such cases, but there is no need to do it every time we render search results.

- With that, I've refactored `PackageVersionView` in a way that should be reusable on the home page and other index pages too: the version is presented together with the analysis, and stuff like the latest dev versions is optional.

- I've also did a little cleanup in the test dir and moved the shared services' mocks into a single place for easier referencing.