### PR TITLE
Lightweight analysis extract for better caching in user-facing views.

### DIFF
--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -9,7 +9,7 @@ import 'dart:math';
 import 'package:gcloud/db.dart' as db;
 import 'package:pub_semver/pub_semver.dart';
 
-import '../shared/analyzer_client.dart' show AnalysisView;
+import '../shared/analyzer_service.dart' show AnalysisExtract;
 import '../shared/model_properties.dart';
 import '../shared/utils.dart';
 
@@ -239,7 +239,7 @@ class PackageView {
   factory PackageView.fromModel({
     Package package,
     PackageVersion version,
-    AnalysisView analysis,
+    AnalysisExtract analysis,
   }) {
     final String devVersion =
         package != null && package.latestVersion != package.latestDevVersion

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -47,15 +47,15 @@ Future<SearchResultPage> _loadResultForPackages(
       packageEntries.map((p) => p.latestVersionKey).toList();
   if (versionKeys.isNotEmpty) {
     // Analysis data fetched concurrently to reduce overall latency.
-    final Future<List<AnalysisView>> analysisViewsFuture =
-        analyzerClient.getAnalysisViews(packageEntries
+    final Future<List<AnalysisExtract>> analysisExtractsFuture =
+        analyzerClient.getAnalysisExtracts(packageEntries
             .map((p) => new AnalysisKey(p.name, p.latestVersion)));
     final Future<List<PackageVersion>> allVersionsFuture =
         dbService.lookup(versionKeys);
 
     final List batchResults =
-        await Future.wait([analysisViewsFuture, allVersionsFuture]);
-    final List<AnalysisView> analysisViews = await batchResults[0];
+        await Future.wait([analysisExtractsFuture, allVersionsFuture]);
+    final List<AnalysisExtract> analysisExtracts = await batchResults[0];
     final List<PackageVersion> versions = await batchResults[1];
 
     final List<PackageView> resultPackages = new List.generate(
@@ -63,7 +63,7 @@ Future<SearchResultPage> _loadResultForPackages(
         (i) => new PackageView.fromModel(
               package: packageEntries[i],
               version: versions[i],
-              analysis: analysisViews[i],
+              analysis: analysisExtracts[i],
             ));
     return new SearchResultPage(query, totalCount, resultPackages);
   } else {

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -483,15 +483,15 @@ class TemplateService {
   }
 
   /// Renders the `views/index.mustache` template.
-  String renderIndexPage(
-      List<PackageVersion> recentPackages, List<AnalysisView> analysisViews) {
+  String renderIndexPage(List<PackageVersion> recentPackages,
+      List<AnalysisExtract> analysisExtracts) {
     final values = {
       'recent_packages': new List.generate(recentPackages.length, (index) {
         final PackageVersion version = recentPackages[index];
-        final AnalysisView analysis = analysisViews[index];
+        final AnalysisExtract analysis = analysisExtracts[index];
         final description = version.ellipsizedDescription;
         return {
-          'icons': _renderIconsColumnHtml(analysis.platforms),
+          'icons': _renderIconsColumnHtml(analysis?.platforms),
           'name': version.packageKey.id,
           'short_updated': version.shortCreated,
           'latest_version': {'version': version.id},

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -65,3 +65,22 @@ class AnalysisData extends Object with _$AnalysisDataSerializerMixin {
 
   factory AnalysisData.fromJson(Map json) => _$AnalysisDataFromJson(json);
 }
+
+@JsonSerializable()
+class AnalysisExtract extends Object with _$AnalysisExtractSerializerMixin {
+  final double health;
+  final double maintenance;
+  final double popularity;
+
+  final List<String> platforms;
+
+  AnalysisExtract({
+    this.health,
+    this.maintenance,
+    this.popularity,
+    this.platforms,
+  });
+
+  factory AnalysisExtract.fromJson(Map<String, dynamic> json) =>
+      _$AnalysisExtractFromJson(json);
+}

--- a/app/lib/shared/analyzer_service.g.dart
+++ b/app/lib/shared/analyzer_service.g.dart
@@ -50,3 +50,24 @@ abstract class _$AnalysisDataSerializerMixin {
         'analysisContent': analysisContent
       };
 }
+
+AnalysisExtract _$AnalysisExtractFromJson(Map<String, dynamic> json) =>
+    new AnalysisExtract(
+        health: (json['health'] as num)?.toDouble(),
+        maintenance: (json['maintenance'] as num)?.toDouble(),
+        popularity: (json['popularity'] as num)?.toDouble(),
+        platforms:
+            (json['platforms'] as List)?.map((e) => e as String)?.toList());
+
+abstract class _$AnalysisExtractSerializerMixin {
+  double get health;
+  double get maintenance;
+  double get popularity;
+  List<String> get platforms;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'health': health,
+        'maintenance': maintenance,
+        'popularity': popularity,
+        'platforms': platforms
+      };
+}

--- a/app/lib/shared/memcache.dart
+++ b/app/lib/shared/memcache.dart
@@ -18,6 +18,7 @@ const String v2IndexUiPageKey = 'experimental/pub_index';
 const String packageJsonPrefix = 'package_json_';
 const String packageUiPagePrefix = 'package_ui_';
 const String analyzerDataPrefix = 'dart_analyzer_api_';
+const String analyzerExtractPrefix = 'dart_analyzer_extract_';
 const String searchUiPagePrefix = 'dart_search_ui_';
 
 class SimpleMemcache {

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -152,8 +152,8 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderIndexPage(
-      List<PackageVersion> recentPackages, List<AnalysisView> analysisViews) {
+  String renderIndexPage(List<PackageVersion> recentPackages,
+      List<AnalysisExtract> analysisExtracts) {
     return Response;
   }
 
@@ -310,6 +310,7 @@ class SearchServiceMock implements SearchService {
 
 class AnalyzerClientMock implements AnalyzerClient {
   AnalysisData mockAnalysisData;
+  AnalysisExtract mockAnalysisExtract;
 
   @override
   Future<AnalysisData> getAnalysisData(AnalysisKey key) async =>
@@ -325,4 +326,13 @@ class AnalyzerClientMock implements AnalyzerClient {
   @override
   Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) =>
       Future.wait(keys.map(getAnalysisView));
+
+  @override
+  Future<AnalysisExtract> getAnalysisExtract(AnalysisKey key) async =>
+      mockAnalysisExtract;
+
+  @override
+  Future<List<AnalysisExtract>> getAnalysisExtracts(
+          Iterable<AnalysisKey> keys) =>
+      Future.wait(keys.map(getAnalysisExtract));
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -42,8 +42,8 @@ void main() {
         testPackageVersion,
         flutterPackageVersion,
       ], [
-        new MockAnalysisView(),
-        new MockAnalysisView(platforms: ['flutter']),
+        new AnalysisExtract(),
+        new AnalysisExtract(platforms: ['flutter']),
       ]);
       expectGoldenFile(html, 'index_page.html');
     });
@@ -53,21 +53,21 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['web']),
+          analysis: new AnalysisExtract(platforms: ['web']),
         ),
       ]);
       final updatedHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter']),
+          analysis: new AnalysisExtract(platforms: ['flutter']),
         ),
       ]);
       final newestHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter', 'server']),
+          analysis: new AnalysisExtract(platforms: ['flutter', 'server']),
         ),
       ]);
       final String html = templates.renderIndexPageV2(
@@ -80,21 +80,21 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter']),
+          analysis: new AnalysisExtract(platforms: ['flutter']),
         ),
       ]);
       final updatedHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter']),
