### PR TITLE
Search service tracks new Analysis instances to update index.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -17,6 +17,7 @@ import 'package:pub_dartlang_org/shared/analyzer_memcache.dart';
 import 'package:pub_dartlang_org/shared/configuration.dart';
 import 'package:pub_dartlang_org/shared/task_client.dart';
 import 'package:pub_dartlang_org/shared/task_scheduler.dart';
+import 'package:pub_dartlang_org/shared/task_sources.dart';
 
 import 'package:pub_dartlang_org/search/backend.dart';
 import 'package:pub_dartlang_org/search/handlers.dart';
@@ -75,6 +76,12 @@ void _main(int isolateId) {
       [
         new ManualTriggerTaskSource(taskReceivePort),
         new IndexUpdateTaskSource(db.dbService, batchIndexUpdater),
+        new DatastoreVersionsHeadTaskSource(
+          db.dbService,
+          TaskSourceModel.analysis,
+          sleep: const Duration(minutes: 10),
+          skipHistory: true,
+        ),
       ],
     );
     scheduler.run();

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -89,11 +89,6 @@ class PanaRunner implements TaskRunner {
       // TODO: trigger re-analysis of packages depending on this one
     }
 
-    if (backendStatus.isLatestStable) {
-      // Do not await on the notification.
-      notificationClient.notifySearch(analysis.packageName);
-    }
-
     return backendStatus.wasRace;
   }
 }

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -16,11 +16,6 @@ import 'index_simple.dart';
 
 Logger _logger = new Logger('pub.search.updater');
 
-/// The time between building new PackageDocuments for the same package version.
-/// This affects the update frequency of metrics and data from analyzer
-/// (e.g. health score, dependencies...)
-final _indexUpdateThreshold = const Duration(days: 1);
-
 class IndexUpdateTaskSource extends DatastoreVersionsHeadTaskSource {
   final BatchIndexUpdater _batchIndexUpdater;
   IndexUpdateTaskSource(DatastoreDB db, this._batchIndexUpdater)
@@ -82,13 +77,7 @@ class BatchIndexUpdater implements TaskRunner {
   }
 
   @override
-  Future<bool> hasCompletedRecently(Task task) {
-    return packageIndex.containsPackage(
-      task.package,
-      version: task.version,
-      maxAge: _indexUpdateThreshold,
-    );
-  }
+  Future<bool> hasCompletedRecently(Task task) async => false;
 
   @override
   Future<bool> runTask(Task task) async {


### PR DESCRIPTION
Related to the discussions in #341. After this change, we could remove the notications entirely, reducing the direct dependencies between the services.