### PR TITLE
Remove packages excludes rule when building docker context

### DIFF
--- a/analyzer.yaml
+++ b/analyzer.yaml
@@ -21,5 +21,4 @@ automatic_scaling:
   max_num_instances: 4
 
 skip_files:
-- ^.*/packages.*$
 - ^\.git/.*$

--- a/app.yaml
+++ b/app.yaml
@@ -18,5 +18,4 @@ automatic_scaling:
   max_num_instances: 4
 
 skip_files:
-- ^.*/packages.*$
 - ^\.git/.*$

--- a/dartdoc.yaml
+++ b/dartdoc.yaml
@@ -18,5 +18,4 @@ automatic_scaling:
   max_num_instances: 2
 
 skip_files:
-- ^.*/packages.*$
 - ^\.git/.*$

--- a/search.yaml
+++ b/search.yaml
@@ -18,5 +18,4 @@ automatic_scaling:
   max_num_instances: 2
 
 skip_files:
-- ^.*/packages.*$
 - ^\.git/.*$


### PR DESCRIPTION
It turns out that this rule had a nasty side effect, since it excluded
any dart files matching it as well, which can cause failure to deploy:

  Unhandled exception:
  Could not import "package:package_config/packages.dart" from "package:analyzer/src/generated/source.dart":
    FileSystemException: Cannot open file, path = '/project/pkg/package_config/lib/packages.dart' (OS Error: No such file or directory, errno = 2)

This happens since `packages.dart` matches the mentioned exclude regexp rule
and is therefore not sent via the docker context to the building service (when
adding all 3rd party packages into pkg/* & using dependency_overrides this
issue surfaced).

The reason for this rule was originally due to our packages folders we
used to have.  Though `pub get` no longer creates them so there is no
need to have it.