### PR TITLE
New design: package show page + versions page

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -82,14 +82,14 @@ class TemplateService {
   }
 
   /// Renders the `views/v2/pkg/versions/index` template.
-  String renderNewPkgVersionsPage(String package, List<PackageVersion> versions,
+  String renderPkgVersionsPageV2(String package, List<PackageVersion> versions,
       List<Uri> versionDownloadUrls) {
     assert(versions.length == versionDownloadUrls.length);
 
     final Map<String, Object> values =
         _pkgVersionsValues(package, versions, versionDownloadUrls);
     final content = _renderTemplate('v2/pkg/versions/index', values);
-    return renderNewLayoutPage(content);
+    return renderLayoutPageV2(content);
   }
 
   /// Renders the `views/pkg/index.mustache` template.
@@ -163,7 +163,7 @@ class TemplateService {
     return _renderTemplate('pkg/analysis_tab', data);
   }
 
-  /// Renders the `views/private_keys/show.mustache` template.
+  /// Renders the `views/pkg/show.mustache` template.
   String renderPkgShowPage(
       Package package,
       List<PackageVersion> versions,
@@ -377,8 +377,8 @@ class TemplateService {
     return values;
   }
 
-  /// Renders the `views/private_keys/show.mustache` template.
-  String renderNewPkgShowPage(
+  /// Renders the `views/v2/pkg/show.mustache` template.
+  String renderPkgShowPageV2(
       Package package,
       List<PackageVersion> versions,
       List<Uri> versionDownloadUrls,
@@ -404,7 +404,7 @@ class TemplateService {
       isFlutterPlugin,
     );
     final content = _renderTemplate('v2/pkg/show', values);
-    return renderNewLayoutPage(
+    return renderLayoutPageV2(
       content,
       title: '${package.name} ${selectedVersion.id} | Dart Package',
       packageName: selectedVersion.package,
@@ -452,7 +452,7 @@ class TemplateService {
   }
 
   /// Renders the `views/v2/layout.mustache` template.
-  String renderNewLayoutPage(
+  String renderLayoutPageV2(
     String contentHtml, {
     String title: 'pub.dartlang.org',
     String packageName,
@@ -513,7 +513,7 @@ class TemplateService {
   }
 
   /// Renders the `views/v2/pagination.mustache` template.
-  String renderNewPagination(PageLinks pageLinks) {
+  String renderPaginationV2(PageLinks pageLinks) {
     final values = {
       'page_links': pageLinks.hrefPatterns(),
     };

--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -1,0 +1,237 @@
+
+<!DOCTYPE html>
+<html lang="en-us" itemscope itemtype="http://schema.org/CreativeWork">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>foobar_pkg 0.1.1 | Dart Package</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
+  <meta itemprop="image" content="/static/img/dart-logo-400x400.png" />
+    <link rel="shortcut icon" href="/static/favicon.ico" />
+    <meta itemprop="name" content="foobar_pkg - a Dart package" />
+    <meta name="description" content="foobar_pkg - my package description" />
+    <meta itemprop="description" content="foobar_pkg - my package description" />
+    <link href="/static/github.css" rel="stylesheet" />
+  <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
+  <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
+  <script src="/static/v2/js/script.js" defer></script>
+  <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-26406144-13', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+</head>
+<body>
+<header class="site-header">
+  <h1 class="_visuallyhidden">Dart pub</h1>
+  <button class="hamburger"></button>
+  <div class="mask"></div>
+  <div class="nav-wrap">
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+      <div class="_flex-space"></div>
+      <button class="close"></button>
+    </div>
+    <nav class="site-nav">
+      <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/get-started">Getting Started</a>
+      <div class="sub-wrap">
+        <button class="button">Docs</button>
+        <div class="sub-nav">
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/get-started">Getting Started</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/dependencies">Dependencies</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/pubspec">Pubspec Format</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/package-layout">Package Layout Conventions</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/assets-and-transformers">Assets and Transformers</a>
+          <div class="title">reference</div>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/faq#pub">FAQ</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/glossary">Glossary</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/versioning">Versioning Philosophy</a>
+        </div>
+      </div>
+      <div class="sub-wrap">
+        <button class="button">commands</button>
+        <div class="sub-nav">
+          <div class="title">pub commands</div>
+          <ul class="command-list">
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-build.html">pub build</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-cache.html">pub cache</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-deps.html">pub deps</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-get.html">pub get</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-global.html">pub global</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-lish.html">pub publish</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-run.html">pub run</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-serve.html">pub serve</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-upgrade.html">pub upgrade</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-uploader.html">pub uploader</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>
+
+  <div class="_banner-bg">
+    <main class="package-banner">
+      <form class="search-bar" action="/search">
+        <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus>
+        <button class="icon"></button>
+      </form>
+    </main>
+  </div>
+
+
+<main>
+  
+<div class="package-header">
+  <h2 class="title">foobar_pkg 0.1.1</h2>
+  <div class="metadata">
+    Published <span>Jan 1, 2014</span>
+    <!-- &bull; Downloads: X -->
+    
+  </div>
+</div>
+
+<div class="package-container">
+  <div class="main tabs-content">
+    <ul class="package-tabs js-tabs">
+        <li class="tab -active" data-name="pub-tab-readme">README.md</li>
+        <li class="tab " data-name="pub-tab-changelog">CHANGELOG.md</li>
+        <li class="tab " data-name="pub-tab-example">Example</li>
+      <li class="tab " data-name="pub-tab-installing">Installing</li>
+      <li class="tab" data-name="pub-tab-versions">Versions</li>
+      <li class="tab" data-name="score">
+        <div class="score-box"><span class="number -good">??</span><span class="text">????</span>
+        </div>
+      </li>
+    </ul>
+      <section class="content -active js-content markdown-body" data-name="pub-tab-readme">
+        <h1 id="test-package">Test Package</h1>
+<p>This is a readme file.</p>
+<pre><code class="language-dart">void main() {
+}
+</code></pre>
+
+      </section>
+      <section class="content  js-content markdown-body" data-name="pub-tab-changelog">
+        <h1 id="changelog">Changelog</h1>
+<p>0.1.1 - test package</p>
+
+      </section>
+      <section class="content  js-content markdown-body" data-name="pub-tab-example">
+        <p style="font-family: monospace"><b>example&#47;lib&#47;main.dart</b></p>
+<pre><code class="language-dart">main() {
+  print('Hello world!');
+}
+</code></pre>
+
+      </section>
+    <section class="content  js-content markdown-body" data-name="pub-tab-installing">
+      <h3>1. Depend on it</h3>
+      <p>Add this to your package's pubspec.yaml file:</p>
+      <pre><code class="language-yaml">
+dependencies:
+  <strong>foobar_pkg: &quot;^0.1.1&quot;</strong>
+
+</code></pre>
+      <h3>2. Install it</h3>
+      <p>You can install packages from the command line:</p>
+      <pre><code class="language-shell">
+$ <strong>pub get</strong>
+
+</code></pre>
+      <p>Alternatively, your editor might support &#x27;pub get&#x27;. Check the docs for your editor to learn more.</p>
+        <h3>3. Import it</h3>
+        <p>Now in your Dart code, you can use:
+        </p>
+        <pre><code class="language-dart">
+import 'package:foobar_pkg/foolib.dart';
+        </code></pre>
+    </section>
+    <section class="content js-content markdown-body" data-name="pub-tab-versions">
+      <table class="version-table">
+        <thead>
+        <tr>
+          <th>Version</th>
+          <th>Uploaded</th>
+          <th class="documentation" width="60">Documentation</th>
+          <th class="archive" width="60">Archive</th>
+        </tr>
+        </thead>
+          <tr>
+            <th>0.1.1</th>
+            <td>Jan 1, 2014</td>
+            <td class="documentation">
+              <a href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;"
+                 title="Go to the documentation of foobar_pkg 0.1.1">
+                <img src="&#x2F;static&#x2F;v2&#x2F;img&#x2F;ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
+              </a>
+            </td>
+            <td class="archive">
+              <a href="http:&#x2F;&#x2F;dart-example.com&#x2F;"
+                 title="Download foobar_pkg 0.1.1 archive">
+                <img src="&#x2F;static&#x2F;v2&#x2F;img&#x2F;ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1 archive" />
+              </a>
+            </td>
+          </tr>
+      </table>
+    </section>
+    <section class="content js-content markdown-body" data-name="score">
+      <p>(some content for the analysis results tab)</p>
+      
+    </section>
+  </div>
+
+  <aside class="sidebar sidebar-content">
+      <h3 class="title">About</h3>
+      <p>my package description</p>
+
+    <h3 class="title">Author</h3>
+    <div><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="icon-envelope">Email hans@juergen.com</i></a> Hans Juergen</span></div>
+
+      <h3 class="title">Homepage</h3>
+      <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
+
+      <h3 class="title">Documentation</h3>
+      <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+
+      <h3 class="title">Source code (hyperlinked)</h3>
+      <a class="link" href="https:&#x2F;&#x2F;www.crossdart.info&#x2F;p&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.crossdart.info&#x2F;p&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+
+    <h3 class="title">Uploader</h3>
+    <p>hans@juergen.com</p>
+
+      <h3 class="title">License</h3>
+      <p>BSD</p>
+
+    <h3 class="title">Share</h3>
+    <div class="g-plusone" data-annotation="none"></div>
+    <a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="dartlang">Tweet</a>
+  </aside>
+</div>
+
+<script src="/static/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+
+</main>
+
+<footer class="site-footer">
+  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+</footer>
+
+<script type="text/javascript">
+      (function() {
+        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+        po.src = 'https://apis.google.com/js/plusone.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+      })();
+    </script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+<script src="/static/v2/js/script.js" defer></script>
+</body>
+</html>

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -1,0 +1,229 @@
+
+<!DOCTYPE html>
+<html lang="en-us" itemscope itemtype="http://schema.org/CreativeWork">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>foobar_pkg 0.1.1 | Dart Package</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
+  <meta itemprop="image" content="/static/img/dart-logo-400x400.png" />
+    <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png" />
+    <meta itemprop="name" content="foobar_pkg - a Dart package" />
+    <meta name="description" content="foobar_pkg - my package description" />
+    <meta itemprop="description" content="foobar_pkg - my package description" />
+    <link href="/static/github.css" rel="stylesheet" />
+  <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
+  <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
+  <script src="/static/v2/js/script.js" defer></script>
+  <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-26406144-13', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+</head>
+<body>
+<header class="site-header">
+  <h1 class="_visuallyhidden">Dart pub</h1>
+  <button class="hamburger"></button>
+  <div class="mask"></div>
+  <div class="nav-wrap">
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+      <div class="_flex-space"></div>
+      <button class="close"></button>
+    </div>
+    <nav class="site-nav">
+      <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/get-started">Getting Started</a>
+      <div class="sub-wrap">
+        <button class="button">Docs</button>
+        <div class="sub-nav">
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/get-started">Getting Started</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/dependencies">Dependencies</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/pubspec">Pubspec Format</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/package-layout">Package Layout Conventions</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/assets-and-transformers">Assets and Transformers</a>
+          <div class="title">reference</div>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/faq#pub">FAQ</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/glossary">Glossary</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/versioning">Versioning Philosophy</a>
+        </div>
+      </div>
+      <div class="sub-wrap">
+        <button class="button">commands</button>
+        <div class="sub-nav">
+          <div class="title">pub commands</div>
+          <ul class="command-list">
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-build.html">pub build</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-cache.html">pub cache</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-deps.html">pub deps</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-get.html">pub get</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-global.html">pub global</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-lish.html">pub publish</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-run.html">pub run</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-serve.html">pub serve</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-upgrade.html">pub upgrade</a></li>
+            <li><a class="command" target="_blank" href="https://www.dartlang.org/tools/pub/cmd/pub-uploader.html">pub uploader</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>
+
+  <div class="_banner-bg">
+    <main class="package-banner">
+      <form class="search-bar" action="/search">
+        <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus>
+        <button class="icon"></button>
+      </form>
+    </main>
+  </div>
+
+
+<main>
+  
+<div class="package-header">
+  <h2 class="title">foobar_pkg 0.1.1</h2>
+  <div class="metadata">
+    Published <span>Jan 1, 2015</span>
+    <!-- &bull; Downloads: X -->
+      <div class="tags">
+        <a class="package-tag" href="/flutter/packages"></a>
+  </div>
+
+  </div>
+</div>
+
+<div class="package-container">
+  <div class="main tabs-content">
+    <ul class="package-tabs js-tabs">
+        <li class="tab -active" data-name="pub-tab-readme">README.md</li>
+        <li class="tab " data-name="pub-tab-changelog">CHANGELOG.md</li>
+      <li class="tab " data-name="pub-tab-installing">Installing</li>
+      <li class="tab" data-name="pub-tab-versions">Versions</li>
+      <li class="tab" data-name="score">
+        <div class="score-box"><span class="number -good">??</span><span class="text">????</span>
+        </div>
+      </li>
+    </ul>
+      <section class="content -active js-content markdown-body" data-name="pub-tab-readme">
+        <h1 id="test-package">Test Package</h1>
+<p>This is a readme file.</p>
+<pre><code class="language-dart">void main() {
+}
+</code></pre>
+
+      </section>
+      <section class="content  js-content markdown-body" data-name="pub-tab-changelog">
+        <h1 id="changelog">Changelog</h1>
+<p>0.1.1 - test package</p>
+
+      </section>
+    <section class="content  js-content markdown-body" data-name="pub-tab-installing">
+      <h3>1. Depend on it</h3>
+      <p>Add this to your package's pubspec.yaml file:</p>
+      <pre><code class="language-yaml">
+dependencies:
+  <strong>foobar_pkg: &quot;^0.1.1&quot;</strong>
+
+</code></pre>
+      <h3>2. Install it</h3>
+      <p>You can install packages from the command line:</p>
+      <pre><code class="language-shell">
+$ <strong>flutter packages get</strong>
+
+</code></pre>
+      <p>Alternatively, your editor might support &#x27;packages get&#x27;. Check the docs for your editor to learn more.</p>
+        <h3>3. Import it</h3>
+        <p>Now in your Dart code, you can use:
+        </p>
+        <pre><code class="language-dart">
+import 'package:foobar_pkg/foolib.dart';
+        </code></pre>
+    </section>
+    <section class="content js-content markdown-body" data-name="pub-tab-versions">
+      <table class="version-table">
+        <thead>
+        <tr>
+          <th>Version</th>
+          <th>Uploaded</th>
+          <th class="documentation" width="60">Documentation</th>
+          <th class="archive" width="60">Archive</th>
+        </tr>
+        </thead>
+          <tr>
+            <th>0.1.1</th>
+            <td>Jan 1, 2015</td>
+            <td class="documentation">
+              <a href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;"
+                 title="Go to the documentation of foobar_pkg 0.1.1">
+                <img src="&#x2F;static&#x2F;v2&#x2F;img&#x2F;ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
+              </a>
+            </td>
+            <td class="archive">
+              <a href="http:&#x2F;&#x2F;dart-example.com&#x2F;"
+                 title="Download foobar_pkg 0.1.1 archive">
+                <img src="&#x2F;static&#x2F;v2&#x2F;img&#x2F;ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1 archive" />
+              </a>
+            </td>
+          </tr>
+      </table>
+    </section>
+    <section class="content js-content markdown-body" data-name="score">
+      <p>(some content for the analysis results tab)</p>
+      
+    </section>
+  </div>
+
+  <aside class="sidebar sidebar-content">
+      <h3 class="title">About</h3>
+      <p>my package description</p>
+
+    <h3 class="title">Author</h3>
+    <div><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="icon-envelope">Email hans@juergen.com</i></a> Hans Juergen</span></div>
+
+      <h3 class="title">Homepage</h3>
+      <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
+
+      <h3 class="title">Documentation</h3>
+      <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+
+      <h3 class="title">Source code (hyperlinked)</h3>
+      <a class="link" href="https:&#x2F;&#x2F;www.crossdart.info&#x2F;p&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.crossdart.info&#x2F;p&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+
+    <h3 class="title">Uploader</h3>
+    <p>hans@juergen.com</p>
+
+
+    <h3 class="title">Share</h3>
+    <div class="g-plusone" data-annotation="none"></div>
+    <a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="dartlang">Tweet</a>
+  </aside>
+</div>
+
+<script src="/static/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+
+</main>
+
+<footer class="site-footer">
+  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+</footer>
+
+<script type="text/javascript">
+      (function() {
+        var po = document.createElement('script'); po.type = 'text/javascript'; po.async = true;
+        po.src = 'https://apis.google.com/js/plusone.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(po, s);
+      })();
+    </script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+<script src="/static/v2/js/script.js" defer></script>
+</body>
+</html>

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -146,8 +146,8 @@ class TemplateMock implements TemplateService {
 
   @override
   String renderNewLayoutPage(
-    String title,
     String contentHtml, {
+    String title: 'pub.dartlang.org',
     String packageName,
     String packageDescription,
     String faviconUrl,
@@ -200,7 +200,26 @@ class TemplateMock implements TemplateService {
   }
 
   @override
+  String renderNewPkgShowPage(
+      Package package,
+      List<PackageVersion> versions,
+      List<Uri> versionDownloadUrls,
+      PackageVersion selectedVersion,
+      PackageVersion latestStableVersion,
+      PackageVersion latestDevVersion,
+      int totalNumberOfVersions,
+      AnalysisView analysis) {
+    return Response;
+  }
+
+  @override
   String renderPkgVersionsPage(String package, List<PackageVersion> versions,
+      List<Uri> versionDownloadUrls) {
+    return Response;
+  }
+
+  @override
+  String renderNewPkgVersionsPage(String package, List<PackageVersion> versions,
       List<Uri> versionDownloadUrls) {
     return Response;
   }

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -145,7 +145,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderNewLayoutPage(
+  String renderLayoutPageV2(
     String contentHtml, {
     String title: 'pub.dartlang.org',
     String packageName,
@@ -167,7 +167,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderNewPagination(PageLinks pageLinks) {
+  String renderPaginationV2(PageLinks pageLinks) {
     return Response;
   }
 
@@ -200,7 +200,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderNewPkgShowPage(
+  String renderPkgShowPageV2(
       Package package,
       List<PackageVersion> versions,
       List<Uri> versionDownloadUrls,
@@ -219,7 +219,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderNewPkgVersionsPage(String package, List<PackageVersion> versions,
+  String renderPkgVersionsPageV2(String package, List<PackageVersion> versions,
       List<Uri> versionDownloadUrls) {
     return Response;
   }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -61,6 +61,19 @@ void main() {
       expectGoldenFile(html, 'pkg_show_page.html');
     });
 
+    test('package show page v2', () {
+      final String html = templates.renderPkgShowPageV2(
+          testPackage,
+          [testPackageVersion],
+          [Uri.parse('http://dart-example.com/')],
+          testPackageVersion,
+          testPackageVersion,
+          testPackageVersion,
+          1,
+          new MockAnalysisView()..licenseText = 'BSD');
+      expectGoldenFile(html, 'v2/pkg_show_page.html');
+    });
+
     test('package show page with flutter_plugin', () {
       final String html = templates.renderPkgShowPage(
           testPackage,
@@ -72,6 +85,19 @@ void main() {
           1,
           new MockAnalysisView()..platforms = ['flutter']);
       expectGoldenFile(html, 'pkg_show_page_flutter_plugin.html');
+    });
+
+    test('package show page with flutter_plugin v2', () {
+      final String html = templates.renderPkgShowPageV2(
+          testPackage,
+          [flutterPackageVersion],
+          [Uri.parse('http://dart-example.com/')],
+          flutterPackageVersion,
+          flutterPackageVersion,
+          flutterPackageVersion,
+          1,
+          new MockAnalysisView()..platforms = ['flutter']);
+      expectGoldenFile(html, 'v2/pkg_show_page_flutter_plugin.html');
     });
 
     test('package analysis tab', () async {

--- a/app/views/v2/pkg/show.mustache
+++ b/app/views/v2/pkg/show.mustache
@@ -1,0 +1,147 @@
+{{! Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="package-header">
+  <h2 class="title">{{package.name}} {{package.selected_version.version}}</h2>
+  <div class="metadata">
+    Published <span>{{package.short_created}}</span>
+    <!-- &bull; Downloads: X -->
+    {{#package.latest.should_show}}
+      &bull; Updated:
+      <span><a href="/experimental/packages/{{package.name}}/versions/{{package.latest.stable_href}}">{{package.latest.stable_name}}</a></span>
+      {{#package.latest.should_show_dev}}
+        /
+        <span><a href="/experimental/packages/{{package.name}}/versions/{{package.latest.dev_href}}">{{package.latest.dev_name}}</a></span>
+      {{/package.latest.should_show_dev}}
+    {{/package.latest.should_show}}
+    {{& package.tags_html}}
+  </div>
+</div>
+
+<div class="package-container">
+  <div class="main tabs-content">
+    <ul class="package-tabs js-tabs">
+      {{#tabs}}
+        <li class="tab {{active}}" data-name="pub-tab-{{id}}">{{title}}</li>
+      {{/tabs}}
+      <li class="tab {{#has_no_file_tab}}-active{{/has_no_file_tab}}" data-name="pub-tab-installing">Installing</li>
+      <li class="tab" data-name="pub-tab-versions">Versions</li>
+      <li class="tab" data-name="score">
+        <div class="score-box"><span class="number -good">??</span><span class="text">????</span>
+        </div>
+      </li>
+    </ul>
+    {{#tabs}}
+      <section class="content {{active}} js-content markdown-body" data-name="pub-tab-{{id}}">
+        {{&content}}
+      </section>
+    {{/tabs}}
+    <section class="content {{#has_no_file_tab}}-active{{/has_no_file_tab}} js-content markdown-body" data-name="pub-tab-installing">
+      <h3>1. Depend on it</h3>
+      <p>Add this to your package's pubspec.yaml file:</p>
+      <pre><code class="language-yaml">
+dependencies:
+  <strong>{{package.name}}: {{package.selected_version.example_version_constraint}}</strong>
+
+</code></pre>
+      <h3>2. Install it</h3>
+      <p>You can install packages from the command line:</p>
+      <pre><code class="language-shell">
+$ <strong>{{package.install_command}}</strong>
+
+</code></pre>
+      <p>Alternatively, your editor might support {{package.install_tool}}. Check the docs for your editor to learn more.</p>
+      {{#package.selected_version.has_libraries}}
+        <h3>3. Import it</h3>
+        <p>Now in your Dart code, you can use:
+        </p>
+        <pre><code class="language-dart">{{#package.selected_version.import_examples}}
+import 'package:{{package}}/{{library}}';
+{{/package.selected_version.import_examples}}
+        </code></pre>
+      {{/package.selected_version.has_libraries}}
+    </section>
+    <section class="content js-content markdown-body" data-name="pub-tab-versions">
+      <table class="version-table">
+        <thead>
+        <tr>
+          <th>Version</th>
+          <th>Uploaded</th>
+          <th class="documentation" width="60">Documentation</th>
+          <th class="archive" width="60">Archive</th>
+        </tr>
+        </thead>
+        {{#versions}}
+          <tr>
+            <th>{{version}}</th>
+            <td>{{short_created}}</td>
+            <td class="documentation">
+              <a href="{{documentation}}"
+                 title="Go to the documentation of {{package.name}} {{version}}">
+                <img src="{{icons.documentation}}" alt="Go to the documentation of {{package.name}} {{version}}" />
+              </a>
+            </td>
+            <td class="archive">
+              <a href="{{download_url}}"
+                 title="Download {{package.name}} {{version}} archive">
+                <img src="{{icons.download}}" alt="Download {{package.name}} {{version}} archive" />
+              </a>
+            </td>
+          </tr>
+        {{/versions}}
+      </table>
+      {{#show_versions_link}}
+        <p>
+          <a href="/experimental/packages/{{package.name}}/versions">
+            All {{version_count}} versions...
+          </a>
+        </p>
+      {{/show_versions_link}}
+    </section>
+    <section class="content js-content markdown-body" data-name="score">
+      <p>(some content for the analysis results tab)</p>
+      {{& package.analysis_html}}
+    </section>
+  </div>
+
+  <aside class="sidebar sidebar-content">
+    {{#package.description}}
+      <h3 class="title">About</h3>
+      <p>{{package.description}}</p>
+    {{/package.description}}
+
+    <h3 class="title">{{package.authors_title}}</h3>
+    <div>{{& package.authors_html}}</div>
+
+    {{#package.homepage}}
+      <h3 class="title">Homepage</h3>
+      <a class="link" href="{{package.homepage}}">{{package.nice_homepage}}</a>
+    {{/package.homepage}}
+
+    {{#package.documentation}}
+      <h3 class="title">Documentation</h3>
+      <a class="link" href="{{package.documentation}}">{{package.nice_documentation}}</a>
+    {{/package.documentation}}
+
+    {{#package.crossdart}}
+      <h3 class="title">Source code (hyperlinked)</h3>
+      <a class="link" href="{{package.crossdart}}">{{package.nice_crossdart}}</a>
+    {{/package.crossdart}}
+
+    <h3 class="title">{{package.uploaders_title}}</h3>
+    <p>{{& package.uploaders_html}}</p>
+
+    {{#package.license}}
+      <h3 class="title">License</h3>
+      <p>{{package.license}}</p>
+    {{/package.license}}
+
+    <h3 class="title">Share</h3>
+    <div class="g-plusone" data-annotation="none"></div>
+    <a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-hashtags="dartlang">Tweet</a>
+  </aside>
+</div>
+
+<script src="/static/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>

--- a/app/views/v2/pkg/tags.mustache
+++ b/app/views/v2/pkg/tags.mustache
@@ -1,0 +1,15 @@
+{{! Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+{{#has_tags}}
+  {{#wrapper_div}}<div class="tags">{{/wrapper_div}}
+  {{#tags}}
+    {{#href}}
+        <a class="package-tag" href="{{{href}}}">{{text}}</a>
+    {{/href}}
+    {{^href}}
+        <span class="package-tag">{{text}}</span>
+    {{/href}}
+  {{/tags}}
+  {{#wrapper_div}}</div>{{/wrapper_div}}
+{{/has_tags}}

--- a/app/views/v2/pkg/versions/index.mustache
+++ b/app/views/v2/pkg/versions/index.mustache
@@ -1,0 +1,35 @@
+{{! Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<h1>All versions of {{package.name}}</h1>
+<table class="version-table">
+  <thead>
+  <tr>
+    <th>Version</th>
+    <th>Uploaded</th>
+    <th class="documentation" width="80">Documentation</th>
+    <th class="archive" width="80">Archive</th>
+  </tr>
+  </thead>
+  <tbody>
+  {{#versions}}
+    <tr>
+      <td><strong>{{version}}</strong></td>
+      <td>{{short_created}}</td>
+      <td class="documentation">
+        <a href="{{documentation}}"
+           title="Go to the documentation of {{package.name}} {{version}}">
+          <img src="{{icons.documentation}}" alt="Go to the documentation of {{package.name}} {{version}}" />
+        </a>
+      </td>
+      <td class="archive">
+        <a href="{{download_url}}"
+           title="Download {{package.name}} {{version}} archive">
+          <img src="{{icons.download}}" alt="Download {{package.name}} {{version}} archive" />
+        </a>
+      </td>
+    </tr>
+  {{/versions}}
+  </tbody>
+</table>


### PR DESCRIPTION
I've tried to stick to the following refactor logic:
- Reuse as much as possible, don't duplicate code. I've extracted value calculation, old method goes to the front, new method afterward (that way the diff is reasonable).
- I've commented a few lines with //experimental_design: obsolete or new. These are to make it easier to clean up after the merge.


