### PR TITLE
Extract overall score calculation from search index.

### DIFF
--- a/app/lib/search/scoring.dart
+++ b/app/lib/search/scoring.dart
@@ -4,6 +4,40 @@
 
 import 'dart:math' as math;
 
+final double popularityInTopRange = 0.5;
+final double healthInTopRange = 0.25;
+final double maintenanceInTopRange = 0.1;
+
+final double topRangeLowerBound = (1.0 - popularityInTopRange) *
+    (1.0 - healthInTopRange) *
+    (1.0 - maintenanceInTopRange);
+
+/// Calculates the overall score for a package.
+double calculateOverallScore({
+  double popularity,
+  double health,
+  double maintenance,
+  bool normalize: false,
+}) {
+  assert(popularity != null && popularity >= 0.0 && popularity <= 1.0);
+  assert(health != null && health >= 0.0 && health <= 1.0);
+  assert(maintenance != null && maintenance >= 0.0 && maintenance <= 1.0);
+
+  double transform(double value, double range) => (1.0 - range) + range * value;
+
+  // between [_rangeLowerBound = 0.3375 .. 1.0]
+  final m = transform(popularity, popularityInTopRange) *
+      transform(health, healthInTopRange) *
+      transform(maintenance, maintenanceInTopRange);
+
+  if (normalize) {
+    // transform it to [0.0 .. 1.0]
+    return (m - topRangeLowerBound) / (1 - topRangeLowerBound);
+  } else {
+    return m;
+  }
+}
+
 class Summary {
   final num max;
   final num min;

--- a/app/test/search/scoring_test.dart
+++ b/app/test/search/scoring_test.dart
@@ -7,6 +7,120 @@ import 'package:pub_dartlang_org/search/scoring.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('overall', () {
+    test('popularity', () {
+      expect(
+          calculateOverallScore(
+              popularity: 0.1, health: 0.0, maintenance: 0.0, normalize: false),
+          0.37125);
+      // P: 10, H: 0, M: 0 -> T: 5
+      expect(
+          calculateOverallScore(
+              popularity: 0.1, health: 0.0, maintenance: 0.0, normalize: true),
+          closeTo(0.0509, 0.0001));
+      expect(
+          calculateOverallScore(
+              popularity: 0.9, health: 0.0, maintenance: 0.0, normalize: false),
+          0.64125);
+      // P: 90, H: 0, M: 0 -> T: 46
+      expect(
+          calculateOverallScore(
+              popularity: 0.9, health: 0.0, maintenance: 0.0, normalize: true),
+          closeTo(0.4585, 0.0001));
+    });
+    test('health', () {
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.1, maintenance: 0.0, normalize: false),
+          0.34875);
+      // P: 0, H: 10, M: 0 -> T: 2
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.1, maintenance: 0.0, normalize: true),
+          closeTo(0.01698, 0.0001));
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.9, maintenance: 0.0, normalize: false),
+          0.43875);
+      // P: 0, H: 90, M: 0 -> T: 15
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.9, maintenance: 0.0, normalize: true),
+          closeTo(0.1528, 0.0001));
+    });
+    test('maintenance', () {
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.0, maintenance: 0.1, normalize: false),
+          0.34125);
+      // P: 0, H: 0, M: 10 -> T: 1
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.0, maintenance: 0.1, normalize: true),
+          closeTo(0.0057, 0.0001));
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.0, maintenance: 0.9, normalize: false),
+          closeTo(0.37125, 0.0001));
+      // P: 0, H: 0, M: 90 -> T: 5
+      expect(
+          calculateOverallScore(
+              popularity: 0.0, health: 0.0, maintenance: 0.9, normalize: true),
+          closeTo(0.05094, 0.0001));
+    });
+    test('high score', () {
+      expect(
+          calculateOverallScore(
+              popularity: 0.95,
+              health: 0.99,
+              maintenance: 0.99,
+              normalize: false),
+          closeTo(0.9716, 0.0001));
+      // P: 95, H: 99, M: 99 -> T: 96
+      expect(
+          calculateOverallScore(
+              popularity: 0.95,
+              health: 0.99,
+              maintenance: 0.99,
+              normalize: true),
+          closeTo(0.9571, 0.0001));
+    });
+    test('mediocre score', () {
+      expect(
+          calculateOverallScore(
+              popularity: 0.56,
+              health: 0.78,
+              maintenance: 0.54,
+              normalize: false),
+          closeTo(0.7031, 0.0001));
+      // P: 56, H: 78, M: 54 -> T: 55
+      expect(
+          calculateOverallScore(
+              popularity: 0.56,
+              health: 0.78,
+              maintenance: 0.54,
+              normalize: true),
+          closeTo(0.5519, 0.0001));
+    });
+    test('low score', () {
+      expect(
+          calculateOverallScore(
+              popularity: 0.12,
+              health: 0.34,
+              maintenance: 0.18,
+              normalize: false),
+          closeTo(0.4292, 0.0001));
+      // P: 12, H: 34, M: 18-> T: 14
+      expect(
+          calculateOverallScore(
+              popularity: 0.12,
+              health: 0.34,
+              maintenance: 0.18,
+              normalize: true),
+          closeTo(0.1385, 0.0001));
+    });
+  });
+
   group('summary', () {
     test('empty', () {
       expect(() => new Summary([]), throwsArgumentError);


### PR DESCRIPTION
This is required for the scoring bubble in listing results: the number displayed there and the overall ranking of packages should use the same source of truth.

The normalization preserves order, and it will give us the score to be used in the bubble, while the non-normalized value can be used in search ranking's multiplication.

I've put some hints in the test, to indicate what will be visible on the UI: `// P: 0, H: 0, M: 90 -> T: 5`, meaning 0 popularity, 0 health but 90 maintenance yields 5 as total score in the bubble.