### PR TITLE
Don't store Analysis regression for a short period.

### DIFF
--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -40,6 +40,20 @@ enum AnalysisStatus {
   success,
 }
 
+/// Gets a comparable level for analysis statuses. The bigger the better.
+int analysisStatusLevel(AnalysisStatus status) {
+  if (status == null) return -1;
+  switch (status) {
+    case AnalysisStatus.aborted:
+      return 0;
+    case AnalysisStatus.failure:
+      return 1;
+    case AnalysisStatus.success:
+      return 2;
+  }
+  return -1;
+}
+
 /// The data which is served thought the HTTP interface of the analyzer service.
 @JsonSerializable()
 class AnalysisData extends Object with _$AnalysisDataSerializerMixin {


### PR DESCRIPTION
Before:
- During the 3-hour outage, a few Analysis may have completed with tool failures, and we store them as aborted or failed. The task scheduler will pick these up after a day or two at most, and re-analysis will make them succeed.
- Worst case: a good package will be treated as bad for a few days at most.

After:
- If there is an Analysis that is a regression (e.g. it shows tool failure, while the previous one doesn't have failures), we won't store it for a set amount of days. Instead, the task scheduler will schedule it again, and we analyze it the next day, and the next. We keep doing it until either it is successful, or the age threshold is over, either way storing the result.
- Worst case: a bad package will be treated as good for two weeks longer than it usually would.  Unlikely though, because dependency changes don't trigger tool failures, unless we delete one of its dependencies.