### PR TITLE
Rename V2 package tab IDs

### DIFF
--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -82,16 +82,16 @@
 <div class="package-container">
   <div class="main tabs-content">
     <ul class="package-tabs js-tabs">
-        <li class="tab -active" data-name="pub-tab-readme">README.md</li>
-        <li class="tab " data-name="pub-tab-changelog">CHANGELOG.md</li>
-        <li class="tab " data-name="pub-tab-example">Example</li>
-      <li class="tab " data-name="pub-tab-installing">Installing</li>
-      <li class="tab" data-name="pub-tab-versions">Versions</li>
-      <li class="tab" data-name="score">
+        <li class="tab -active" data-name="-readme-tab-">README.md</li>
+        <li class="tab " data-name="-changelog-tab-">CHANGELOG.md</li>
+        <li class="tab " data-name="-example-tab-">Example</li>
+      <li class="tab " data-name="-installing-tab-">Installing</li>
+      <li class="tab" data-name="-versions-tab-">Versions</li>
+      <li class="tab" data-name="-analysis-tab-">
         <div class="score-box"><span class="number -good">??</span></div>
       </li>
     </ul>
-      <section class="content -active js-content markdown-body" data-name="pub-tab-readme">
+      <section class="content -active js-content markdown-body" data-name="-readme-tab-">
         <h1 id="test-package">Test Package</h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
@@ -99,12 +99,12 @@
 </code></pre>
 
       </section>
-      <section class="content  js-content markdown-body" data-name="pub-tab-changelog">
+      <section class="content  js-content markdown-body" data-name="-changelog-tab-">
         <h1 id="changelog">Changelog</h1>
 <p>0.1.1 - test package</p>
 
       </section>