+          analysis: new AnalysisExtract(platforms: ['flutter']),
         ),
       ]);
       final newestHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter', 'server']),
+          analysis: new AnalysisExtract(platforms: ['flutter', 'server']),
         ),
       ]);
       final String html = templates.renderIndexPageV2(
@@ -107,21 +107,21 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['server']),
+          analysis: new AnalysisExtract(platforms: ['server']),
         ),
       ]);
       final updatedHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['server']),
+          analysis: new AnalysisExtract(platforms: ['server']),
         ),
       ]);
       final newestHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['server', 'web']),
+          analysis: new AnalysisExtract(platforms: ['server', 'web']),
         ),
       ]);
       final String html = templates.renderIndexPageV2(
@@ -134,21 +134,21 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['web']),
+          analysis: new AnalysisExtract(platforms: ['web']),
         ),
       ]);
       final updatedHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['web']),
+          analysis: new AnalysisExtract(platforms: ['web']),
         ),
       ]);
       final newestHtml = templates.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['server', 'web']),
+          analysis: new AnalysisExtract(platforms: ['server', 'web']),
         ),
       ]);
       final String html = templates.renderIndexPageV2(
@@ -239,12 +239,12 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new MockAnalysisView(),
+          analysis: new AnalysisExtract(),
         ),
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter']),
+          analysis: new AnalysisExtract(platforms: ['flutter']),
         ),
       ], new PackageLinks.empty());
       expectGoldenFile(html, 'pkg_index_page.html');
@@ -255,12 +255,12 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new MockAnalysisView(),
+          analysis: new AnalysisExtract(),
         ),
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new MockAnalysisView(platforms: ['flutter']),
+          analysis: new AnalysisExtract(platforms: ['flutter']),
         ),
       ], new PackageLinks.empty(), null);
       expectGoldenFile(html, 'v2/pkg_index_page.html');
@@ -278,7 +278,7 @@ void main() {
           new PackageView.fromModel(
             package: testPackage,
             version: flutterPackageVersion,
-            analysis: new MockAnalysisView(platforms: ['flutter']),
+            analysis: new AnalysisExtract(platforms: ['flutter']),
           ),
         ],
         new PackageLinks(
@@ -299,7 +299,7 @@ void main() {
           new PackageView.fromModel(version: testPackageVersion),
           new PackageView.fromModel(
               version: flutterPackageVersion,
-              analysis: new MockAnalysisView(platforms: ['flutter'])),
+              analysis: new AnalysisExtract(platforms: ['flutter'])),
         ],
       );
       final String html =
@@ -316,7 +316,7 @@ void main() {
           new PackageView.fromModel(version: testPackageVersion),
           new PackageView.fromModel(
               version: flutterPackageVersion,
-              analysis: new MockAnalysisView(platforms: ['flutter'])),
+              analysis: new AnalysisExtract(platforms: ['flutter'])),
         ],
       );
       final String html =


### PR DESCRIPTION
While an analysis data object could be pretty large (depending on the number of libraries and their errors), this is only the strictly required data for the list views. Less data to push through the network, less to parse.