### PR TITLE
Remove `version` from the site pubspec

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,6 +1,5 @@
 name: pub_dartlang_org
-version: 0.1.0
-author: Dart Team
+author: Dart Team <misc@dartlang.org>
 description: The pub.dartlang.org website.
 environment:
   sdk: ">=1.25.0-dev.9.0 <2.0.0"


### PR DESCRIPTION
A good hint to several tools that this is not published and should not
be published.