### PR TITLE
New search score combination: text match is based on union, overall match is done with multiplication

### DIFF
--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -37,12 +37,12 @@ void main() {
         'totalCount': 2,
         'packages': [
           {
-            'package': 'angular_ui',
-            'score': closeTo(76.6, 0.1),
+            'package': 'angular',
+            'score': closeTo(100.0, 0.1),
           },
           {
-            'package': 'angular',
-            'score': closeTo(60.0, 0.1),
+            'package': 'angular_ui',
+            'score': closeTo(99.0, 0.1),
           },
         ],
       });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -58,7 +58,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(54.2, 0.1),
+              'score': closeTo(37.1, 0.1),
             }
           ],
         });
@@ -72,7 +72,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(15.0, 0.1),
+              'score': closeTo(20.3, 0.1),
             }
           ],
         });
@@ -87,7 +87,7 @@ void main() {
               'packages': [
                 {
                   'package': 'pkg_foo',
-                  'score': closeTo(15.0, 0.1),
+                  'score': closeTo(20.3, 0.1),
                 }
               ],
             });
@@ -101,7 +101,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(1.0, 0.1),
+              'score': closeTo(0.4, 0.1),
             }
           ],
         });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -386,27 +386,27 @@ MIT'''),
           {
             // should be the top
             'package': 'haversine',
-            'score': closeTo(77.4, 0.1),
+            'score': closeTo(100.0, 0.1),
           },
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(10.3, 0.1),
+            'score': closeTo(51.6, 0.1),
           },
           {
             // should be present
             'package': 'great_circle_distance',
-            'score': closeTo(10.3, 0.1),
+            'score': closeTo(51.0, 0.1),
           },
           {
             // not relevant
             'package': 'version',
-            'score': closeTo(5.4, 0.1),
+            'score': closeTo(7.3, 0.1),
           },
           {
             // should be present
             'package': 'reversi',
-            'score': closeTo(4.9, 0.1),
+            'score': closeTo(5.1, 0.1),
           },
         ]
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -91,29 +91,21 @@ void main() {
   group('Score', () {
     Score score;
     setUp(() {
-      score = new Score()..addValues({'a': 100.0, 'b': 30.0, 'c': 55.0}, 1.0);
-    });
-
-    test('add values with weight', () {
-      score.addValues({'c': 50.0, 'd': 10.0}, 0.1);
-      expect(score.values, {
-        'a': 100.0,
-        'b': 30.0,
-        'c': 60.0,
-        'd': 1.0,
-      });
+      score = new Score({'a': 100.0, 'b': 30.0, 'c': 55.0});
     });
 
     test('remove low scores', () {
-      expect(score.values, {
+      expect(score.getValues(), {
         'a': 100.0,
         'b': 30.0,
         'c': 55.0,
       });
-      score.removeLowScores(0.31);
-      expect(score.values, {
+      expect(score.removeLowValues(fraction: 0.31).getValues(), {
         'a': 100.0,
         'c': 55.0,
+      });
+      expect(score.removeLowValues(minValue: 56.0).getValues(), {
+        'a': 100.0,
       });
     });
   });
@@ -175,27 +167,27 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       await index.merge();
     });
 
-    test('normalized health scores', () {
+    test('health scores', () {
       expect(index.getHealthScore(['http', 'async', 'chrome_net']), {
-        'http': 100.0,
-        'async': 100.0,
-        'chrome_net': 50.0,
+        'http': 1.0,
+        'async': 1.0,
+        'chrome_net': 0.5,
       });
     });
 
     test('popularity scores', () {
       expect(index.getPopularityScore(['http', 'async', 'chrome_net']), {
-        'http': 70.0,
-        'async': 80.0,
+        'http': 0.7,
+        'async': 0.8,
         'chrome_net': 0.0,
       });
     });
 
     test('maintenance scores', () {
       expect(index.getMaintenanceScore(['http', 'async', 'chrome_net']), {
-        'http': 100.0,
-        'async': 100.0,
-        'chrome_net': 90.0,
+        'http': 1.0,
+        'async': 1.0,
+        'chrome_net': 0.9,
       });
     });
 
@@ -208,7 +200,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'async',
-            'score': closeTo(75.4, 0.1),
+            'score': closeTo(90.0, 0.1),
           },
         ]
       });
@@ -219,11 +211,15 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(new SearchQuery('composable'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 1,
+        'totalCount': 2,
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(31.2, 0.1),
+            'score': closeTo(50.1, 0.1),
+          },
+          {
+            'package': 'async',
+            'score': closeTo(3.9, 0.1),
           },
         ]
       });
@@ -234,11 +230,15 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(new SearchQuery('chrome.sockets'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 1,
+        'totalCount': 2,
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(33.2, 0.1),
+            'score': closeTo(22.8, 0.1),
+          },
+          {
+            'package': 'async',
+            'score': closeTo(3.9, 0.1),
           },
         ]
       });
@@ -253,7 +253,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(2.5, 0.1),
+            'score': closeTo(0.4, 0.1),
           },
         ]
       });
@@ -278,7 +278,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(9.6, 0.1),
+            'score': closeTo(16.0, 0.1),
           },
         ],
       });
@@ -337,8 +337,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 3,
         'packages': [
-          {'package': 'async', 'score': 80.0},
-          {'package': 'http', 'score': 70.0},
+          {'package': 'async', 'score': 0.8},
+          {'package': 'http', 'score': 0.7},
           {'package': 'chrome_net', 'score': 0.0},
         ],
       });
@@ -351,9 +351,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 3,
         'packages': [
-          {'package': 'http', 'score': 100.0},
-          {'package': 'async', 'score': 100.0},
-          {'package': 'chrome_net', 'score': 50.0},
+          {'package': 'http', 'score': 1.0},
+          {'package': 'async', 'score': 1.0},
+          {'package': 'chrome_net', 'score': 0.5},
         ],
       });
     });
@@ -365,9 +365,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 3,
         'packages': [
-          {'package': 'http', 'score': 100.0},
-          {'package': 'async', 'score': 100.0},
-          {'package': 'chrome_net', 'score': 90.0},
+          {'package': 'http', 'score': 1.0},
+          {'package': 'async', 'score': 1.0},
+          {'package': 'chrome_net', 'score': 0.9},
         ],
       });
     });

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -60,31 +60,31 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
         'packages': [
           {
             'package': 'travis',
-            'score': closeTo(60.0, 0.1),
-          },
-          {
-            'package': 'rainbow_vis',
-            'score': closeTo(11.3, 0.1),
-          },
-          {
-            'package': 'dartemis_transformer',
-            'score': closeTo(11.1, 0.1),
-          },
-          {
-            'package': 'w_transport',
-            'score': closeTo(11.0, 0.1),
-          },
-          {
-            'package': 'sass_transformer',
-            'score': closeTo(11.0, 0.1),
+            'score': closeTo(100.0, 0.1),
           },
           {
             'package': 'mongo_dart_query',
-            'score': closeTo(10.2, 0.1),
+            'score': closeTo(50.9, 0.1),
+          },
+          {
+            'package': 'rainbow_vis',
+            'score': closeTo(50.9, 0.1),
           },
           {
             'package': 'angular_aria',
-            'score': closeTo(10.2, 0.1),
+            'score': closeTo(50.9, 0.1),
+          },
+          {
+            'package': 'w_transport',
+            'score': closeTo(50.9, 0.1),
+          },
+          {
+            'package': 'sass_transformer',
+            'score': closeTo(50.9, 0.1),
+          },
+          {
+            'package': 'dartemis_transformer',
+            'score': closeTo(50.8, 0.1),
           },
         ],
       });


### PR DESCRIPTION
Improves `haversine` and `angular`, doesn't change `travis`. I think it also helps for `game`, but that and `travis` would really need the TF-IDF scoring for more improvements.