### PR TITLE
URI-based package memcache.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -108,8 +108,9 @@ Future<shelf.Response> debugHandler(shelf.Request request) async {
 }
 
 /// Handles requests for /
-Future<shelf.Response> indexHandler(_) async {
-  String pageContent = await backend.uiPackageCache?.getUIIndexPage(false);
+Future<shelf.Response> indexHandler(shelf.Request request) async {
+  String pageContent =
+      await backend.uiPackageCache?.getUIPageHtml(request.requestedUri.path);
   if (pageContent == null) {
     final versions =
         await backend.latestPackageVersions(limit: 5, devVersions: true);
@@ -118,14 +119,16 @@ Future<shelf.Response> indexHandler(_) async {
         await analyzerClient.getAnalysisViews(
             versions.map((pv) => new AnalysisKey(pv.package, pv.version)));
     pageContent = templateService.renderIndexPage(versions, analysisViews);
-    await backend.uiPackageCache?.setUIIndexPage(false, pageContent);
+    await backend.uiPackageCache
+        ?.setUIPageHtml(request.requestedUri.path, pageContent);
   }
   return htmlResponse(pageContent);
 }
 
 /// Handles requests for /experimental/
-Future<shelf.Response> indexHandlerV2(_) async {
-  String pageContent = await backend.uiPackageCache?.getUIIndexPage(true);
+Future<shelf.Response> indexHandlerV2(shelf.Request request) async {
+  String pageContent =
+      await backend.uiPackageCache?.getUIPageHtml(request.requestedUri.path);
   if (pageContent == null) {
     Future<String> searchAndRenderMiniList(SearchOrder order) async {
       final result = await searchService
@@ -160,7 +163,8 @@ Future<shelf.Response> indexHandlerV2(_) async {
     ]);
     pageContent = templateService.renderIndexPageV2(
         miniListHtmls[0], miniListHtmls[1], miniListHtmls[2]);
-    await backend.uiPackageCache?.setUIIndexPage(true, pageContent);
+    await backend.uiPackageCache
+        ?.setUIPageHtml(request.requestedUri.path, pageContent);
   }
   return htmlResponse(pageContent);
 }
@@ -597,8 +601,8 @@ Future<shelf.Response> _packageVersionHandlerHtml(
   final Stopwatch sw = new Stopwatch()..start();
   String cachedPage;
   if (backend.uiPackageCache != null) {
-    cachedPage = await backend.uiPackageCache
-        .getUIPackagePage(isV2, packageName, versionName);
+    cachedPage =
+        await backend.uiPackageCache.getUIPageHtml(request.requestedUri.path);
   }
 
   if (cachedPage == null) {
@@ -650,7 +654,7 @@ Future<shelf.Response> _packageVersionHandlerHtml(
 
     if (backend.uiPackageCache != null) {
       await backend.uiPackageCache
-          .setUIPackagePage(isV2, packageName, versionName, cachedPage);
+          .setUIPageHtml(request.requestedUri.path, cachedPage);
     }
     _packageOverallLatencyTracker.add(sw.elapsed);
   }

--- a/app/lib/shared/memcache.dart
+++ b/app/lib/shared/memcache.dart
@@ -40,9 +40,10 @@ class SimpleMemcache {
     return null;
   }
 
-  Future setText(String key, String content) async {
+  Future setText(String key, String content, {Duration expiration}) async {
     try {
-      await _memcache.set(_key(key), content, expiration: _expiration);
+      await _memcache.set(_key(key), content,
+          expiration: expiration ?? _expiration);
     } catch (e, st) {
       _logger.warning('Couldn\'t set memcache entry for $key', e, st);
     }


### PR DESCRIPTION
@mkustermann: I was going back-and-forth with this before introducing the v2-flag for the memcache. This one is a simpler solution, and I believe we are not exposing ourselves to cache-filling attacks (e.g. one the expected path values will be cached, and you cannot introduce new cached keys by altering the request URI). I'm not sure if it is a valid concern though...

wdyt?