### PR TITLE
V2 design: Analysis tab doesn't need label

### DIFF
--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -88,8 +88,7 @@
       <li class="tab " data-name="pub-tab-installing">Installing</li>
       <li class="tab" data-name="pub-tab-versions">Versions</li>
       <li class="tab" data-name="score">
-        <div class="score-box"><span class="number -good">??</span><span class="text">????</span>
-        </div>
+        <div class="score-box"><span class="number -good">??</span></div>
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="pub-tab-readme">

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -90,8 +90,7 @@
       <li class="tab " data-name="pub-tab-installing">Installing</li>
       <li class="tab" data-name="pub-tab-versions">Versions</li>
       <li class="tab" data-name="score">
-        <div class="score-box"><span class="number -good">??</span><span class="text">????</span>
-        </div>
+        <div class="score-box"><span class="number -good">??</span></div>
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="pub-tab-readme">

--- a/app/views/v2/pkg/show.mustache
+++ b/app/views/v2/pkg/show.mustache
@@ -28,8 +28,7 @@
       <li class="tab {{#has_no_file_tab}}-active{{/has_no_file_tab}}" data-name="pub-tab-installing">Installing</li>
       <li class="tab" data-name="pub-tab-versions">Versions</li>
       <li class="tab" data-name="score">
-        <div class="score-box"><span class="number -good">??</span><span class="text">????</span>
-        </div>
+        <div class="score-box"><span class="number -good">??</span></div>
       </li>
     </ul>
     {{#tabs}}


### PR DESCRIPTION
I've tried a few things, e.g. putting "Analysis" as the label, move the score to the left or the right of it, but this simplest no-label version looked the best for me.