### PR TITLE
Fix CSS style clipping the search bar. Fixes #464.

### DIFF
--- a/static/v2/css/style.css
+++ b/static/v2/css/style.css
@@ -87,7 +87,7 @@ main{
 
 body{
   /* offset the body for the fixed header */
-  padding-top: 56px;
+  padding-top: 76px;
 }
 
 .site-header{


### PR DESCRIPTION
Root cause: https://github.com/dart-lang/pub-dartlang-dart/pull/445, increase the padding of the link items, making the floating header larger.