### PR TITLE
Use memcached inside the containers again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM google/dart-runtime-base:1.25.0-dev.9.0
 
- # After install we remove the apt-index again to keep the docker image diff small.
- RUN apt-get update && \
-     apt-get upgrade -y && \
-     apt-get install -y git unzip && \
-     rm -rf /var/lib/apt/lists/*
+# We install memcached and remove the apt-index again to keep the
+# docker image diff small.
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y git memcached unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 # Let the pub server know that this is not a "typical" pub client but rather a bot.
 ENV PUB_ENVIRONMENT="bot.pub_dartlang_org.docker"
@@ -27,4 +28,4 @@ RUN pub get --offline
 # Clear out any arguments the base images might have set and ensure we start
 # memcached and wait for it to come up before running the Dart app.
 CMD []
-ENTRYPOINT /bin/bash /dart_runtime/dart_run.sh
+ENTRYPOINT service memcached start && sleep 1 && /bin/bash /dart_runtime/dart_run.sh

--- a/app/lib/shared/memcache.dart
+++ b/app/lib/shared/memcache.dart
@@ -7,11 +7,11 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:memcache/memcache.dart';
 
-const Duration indexUiPageExpiration = const Duration(minutes: 10);
-const Duration packageJsonExpiration = const Duration(minutes: 10);
-const Duration packageUiPageExpiration = const Duration(minutes: 10);
+const Duration indexUiPageExpiration = const Duration(minutes: 1);
+const Duration packageJsonExpiration = const Duration(minutes: 1);
+const Duration packageUiPageExpiration = const Duration(minutes: 1);
 const Duration analyzerDataExpiration = const Duration(minutes: 60);
-const Duration searchUiPageExpiration = const Duration(minutes: 10);
+const Duration searchUiPageExpiration = const Duration(minutes: 1);
 
 const String indexUiPageKey = 'pub_index';
 const String v2IndexUiPageKey = 'experimental/pub_index';

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -24,7 +24,7 @@ packages:
       name: appengine
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.1"
   archive:
     description:
       name: archive
@@ -126,7 +126,7 @@ packages:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.6"
+    version: "0.10.5"
   front_end:
     description:
       name: front_end
@@ -162,7 +162,7 @@ packages:
       name: googleapis_beta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.2"
+    version: "0.39.1"
   html:
     description:
       name: html
@@ -180,7 +180,7 @@ packages:
       name: http2
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.6"
   http_multi_server:
     description:
       name: http_multi_server
@@ -330,7 +330,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.5"
+    version: "0.5.4"
   pub_semver:
     description:
       name: pub_semver
@@ -342,7 +342,7 @@ packages:
       name: pub_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+4"
+    version: "0.1.2"
   quiver:
     description:
       name: quiver
@@ -402,7 +402,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   stream_channel:
     description:
       name: stream_channel
@@ -432,7 +432,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.26"
+    version: "0.12.27"
   typed_data:
     description:
       name: typed_data

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 dependencies:
   _popularity:
     path: ../pkg/_popularity
-  appengine: '^0.4.2'
+  appengine: '>=0.4.1 <0.4.2'
   args: '^0.13.7'
   gcloud: '>=0.4.0 <0.5.0'
   googleapis: '>=0.31.0 <0.37.0'


### PR DESCRIPTION
We need to **force-downgrade package:appengine** in order for this to work,
since package:appengine will first respect the environment variables
(given from GAE) and only later fall back to the local memcached (if
available)

We also reduce the expiration dates so all serving instances are
up-to-date after 1 minute.