### PR TITLE
Format overall score in package listing.

### DIFF
--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -224,6 +224,7 @@ class PackageView {
   final String ellipsizedDescription;
   final String shortUpdated;
   final List<String> authors;
+  final double overallScore;
   final List<String> platforms;
 
   PackageView({
@@ -233,6 +234,7 @@ class PackageView {
     this.ellipsizedDescription,
     this.shortUpdated,
     this.authors,
+    this.overallScore,
     this.platforms,
   });
 
@@ -252,6 +254,7 @@ class PackageView {
       ellipsizedDescription: version?.ellipsizedDescription,
       shortUpdated: version?.shortCreated ?? package?.shortUpdated,
       authors: version?.pubspec?.getAllAuthors(),
+      overallScore: analysis == null ? null : analysis.overallScore,
       platforms: analysis?.platforms,
     );
   }

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -129,6 +129,7 @@ class TemplateService {
     final packagesJson = [];
     for (int i = 0; i < packages.length; i++) {
       final view = packages[i];
+      final overallScore = view.overallScore;
       packagesJson.add({
         'url': '/packages/${view.name}',
         'name': view.name,
@@ -139,6 +140,8 @@ class TemplateService {
         'last_uploaded': view.shortUpdated,
         'desc': view.ellipsizedDescription,
         'tags_html': _renderTags(view.platforms), // used in v2 only
+        'overall_score': _formatScore(overallScore),
+        'overall_class': _classifyScore(overallScore),
       });
     }
 
@@ -219,7 +222,7 @@ class TemplateService {
       "has_tool_problems": toolProblems != null && toolProblems.isNotEmpty,
       'has_dependency': dependencies.isNotEmpty,
       'dependencies': dependencies,
-      'health': analysis.health,
+      'health': _formatScore(analysis.health),
     };
 
     return _renderTemplate('v2/pkg/analysis_tab', data);
@@ -847,6 +850,20 @@ String _getAuthorsHtml(List<String> authors, {bool clickableName: false}) {
       return '<span class="author"><i class="icon-envelope"></i> $escapedName</span>';
     }
   }).join('<br/>');
+}
+
+String _formatScore(double value) {
+  if (value == null) return '--';
+  if (value <= 0.0) return '0';
+  if (value >= 1.0) return '100';
+  return (value * 100.0).round().toString();
+}
+
+String _classifyScore(double value) {
+  if (value == null) return 'missing';
+  if (value <= 0.4) return 'rotten';
+  if (value <= 0.7) return 'good';
+  return 'solid';
 }
 
 String _getUploadersHtml(Package package) {

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -6,6 +6,8 @@
 library pub_dartlang_org.shared.analyzer_service;
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:pub_dartlang_org/search/scoring.dart'
+    show calculateOverallScore;
 
 part 'analyzer_service.g.dart';
 
@@ -103,4 +105,10 @@ class AnalysisExtract extends Object with _$AnalysisExtractSerializerMixin {
 
   factory AnalysisExtract.fromJson(Map<String, dynamic> json) =>
       _$AnalysisExtractFromJson(json);
+
+  double get overallScore => calculateOverallScore(
+        health: health ?? 0.0,
+        maintenance: maintenance ?? 0.0,
+        popularity: popularity ?? 0.0,
+      );
 }

--- a/app/test/frontend/golden/v2/analysis_tab_http.html
+++ b/app/test/frontend/golden/v2/analysis_tab_http.html
@@ -5,7 +5,7 @@
 <h4>Scores</h4>
 
 <ul>
-  <li>Health: 0.987411487018096</li>
+  <li>Health: 99</li>
   <li>Popularity: TBD</li>
   <li>Maintenance: TBD</li>
 </ul>

--- a/app/test/frontend/golden/v2/analysis_tab_mock.html
+++ b/app/test/frontend/golden/v2/analysis_tab_mock.html
@@ -5,7 +5,7 @@
 <h4>Scores</h4>
 
 <ul>
-  <li>Health: 0.95</li>
+  <li>Health: 95</li>
   <li>Popularity: TBD</li>
   <li>Maintenance: TBD</li>
 </ul>

--- a/app/test/frontend/golden/v2/pkg_index_page.html
+++ b/app/test/frontend/golden/v2/pkg_index_page.html
@@ -81,7 +81,8 @@
 
 <ul class="package-list">
     <li class="list-item -full">
-      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      <div class="score-box">
+        <span class="number -rotten">0</span>
       </div>
       <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>
@@ -93,7 +94,8 @@
       </p>
     </li>
     <li class="list-item -full">
-      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      <div class="score-box">
+        <span class="number -rotten">0</span>
       </div>
       <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>

--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -173,7 +173,7 @@ import 'package:foobar_pkg/foolib.dart';
 <h4>Scores</h4>
 
 <ul>
-  <li>Health: </li>
+  <li>Health: --</li>
   <li>Popularity: TBD</li>
   <li>Maintenance: TBD</li>
 </ul>

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -167,7 +167,7 @@ import 'package:foobar_pkg/foolib.dart';
 <h4>Scores</h4>
 
 <ul>
-  <li>Health: </li>
+  <li>Health: --</li>
   <li>Popularity: TBD</li>
   <li>Maintenance: TBD</li>
 </ul>

--- a/app/test/frontend/golden/v2/search_page.html
+++ b/app/test/frontend/golden/v2/search_page.html
@@ -79,7 +79,8 @@
 
 <ul class="package-list">
     <li class="list-item -full">
-      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      <div class="score-box">
+        <span class="number -rotten">0</span>
       </div>
       <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>
@@ -91,7 +92,8 @@
       </p>
     </li>
     <li class="list-item -full">
-      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      <div class="score-box">
+        <span class="number -rotten">0</span>
       </div>
       <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>

--- a/app/views/v2/pkg/index.mustache
+++ b/app/views/v2/pkg/index.mustache
@@ -14,7 +14,8 @@
 <ul class="package-list">
   {{#packages}}
     <li class="list-item -full">
-      <div class="score-box"><span class="number -solid">??</span><span class="text">?????</span>
+      <div class="score-box">
+        <span class="number -{{overall_class}}">{{overall_score}}</span>{{! <span class="text">?????</span> }}
       </div>
       <h3 class="title"><a href="/experimental{{url}}">{{name}}</a></h3>
       <p class="description">{{desc}}</p>

--- a/static/v2/css/style.css
+++ b/static/v2/css/style.css
@@ -456,7 +456,7 @@ main, .site-header {
   cursor: pointer
 }
 
-.score-box > .number{
+.score-box > .number {
   display: block;
   border-radius: 50%;
   width: 25px;
@@ -469,17 +469,22 @@ main, .site-header {
   font-weight: 500;
 }
 
-.score-box > .number.-solid{
+.score-box > .number.-solid {
   background: #0075c9;
 }
 
-.score-box > .number.-good{
+.score-box > .number.-good {
   background: #00c4b3;
 }
 
-.score-box > .number.-ok{
+.score-box > .number.-rotten {
+  background: #bb2400;
+}
+
+.score-box > .number.-missing {
   background: #ccc;
 }
+
 
 .score-box > .text{
   font-size: 14px;


### PR DESCRIPTION
Notes:
- I've removed the label for now, TBD if we really need it.
- Colors are not "rottentomato" yet, let's see how a 4-color version goes (2 good-ish, 1 meh, 1 for the unknown analysis).
- Analysis tab logo needs to get the AnalysisExtract to display the same number (will be in a follow-up PR)
- Search does have all the scores, but frontend not yet (pending on new pana version which will provide the maintenance score as part of the analysis).
- Scoring is a bit weird, see https://github.com/dart-lang/pub-dartlang-dart/issues/570
