### PR TITLE
Apply new package name policies

### DIFF
--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -139,7 +139,7 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
   }
 
   final cache = new AppEnginePackageMemcache(memcacheService);
-  initBackend(cache: cache, finishCallback: uploadFinished);
+  await initBackend(cache: cache, finishCallback: uploadFinished);
   registerSearchMemcache(new SearchMemcache(memcacheService));
 
   UploadSignerService uploadSigner;

--- a/app/lib/frontend/service_utils.dart
+++ b/app/lib/frontend/service_utils.dart
@@ -41,8 +41,10 @@ Future initSearchService() async {
   registerScopeExitCallback(searchService.close);
 }
 
-void initBackend(
-    {UIPackageCache cache, FinishedUploadCallback finishCallback}) {
+Future initBackend(
+    {UIPackageCache cache, FinishedUploadCallback finishCallback}) async {
+  registerExistingPackageValidator(new ExistingPackageValidator(dbService));
+  await existingPackageValidator.refresh();
   registerBackend(new Backend(dbService, tarballStorage,
       cache: cache, finishCallback: finishCallback));
 }
@@ -73,13 +75,13 @@ Future<String> obtainServiceAccountEmail() async {
 }
 
 Future withProdServices(Future fun()) {
-  return withAppEngineServices(() {
+  return withAppEngineServices(() async {
     if (!envConfig.hasGcloudKey) {
       throw 'Missing GCLOUD_* environments for package:appengine';
     }
     registerUploadSigner(
         new ServiceAccountBasedUploadSigner(activeConfiguration.credentials));
-    initBackend();
+    await initBackend();
     return fun();
   });
 }

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -761,7 +761,7 @@ void main() {
             final db = new DatastoreDBMock(transactionMock: transactionMock);
             final repo = new GCloudPackageRepository(db, tarballStorage);
             registerLoggedInUser('un@authorized.com');
-            repo
+            await repo
                 .upload(new Stream.fromIterable([tarball]))
                 .catchError(expectAsync2((error, _) {
               expect(error is pub_server.UnauthorizedAccessException, isTrue);
@@ -783,7 +783,7 @@ void main() {
             final db = new DatastoreDBMock(transactionMock: transactionMock);
             final repo = new GCloudPackageRepository(db, tarballStorage);
             registerLoggedInUser('un@authorized.com');
-            repo
+            await repo
                 .upload(new Stream.fromIterable([tarball]))
                 .catchError(expectAsync2((error, _) {
               expect(


### PR DESCRIPTION
The initial `refresh()` takes a couple of seconds at most, the subsequent ones just a few hundred milliseconds.  I've skipped tests, because the logic to test is ~4 lines, and straightforward, while adding it to the mocks will be a lot, without much additional value. If the policy goes ahead, we'd likely transform the uppercased-ones to lowercase and this code will be removed.