-      <section class="content  js-content markdown-body" data-name="pub-tab-example">
+      <section class="content  js-content markdown-body" data-name="-example-tab-">
         <p style="font-family: monospace"><b>example&#47;lib&#47;main.dart</b></p>
 <pre><code class="language-dart">main() {
   print('Hello world!');
@@ -112,7 +112,7 @@
 </code></pre>
 
       </section>
-    <section class="content  js-content markdown-body" data-name="pub-tab-installing">
+    <section class="content  js-content markdown-body" data-name="-installing-tab-">
       <h3>1. Depend on it</h3>
       <p>Add this to your package's pubspec.yaml file:</p>
       <pre><code class="language-yaml">
@@ -137,7 +137,7 @@ $ <strong>pub get</strong>
 import 'package:foobar_pkg/foolib.dart';
         </code></pre>
     </section>
-    <section class="content js-content markdown-body" data-name="pub-tab-versions">
+    <section class="content js-content markdown-body" data-name="-versions-tab-">
       <table class="version-table">
         <thead>
         <tr>
@@ -165,7 +165,7 @@ import 'package:foobar_pkg/foolib.dart';
           </tr>
       </table>
     </section>
-    <section class="content js-content markdown-body" data-name="score">
+    <section class="content js-content markdown-body" data-name="-analysis-tab-">
       <h4>Analysis</h4>
 
 <p>Last package analysis: <i></i> on .</p>

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -85,15 +85,15 @@
 <div class="package-container">
   <div class="main tabs-content">
     <ul class="package-tabs js-tabs">
-        <li class="tab -active" data-name="pub-tab-readme">README.md</li>
-        <li class="tab " data-name="pub-tab-changelog">CHANGELOG.md</li>
-      <li class="tab " data-name="pub-tab-installing">Installing</li>
-      <li class="tab" data-name="pub-tab-versions">Versions</li>
-      <li class="tab" data-name="score">
+        <li class="tab -active" data-name="-readme-tab-">README.md</li>
+        <li class="tab " data-name="-changelog-tab-">CHANGELOG.md</li>
+      <li class="tab " data-name="-installing-tab-">Installing</li>
+      <li class="tab" data-name="-versions-tab-">Versions</li>
+      <li class="tab" data-name="-analysis-tab-">
         <div class="score-box"><span class="number -good">??</span></div>
       </li>
     </ul>
-      <section class="content -active js-content markdown-body" data-name="pub-tab-readme">
+      <section class="content -active js-content markdown-body" data-name="-readme-tab-">
         <h1 id="test-package">Test Package</h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
@@ -101,12 +101,12 @@
 </code></pre>
 
       </section>
-      <section class="content  js-content markdown-body" data-name="pub-tab-changelog">
+      <section class="content  js-content markdown-body" data-name="-changelog-tab-">
         <h1 id="changelog">Changelog</h1>
 <p>0.1.1 - test package</p>
 
       </section>
-    <section class="content  js-content markdown-body" data-name="pub-tab-installing">
+    <section class="content  js-content markdown-body" data-name="-installing-tab-">
       <h3>1. Depend on it</h3>
       <p>Add this to your package's pubspec.yaml file:</p>
       <pre><code class="language-yaml">
@@ -131,7 +131,7 @@ $ <strong>flutter packages get</strong>
 import 'package:foobar_pkg/foolib.dart';
         </code></pre>
     </section>
-    <section class="content js-content markdown-body" data-name="pub-tab-versions">
+    <section class="content js-content markdown-body" data-name="-versions-tab-">
       <table class="version-table">
         <thead>
         <tr>
@@ -159,7 +159,7 @@ import 'package:foobar_pkg/foolib.dart';
           </tr>
       </table>
     </section>
-    <section class="content js-content markdown-body" data-name="score">
+    <section class="content js-content markdown-body" data-name="-analysis-tab-">
       <h4>Analysis</h4>
 
 <p>Last package analysis: <i></i> on .</p>

--- a/app/views/v2/pkg/show.mustache
+++ b/app/views/v2/pkg/show.mustache
@@ -23,20 +23,20 @@
   <div class="main tabs-content">
     <ul class="package-tabs js-tabs">
       {{#tabs}}
-        <li class="tab {{active}}" data-name="pub-tab-{{id}}">{{title}}</li>
+        <li class="tab {{active}}" data-name="-{{id}}-tab-">{{title}}</li>
       {{/tabs}}
-      <li class="tab {{#has_no_file_tab}}-active{{/has_no_file_tab}}" data-name="pub-tab-installing">Installing</li>
-      <li class="tab" data-name="pub-tab-versions">Versions</li>
-      <li class="tab" data-name="score">
+      <li class="tab {{#has_no_file_tab}}-active{{/has_no_file_tab}}" data-name="-installing-tab-">Installing</li>
+      <li class="tab" data-name="-versions-tab-">Versions</li>
+      <li class="tab" data-name="-analysis-tab-">
         <div class="score-box"><span class="number -good">??</span></div>
       </li>
     </ul>
     {{#tabs}}
-      <section class="content {{active}} js-content markdown-body" data-name="pub-tab-{{id}}">
+      <section class="content {{active}} js-content markdown-body" data-name="-{{id}}-tab-">
         {{&content}}
       </section>
     {{/tabs}}
-    <section class="content {{#has_no_file_tab}}-active{{/has_no_file_tab}} js-content markdown-body" data-name="pub-tab-installing">
+    <section class="content {{#has_no_file_tab}}-active{{/has_no_file_tab}} js-content markdown-body" data-name="-installing-tab-">
       <h3>1. Depend on it</h3>
       <p>Add this to your package's pubspec.yaml file:</p>
       <pre><code class="language-yaml">
@@ -57,7 +57,7 @@ import 'package:{{package}}/{{library}}';
         </code></pre>
       {{/package.selected_version.has_libraries}}
     </section>
-    <section class="content js-content markdown-body" data-name="pub-tab-versions">
+    <section class="content js-content markdown-body" data-name="-versions-tab-">
       <table class="version-table">
         <thead>
         <tr>
@@ -94,7 +94,7 @@ import 'package:{{package}}/{{library}}';
         </p>
       {{/show_versions_link}}
     </section>
-    <section class="content js-content markdown-body" data-name="score">
+    <section class="content js-content markdown-body" data-name="-analysis-tab-">
       {{^package.analysis_html}}
         <i>Scheduled for analysis.</i>
       {{/package.analysis_html}}


### PR DESCRIPTION
- analysis tab's name (`score`) was not following the same pattern
- `pub-tab-*` was hard to read, `-*-tab-` is better, and seems to be unique enough that we won't have name collisions from user-provided content.