### PR TITLE
Prepare AnalyzerClient for proper batch requests.

### DIFF
--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -50,20 +50,20 @@ Future<SearchResultPage> _loadResultForPackages(
       packageEntries.map((p) => p.latestVersionKey).toList();
   if (versionKeys.isNotEmpty) {
     // Analysis data fetched concurrently to reduce overall latency.
-    final Future<List<AnalysisData>> allAnalysisFuture = Future.wait(
-        packageEntries.map(
-            (p) => analyzerClient.getAnalysisData(p.name, p.latestVersion)));
+    final Future<List<AnalysisView>> analysisViewsFuture =
+        analyzerClient.getAnalysisViews(packageEntries
+            .map((p) => new AnalysisKey(p.name, p.latestVersion)));
     final Future<List<PackageVersion>> allVersionsFuture =
         dbService.lookup(versionKeys);
 
     final List batchResults =
-        await Future.wait([allAnalysisFuture, allVersionsFuture]);
-    final List<AnalysisData> analysisDataList = await batchResults[0];
+        await Future.wait([analysisViewsFuture, allVersionsFuture]);
+    final List<AnalysisView> analysisViews = await batchResults[0];
     final List<PackageVersion> versions = await batchResults[1];
 
     final List<SearchResultPackage> resultPackages =
         new List.generate(versions.length, (i) {
-      final AnalysisView view = new AnalysisView(analysisDataList[i]);
+      final AnalysisView view = analysisViews[i];
       final Package pkg = packageEntries[i];
       final String devVersion = pkg.latestVersion != pkg.latestDevVersion
           ? pkg.latestDevVersion

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -66,14 +66,9 @@ class SearchBackend {
         versionList.where((pv) => pv != null),
         key: (PackageVersion pv) => pv.package);
 
-    final List<AnalysisView> analysisViews = await Future.wait(packages.map(
-      (Package p) async {
-        if (p == null) return null;
-        final PackageVersion pv = versions[p.name];
-        return new AnalysisView(
-            await analyzerClient.getAnalysisData(pv.package, pv.version));
-      },
-    ));
+    final List<AnalysisView> analysisViews =
+        await analyzerClient.getAnalysisViews(packages.map((p) =>
+            p == null ? null : new AnalysisKey(p.name, p.latestVersion)));
 
     final List<PackageDocument> results = new List(packages.length);
     for (int i = 0; i < packages.length; i++) {

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -35,25 +35,30 @@ class AnalyzerClient {
   final String _analyzerServiceHttpHostPort;
   AnalyzerClient(this._analyzerServiceHttpHostPort);
 
-  Future<AnalysisView> getAnalysisView(String package, String version) async {
-    return new AnalysisView(await getAnalysisData(package, version));
+  Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) {
+    return Future.wait(keys.map(getAnalysisView));
+  }
+
+  Future<AnalysisView> getAnalysisView(AnalysisKey key) async {
+    return new AnalysisView(await getAnalysisData(key));
   }
 
   /// Gets the analysis data from the analyzer service via HTTP.
-  Future<AnalysisData> getAnalysisData(String package, String version) async {
-    final String cachedContent =
-        await analyzerMemcache?.getContent(package, version, panaVersion);
+  Future<AnalysisData> getAnalysisData(AnalysisKey key) async {
+    if (key == null) return null;
+    final String cachedContent = await analyzerMemcache?.getContent(
+        key.package, key.version, panaVersion);
     if (cachedContent != null) {
       return new AnalysisData.fromJson(JSON.decode(cachedContent));
     }
     final String uri =
-        '$_analyzerServiceHttpHostPort/packages/$package/$version?panaVersion=$panaVersion';
+        '$_analyzerServiceHttpHostPort/packages/${key.package}/${key.version}?panaVersion=$panaVersion';
     try {
       final http.Response rs = await _client.get(uri);
       if (rs.statusCode == 200) {
         final String content = rs.body;
         await analyzerMemcache?.setContent(
-            package, version, panaVersion, content);
+            key.package, key.version, panaVersion, content);
         return new AnalysisData.fromJson(JSON.decode(content));
       }
     } catch (e, st) {

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -9,6 +9,23 @@ import 'package:json_serializable/annotations.dart';
 
 part 'analyzer_service.g.dart';
 
+class AnalysisKey {
+  final String package;
+  final String version;
+
+  AnalysisKey(this.package, this.version);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AnalysisKey &&
+          package == other.package &&
+          version == other.version;
+
+  @override
+  int get hashCode => package.hashCode ^ version.hashCode;
+}
+
 /// These status codes mark the status of the analysis, not the result/report.
 enum AnalysisStatus {
   /// Analysis was aborted without a report.

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -232,13 +232,17 @@ class AnalyzerClientMock implements AnalyzerClient {
   AnalysisData mockAnalysisData;
 
   @override
-  Future<AnalysisData> getAnalysisData(String package, String version) async =>
+  Future<AnalysisData> getAnalysisData(AnalysisKey key) async =>
       mockAnalysisData;
 
   @override
   Future close() async => null;
 
   @override
-  Future<AnalysisView> getAnalysisView(String package, String version) async =>
-      new AnalysisView(await getAnalysisData(package, version));
+  Future<AnalysisView> getAnalysisView(AnalysisKey key) async =>
+      new AnalysisView(await getAnalysisData(key));
+
+  @override
+  Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) =>
+      Future.wait(keys.map(getAnalysisView));
 }


### PR DESCRIPTION
This is mostly a code cleanup, making all of the batched requests to use the same API method.

It is also a preparation for a batched request-response on the `analyzer` service. I believe we may gain a bit of latency if we do that, but it is not straightforward, because of the memcache.