### PR TITLE
Remove pkg-prefix from user-facing URLs

### DIFF
--- a/app/lib/shared/platform.dart
+++ b/app/lib/shared/platform.dart
@@ -51,14 +51,7 @@ class PlatformPredicate {
     );
   }
 
-  factory PlatformPredicate.fromUri(Uri uri) {
-    final String pluralStr = uri.queryParameters['platforms'];
-    List<String> platforms;
-    if (pluralStr != null && pluralStr.isNotEmpty) {
-      platforms = pluralStr.split(',');
-    } else {
-      platforms = uri.queryParametersAll['platform'];
-    }
+  factory PlatformPredicate._compose(List<String> platforms) {
     final List<String> required = <String>[];
     final List<String> prohibited = <String>[];
     platforms?.forEach((String p) {
@@ -70,6 +63,20 @@ class PlatformPredicate {
     });
     return new PlatformPredicate(required: required, prohibited: prohibited);
   }
+
+  factory PlatformPredicate.fromUri(Uri uri) {
+    final String pluralStr = uri.queryParameters['platforms'];
+    List<String> platforms;
+    if (pluralStr != null && pluralStr.isNotEmpty) {
+      platforms = pluralStr.split(',');
+    } else {
+      platforms = uri.queryParametersAll['platform'];
+    }
+    return new PlatformPredicate._compose(platforms);
+  }
+
+  factory PlatformPredicate.parse(String platform) =>
+      new PlatformPredicate._compose(platform.split(','));
 
   bool get isSingle =>
       !(required == null || prohibited != null || required.length != 1);

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -267,7 +267,8 @@ void main() {
     });
 
     test('package index page with search v2', () {
-      final searchQuery = new SearchQuery('foobar', order: SearchOrder.top);
+      final searchQuery =
+          new SearchQuery.parse(text: 'foobar', order: SearchOrder.top);
       final String html = templates.renderPkgIndexPageV2(
         [
           new PackageView.fromModel(
@@ -314,7 +315,7 @@ void main() {
     });
 
     test('search page', () {
-      final query = new SearchQuery('foobar', offset: 0);
+      final query = new SearchQuery.parse(text: 'foobar', offset: 0);
       final resultPage = new SearchResultPage(
         query,
         2,
@@ -368,9 +369,9 @@ void main() {
 
     test('platform tabs: search', () {
       final String html = templates.renderPlatformTabs(
-          searchQuery: new SearchQuery(
-        'foo',
-        platformPredicate: new PlatformPredicate(required: ['server']),
+          searchQuery: new SearchQuery.parse(
+        text: 'foo',
+        platform: 'server',
       ));
       expectGoldenFile(html, 'v2/platform_tabs_search.html', isFragment: true);
     });
@@ -455,15 +456,15 @@ void main() {
 
   group('URLs', () {
     test('SearchLinks defaults', () {
-      final query = new SearchQuery('web framework');
+      final query = new SearchQuery.parse(text: 'web framework');
       final SearchLinks links = new SearchLinks(query, 100);
       expect(links.formatHref(1), '/search?q=web+framework&page=1');
       expect(links.formatHref(2), '/search?q=web+framework&page=2');
     });
 
     test('SearchLinks with type', () {
-      final query = new SearchQuery('web framework',
-          platformPredicate: new PlatformPredicate(required: ['server']));
+      final query =
+          new SearchQuery.parse(text: 'web framework', platform: 'server');
       final SearchLinks links = new SearchLinks(query, 100);
       expect(links.formatHref(1),
           '/search?q=web+framework&platforms=server&page=1');

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -30,8 +30,8 @@ void main() {
     });
 
     test('angular', () async {
-      final PackageSearchResult result = await index
-          .search(new SearchQuery('angular', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(text: 'angular', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -377,8 +377,8 @@ MIT'''),
     });
 
     test('hoversine', () async {
-      final PackageSearchResult result = await index
-          .search(new SearchQuery('haversine', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(text: 'haversine', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 5,

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/search/index_simple.dart';
-import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
 void main() {
@@ -193,7 +192,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package name match: async', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery('async'));
+          await index.search(new SearchQuery.parse(text: 'async'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -208,7 +207,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('description match: composable', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery('composable'));
+          await index.search(new SearchQuery.parse(text: 'composable'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -227,7 +226,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('readme match: chrome.sockets', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery('chrome.sockets'));
+          await index.search(new SearchQuery.parse(text: 'chrome.sockets'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -246,7 +245,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package prefix: chrome', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery('', packagePrefix: 'chrome'));
+          await index.search(new SearchQuery.parse(text: 'package:chrome'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -260,8 +259,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by text: single-letter t', () async {
-      final PackageSearchResult result =
-          await index.search(new SearchQuery('t', order: SearchOrder.text));
+      final PackageSearchResult result = await index
+          .search(new SearchQuery.parse(text: 't', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 0,
@@ -270,8 +269,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by text: double-letter tt', () async {
-      final PackageSearchResult result =
-          await index.search(new SearchQuery('tt', order: SearchOrder.text));
+      final PackageSearchResult result = await index
+          .search(new SearchQuery.parse(text: 'tt', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -286,7 +285,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by created: no filter', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery('', order: SearchOrder.created));
+          await index.search(new SearchQuery.parse(order: SearchOrder.created));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -299,8 +298,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by updated: no filter', () async {
-      final PackageSearchResult result =
-          await index.search(new SearchQuery('', order: SearchOrder.updated));
+      final PackageSearchResult result = await index
+          .search(new SearchQuery.parse(text: '', order: SearchOrder.updated));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -313,12 +312,10 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
     });
 
     test('order by updated: platform filter', () async {
-      final PackageSearchResult result = await index.search(new SearchQuery(
-        '',
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(
+        platform: 'web',
         order: SearchOrder.updated,
-        platformPredicate: new PlatformPredicate(
-          required: ['web'],
-        ),
       ));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
@@ -332,7 +329,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by popularity', () async {
       final PackageSearchResult result = await index
-          .search(new SearchQuery('', order: SearchOrder.popularity));
+          .search(new SearchQuery.parse(order: SearchOrder.popularity));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -346,7 +343,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by health', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery('', order: SearchOrder.health));
+          await index.search(new SearchQuery.parse(order: SearchOrder.health));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -360,7 +357,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by maintenance', () async {
       final PackageSearchResult result = await index
-          .search(new SearchQuery('', order: SearchOrder.maintenance));
+          .search(new SearchQuery.parse(order: SearchOrder.maintenance));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,

--- a/app/test/search/platform_rank_test.dart
+++ b/app/test/search/platform_rank_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     test('text search without platform', () async {
       final PackageSearchResult withoutPlatform =
-          await index.search(new SearchQuery('json'));
+          await index.search(new SearchQuery.parse(text: 'json'));
       expect(JSON.decode(JSON.encode(withoutPlatform)), {
         'indexUpdated': isNotNull,
         'totalCount': 4,
@@ -63,9 +63,9 @@ void main() {
 
     test('text search with platform', () async {
       final PackageSearchResult withPlatform =
-          await index.search(new SearchQuery(
-        'json',
-        platformPredicate: new PlatformPredicate(required: ['flutter']),
+          await index.search(new SearchQuery.parse(
+        text: 'json',
+        platform: 'flutter',
       ));
       expect(JSON.decode(JSON.encode(withPlatform)), {
         'indexUpdated': isNotNull,

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -52,8 +52,8 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
     });
 
     test('travis', () async {
-      final PackageSearchResult result = await index
-          .search(new SearchQuery('travis', order: SearchOrder.text));
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(text: 'travis', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 7,

--- a/app/test/shared/search_service_test.dart
+++ b/app/test/shared/search_service_test.dart
@@ -26,51 +26,80 @@ void main() {
 
   group('SearchQuery.isValid', () {
     test('empty', () {
-      expect(new SearchQuery(null).isValid, isFalse);
-      expect(new SearchQuery('').isValid, isFalse);
+      expect(new SearchQuery.parse().isValid, isFalse);
+      expect(new SearchQuery.parse().isValid, isFalse);
     });
 
     test('contains text', () {
-      expect(new SearchQuery('text').isValid, isTrue);
+      expect(new SearchQuery.parse(text: 'text').isValid, isTrue);
     });
 
     test('has package prefix', () {
-      expect(new SearchQuery('', packagePrefix: 'angular_').isValid, isTrue);
+      expect(new SearchQuery.parse(text: 'package:angular_').isValid, isTrue);
     });
 
     test('has text-based ordering', () {
-      expect(new SearchQuery('', order: SearchOrder.top).isValid, isTrue);
-      expect(new SearchQuery('', order: SearchOrder.text).isValid, isFalse);
-
-      expect(new SearchQuery('text', order: SearchOrder.top).isValid, isTrue);
-      expect(new SearchQuery('text', order: SearchOrder.text).isValid, isTrue);
+      expect(new SearchQuery.parse(order: SearchOrder.top).isValid, isTrue);
+      expect(new SearchQuery.parse(order: SearchOrder.text).isValid, isFalse);
 
       expect(
-          new SearchQuery(
-            '',
-            packagePrefix: 'angular_',
-            order: SearchOrder.top,
-          )
+          new SearchQuery.parse(text: 'text', order: SearchOrder.top).isValid,
+          isTrue);
+      expect(
+          new SearchQuery.parse(text: 'text', order: SearchOrder.text).isValid,
+          isTrue);
+
+      expect(
+          new SearchQuery.parse(
+                  text: 'package:angular_', order: SearchOrder.top)
               .isValid,
           isTrue);
       expect(
-          new SearchQuery(
-            '',
-            packagePrefix: 'angular_',
-            order: SearchOrder.text,
-          )
+          new SearchQuery.parse(
+                  text: 'package:angular_', order: SearchOrder.text)
               .isValid,
           isFalse);
     });
 
     test('has non-text-based ordering', () {
-      expect(new SearchQuery('', order: SearchOrder.created).isValid, isTrue);
-      expect(new SearchQuery('', order: SearchOrder.updated).isValid, isTrue);
+      expect(new SearchQuery.parse(order: SearchOrder.created).isValid, isTrue);
+      expect(new SearchQuery.parse(order: SearchOrder.updated).isValid, isTrue);
       expect(
-          new SearchQuery('', order: SearchOrder.popularity).isValid, isTrue);
-      expect(new SearchQuery('', order: SearchOrder.health).isValid, isTrue);
-      expect(
-          new SearchQuery('', order: SearchOrder.maintenance).isValid, isTrue);
+          new SearchQuery.parse(order: SearchOrder.popularity).isValid, isTrue);
+      expect(new SearchQuery.parse(order: SearchOrder.health).isValid, isTrue);
+      expect(new SearchQuery.parse(order: SearchOrder.maintenance).isValid,
+          isTrue);
+    });
+  });
+
+  group('Search URLs', () {
+    test('empty', () {
+      final query = new SearchQuery.parse();
+      expect(query.packagePrefix, isNull);
+      expect(query.toSearchLink(v2: true), '/packages');
+    });
+
+    test('platform: flutter', () {
+      final query = new SearchQuery.parse(platform: 'flutter');
+      expect(query.text, isNull);
+      expect(query.packagePrefix, isNull);
+      expect(query.toSearchLink(v2: true), '/flutter/packages');
+    });
+
+    test('package prefix: angular', () {
+      final query = new SearchQuery.parse(text: 'package:angular');
+      expect(query.text, isNull);
+      expect(query.packagePrefix, 'angular');
+      expect(query.toSearchLink(v2: true), '/packages?q=package%3Aangular');
+    });
+
+    test('complex search', () {
+      final query = new SearchQuery.parse(
+          text: 'package:angular widget', order: SearchOrder.top);
+      expect(query.text, 'widget');
+      expect(query.packagePrefix, 'angular');
+      expect(query.toSearchLink(v2: true),
+          '/packages?q=widget+package%3Aangular&sort=top');
     });
   });
 }


### PR DESCRIPTION
With this change, the user-facing URLs won't have `pkg-prefix` attribute handling, and if there is such value, it will always be part of the query text. The parsing of the query text happens in the frontend, and it will use separate attributes to pass the values to the service.

It also simplifies the `platform` parsing.