### PR TITLE
Add Analysis to datastore head polling.

### DIFF
--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -23,7 +23,7 @@ class DatastoreHeadTaskSource extends DatastoreVersionsHeadTaskSource {
   final DatastoreDB _db;
   DatastoreHeadTaskSource(DatastoreDB db)
       : _db = db,
-        super(db, skipHistory: true);
+        super(db, TaskSourceModel.version, skipHistory: true);
 
   @override
   Future<bool> shouldYieldTask(Task task) async {

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -24,7 +24,7 @@ final _indexUpdateThreshold = const Duration(days: 1);
 class IndexUpdateTaskSource extends DatastoreVersionsHeadTaskSource {
   final BatchIndexUpdater _batchIndexUpdater;
   IndexUpdateTaskSource(DatastoreDB db, this._batchIndexUpdater)
-      : super(db, onlyLatest: true, sleep: const Duration(minutes: 30));
+      : super(db, TaskSourceModel.package, sleep: const Duration(minutes: 30));
 
   @override
   Future dbScanComplete(int count) async {


### PR DESCRIPTION
- The enum makes it explicit what model type we are polling for.
- Polling for new Analysis instances can remove the need for notification altogether, both for `search` and `dartdoc`.