### PR TITLE
New design: package list page.

### DIFF
--- a/app/lib/shared/platform.dart
+++ b/app/lib/shared/platform.dart
@@ -71,6 +71,12 @@ class PlatformPredicate {
     return new PlatformPredicate(required: required, prohibited: prohibited);
   }
 
+  String get single {
+    if (required == null || prohibited != null) return null;
+    if (required.length != 1) return null;
+    return required.single;
+  }
+
   bool get isNotEmpty => required != null || prohibited != null;
 
   bool matches(List<String> platforms) {

--- a/app/test/frontend/golden/v2/index_page.html
+++ b/app/test/frontend/golden/v2/index_page.html
@@ -81,9 +81,9 @@
         <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
-      <a class="link" href="/experimental/search?platforms=flutter">flutter packages</a>
-      <a class="link" href="/experimental/search?platforms=web">web packages</a>
-      <a class="link" href="/experimental/search?platforms=server">server packages</a>
+      <a class="link" href="/experimental/packages?platform=flutter">flutter packages</a>
+      <a class="link" href="/experimental/packages?platform=web">web packages</a>
+      <a class="link" href="/experimental/packages?platform=server">server packages</a>
     </main>
   </div>
 

--- a/app/test/frontend/golden/v2/pkg_index_page.html
+++ b/app/test/frontend/golden/v2/pkg_index_page.html
@@ -1,32 +1,19 @@
-{{! Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
-    for details. All rights reserved. Use of this source code is governed by a
-    BSD-style license that can be found in the LICENSE file. }}
 
 <!DOCTYPE html>
-<html lang="en-us" {{#package}}itemscope itemtype="http://schema.org/CreativeWork"{{/package}}>
+<html lang="en-us" >
 <head>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{{title}}</title>
+  <title>Packages</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/img/dart-logo-400x400.png" />
-  {{#favicon}}
-    <link rel="shortcut icon" href="{{{favicon}}}" />
-  {{/favicon}}
-  {{#package}}
-    <meta itemprop="name" content="{{package.name}} - a Dart package" />
-    <meta name="description" content="{{package.name}} - {{package.description}}" />
-    <meta itemprop="description" content="{{package.name}} - {{package.description}}" />
-    <link href="/static/github.css" rel="stylesheet" />
-  {{/package}}
-  {{^package}}
+    <link rel="shortcut icon" href="/static/favicon.ico" />
     <meta name="description" content="Pub is a package manager for the
         Dart programming language." />
-  {{/package}}
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
-  <link href="{{{static_assets_dir}}}/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="{{{static_assets_dir}}}/js/script.js" defer></script>
+  <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
+  <script src="/static/v2/js/script.js" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -35,9 +22,7 @@
       ga('create', 'UA-26406144-13', 'auto');
       ga('send', 'pageview');
     </script>
-  {{#include_survey}}
     <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
-  {{/include_survey}}
 </head>
 <body>
 <header class="site-header">
@@ -45,7 +30,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="{{{static_assets_dir}}}/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -87,35 +72,79 @@
   </div>
 </header>
 
-{{#default_banner}}
   <div class="_banner-bg">
     <main class="package-banner">
       <form class="search-bar" action="/experimental/search">
-        <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus{{#search_query}} value="{{search_query}}"{{/search_query}}>
+        <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus>
         <button class="icon"></button>
       </form>
     </main>
   </div>
-{{/default_banner}}
 
-{{#home_banner}}
-  <div class="_banner-bg">
-    <main class="home-banner">
-      <h2 class="_visuallyhidden">Dart package manager</h2><img class="logo" src="{{{static_assets_dir}}}/img/site-logo.svg" alt="Dart package manager">
-      <p class="text">Find and use packages for the <a target="_blank" href="https://www.dartlang.org">Dart programming language</a> to make Flutter and web apps.</p>
-      <form class="search-bar" action="/search">
-        <input class="input" name="q" placeholder="Search packages" autocomplete="on" autofocus />
-        <button class="icon"></button>
-      </form>
-      <a class="link" href="/experimental/packages?platform=flutter">flutter packages</a>
-      <a class="link" href="/experimental/packages?platform=web">web packages</a>
-      <a class="link" href="/experimental/packages?platform=server">server packages</a>
-    </main>
-  </div>
-{{/home_banner}}
 
 <main>
-  {{& content_html}}
+  
+<div class="list-filters">
+    <a class="filter " href="/experimental&#x2F;packages?platform=flutter">Flutter</a>
+    <a class="filter " href="/experimental&#x2F;packages?platform=web">Web</a>
+    <a class="filter " href="/experimental&#x2F;packages?platform=server">Server</a>
+    <a class="filter -active" href="/experimental&#x2F;packages">All</a>
+</div>
+
+<h1>Packages</h1>
+
+<p><br/></p>
+
+<ul class="package-list">
+    <li class="list-item -full">
+      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      </div>
+      <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
+      <p class="description">my package description</p>
+      <p class="metadata">
+        v <a href="/experimental&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
+        
+        • Updated: <span>Jan 1, 2014</span>
+        
+      </p>
+    </li>
+    <li class="list-item -full">
+      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      </div>
+      <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
+      <p class="description">my package description</p>
+      <p class="metadata">
+        v <a href="/experimental&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
+        
+        • Updated: <span>Jan 1, 2015</span>
+          
+        <a class="package-tag" href="/flutter/packages">Flutter</a>
+  
+
+      </p>
+    </li>
+</ul>
+
+  
+<ul class="pagination">
+    <li class="-disabled">
+      <a href="">
+        <span>&laquo;</span>
+      </a>
+    </li>
+    <li class="-active">
+      <a href="">
+        <span>1</span>
+      </a>
+    </li>
+    <li class="-disabled">
+      <a href="">
+        <span>&raquo;</span>
+      </a>
+    </li>
+</ul>
+
+
 </main>
 
 <footer class="site-footer">
@@ -132,6 +161,6 @@
       })();
     </script>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-<script src="{{{static_assets_dir}}}/js/script.js" defer></script>
+<script src="/static/v2/js/script.js" defer></script>
 </body>
 </html>

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -203,6 +203,12 @@ class TemplateMock implements TemplateService {
   }
 
   @override
+  String renderPkgIndexPageV2(
+      List<PackageView> packages, PageLinks links, String currentPlatform) {
+    return Response;
+  }
+
+  @override
   String renderPkgShowPage(
       Package package,
       List<PackageVersion> versions,

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -155,6 +155,22 @@ void main() {
       expectGoldenFile(html, 'pkg_index_page.html');
     });
 
+    test('package index page v2', () {
+      final String html = templates.renderPkgIndexPageV2([
+        new PackageView.fromModel(
+          package: testPackage,
+          version: testPackageVersion,
+          analysis: new MockAnalysisView(),
+        ),
+        new PackageView.fromModel(
+          package: testPackage,
+          version: flutterPackageVersion,
+          analysis: new MockAnalysisView(platforms: ['flutter']),
+        ),
+      ], new PackageLinks.empty(), null);
+      expectGoldenFile(html, 'v2/pkg_index_page.html');
+    });
+
     test('package versions page', () {
       final String html = templates.renderPkgVersionsPage(testPackage.name,
           [testPackageVersion], [Uri.parse('http://dart-example.com/')]);

--- a/app/views/v2/pkg/index.mustache
+++ b/app/views/v2/pkg/index.mustache
@@ -1,0 +1,34 @@
+{{! Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<div class="list-filters">
+  {{#platform_tabs}}
+    <a class="filter {{#active}}-active{{/active}}" href="/experimental{{href}}">{{text}}</a>
+  {{/platform_tabs}}
+</div>
+
+<h1>{{title}}</h1>
+{{{description_html}}}
+<p><br/></p>
+
+<ul class="package-list">
+  {{#packages}}
+    <li class="list-item -full">
+      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      </div>
+      <h3 class="title"><a href="/experimental{{url}}">{{name}}</a></h3>
+      <p class="description">{{desc}}</p>
+      <p class="metadata">
+        v <a href="/experimental{{url}}">{{version}}</a>
+        {{#show_dev_version}} / <a href="/experimental{{url}}/versions/{{dev_version_href}}">{{dev_version}}</a> {{/show_dev_version}}
+        • Updated: <span>{{last_uploaded}}</span>
+        {{& tags_html}}
+      </p>
+    </li>
+  {{/packages}}
+</ul>
+
+{{#has_packages}}
+  {{{pagination}}}
+{{/has_packages}}


### PR DESCRIPTION
This has a lot of overlap with the `/search` page, with the notable differences being:
- search has no platform-specific title and description
- package list page has no count on the number of packages
- package list includes the author (in the old design), while the search page didn't (in both) - TBD later

At first I've tried to merge this with the search page in one go, but ended up not doing that, rather doing it in separate steps (too many knobs involved, which may be better to do in isolation). In the end I expect that we'll have a unified `/packages` page with both the search functions and the platform switcher.