### PR TITLE
Filter on exact phrases.

### DIFF
--- a/app/lib/search/README.md
+++ b/app/lib/search/README.md
@@ -110,6 +110,11 @@ and accumulate a score based on the following calculation:
   - `doc.size = the size of the document`, calculated as `sqrt(number of tokens)`.
   - `score(doc) = (matched token weights) / (query weight * doc.size)`
 
+The query text could contain exact phrases (text between quotation marks:
+`"exact phrase""`). When present, the result list is filtered by matching
+those phrases against the original text content, removing packages that doesn't
+have those.
+
 The text match score will then be either used directly (`SearchOrder.text`) or it
 will be combined with other scores (see: combined ranking).
 

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -6,6 +6,7 @@ final RegExp _separators =
     new RegExp(r'[_\.,;=\(\)\>\<\[\]\{\}\|\?\!\/\+\-\*]|\s');
 final RegExp _nonCharacterRegExp = new RegExp('[^a-z0-9]');
 final RegExp _multiWhitespaceRegExp = new RegExp('\\s+');
+final RegExp _exactTermRegExp = new RegExp(r'"([^"]+)"');
 
 String compactText(String text, {int maxLength: -1}) {
   if (text == null) return '';
@@ -33,3 +34,6 @@ Iterable<String> splitForIndexing(String text) {
   if (text == null || text.isEmpty) return new Iterable.empty();
   return text.split(_separators).where((s) => s.isNotEmpty);
 }
+
+List<String> extractExactPhrases(String text) =>
+    _exactTermRegExp.allMatches(text).map((m) => m.group(1)).toList();

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -230,6 +230,42 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       });
     });
 
+    test('typo match: utilito', () async {
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(text: 'utilito'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 2,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.07, 0.01)},
+          {'package': 'http', 'score': closeTo(0.02, 0.01)},
+        ]
+      });
+    });
+
+    test('exact phrase match: utilito', () async {
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(text: '"utilito"'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 0,
+        'packages': [],
+      });
+    });
+
+    test('exact phrase match: utility', () async {
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(text: '"utility"'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 2,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.07, 0.01)},
+          {'package': 'http', 'score': closeTo(0.02, 0.01)},
+        ],
+      });
+    });
+
     test('package prefix: chrome', () async {
       final PackageSearchResult result =
           await index.search(new SearchQuery.parse(text: 'package:chrome'));

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/search/text_utils.dart';
+
+void main() {
+  group('extact phrases', () {
+    test('no phrase', () {
+      expect(extractExactPhrases(''), isEmpty);
+      expect(extractExactPhrases('abc cde'), isEmpty);
+    });
+
+    test('no phrase with single "', () {
+      expect(extractExactPhrases('"'), isEmpty);
+      expect(extractExactPhrases('abc cde "'), isEmpty);
+    });
+
+    test('no empty phrases', () {
+      expect(extractExactPhrases('""'), isEmpty);
+      expect(extractExactPhrases('abc "" cde'), isEmpty);
+    });
+
+    test('entire text is a phrase', () {
+      expect(extractExactPhrases('"abc"'), ['abc']);
+      expect(extractExactPhrases('" abc cde "'), [' abc cde ']);
+    });
+
+    test('mixed phrase + non-phrase', () {
+      expect(extractExactPhrases('"abc" cde'), ['abc']);
+      expect(extractExactPhrases('123 "abc"'), ['abc']);
+      expect(extractExactPhrases('123 "abc" cde'), ['abc']);
+      expect(
+          extractExactPhrases(
+              'before "hello world" middle "greet from world" after'),
+          ['hello world', 'greet from world']);
+    });
+
+    test('multiple phrases', () {
+      expect(extractExactPhrases('"abc" "cde" "123 456"'),
+          ['abc', 'cde', '123 456']);
+    });
+  });
+}


### PR DESCRIPTION
My local test queries were fast enough (worst around 50ms, usually <10ms). We could create a slightly faster filtering with a more upfront work, but I don't think it is worth the complexity.