### PR TITLE
Upgrade pana to 0.6.0

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -56,7 +56,9 @@ class PanaRunner implements TaskRunner {
     }
 
     Summary summary = await analyze();
-    if (summary == null || (summary.toolProblems?.isNotEmpty ?? false)) {
+    final bool firstRunWithErrors =
+        summary?.suggestions?.where((s) => s.isError)?.isNotEmpty ?? false;
+    if (summary == null || firstRunWithErrors) {
       _logger.info('Retrying $task...');
       await new Future.delayed(new Duration(seconds: 15));
       summary = await analyze();
@@ -68,7 +70,9 @@ class PanaRunner implements TaskRunner {
     if (summary == null) {
       analysis.analysisStatus = AnalysisStatus.aborted;
     } else {
-      if (summary.toolProblems == null || summary.toolProblems.isEmpty) {
+      final bool lastRunWithErrors =
+          summary?.suggestions?.where((s) => s.isError)?.isNotEmpty ?? false;
+      if (!lastRunWithErrors) {
         analysis.analysisStatus = AnalysisStatus.success;
       } else {
         analysis.analysisStatus = AnalysisStatus.failure;

--- a/app/lib/analyzer/versions.dart
+++ b/app/lib/analyzer/versions.dart
@@ -5,7 +5,7 @@
 import 'package:pub_semver/pub_semver.dart';
 
 // keep in-sync with app/pubspec.yaml
-final String panaVersion = '0.5.1';
+final String panaVersion = '0.6.0';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
 // keep in-sync with app/script/setup-flutter.sh

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -198,7 +198,12 @@ class TemplateService {
         break;
     }
 
-    final List<String> toolProblems = analysis.toolProblems;
+    final List suggestions = analysis.suggestions?.map((suggestion) {
+      return {
+        'title': markdownToHtml(suggestion.title, null),
+        'description': markdownToHtml(suggestion.description, null),
+      };
+    })?.toList();
 
     List<Map> prepareDependencies(List<PkgDependency> list) {
       if (list == null || list.isEmpty) return const [];
@@ -224,8 +229,8 @@ class TemplateService {
           ? null
           : shortDateFormat.format(analysis.timestamp),
       'analysis_status': statusText,
-      'tool_problems': toolProblems,
-      "has_tool_problems": toolProblems != null && toolProblems.isNotEmpty,
+      'hasSuggestions': suggestions != null && suggestions.isNotEmpty,
+      'suggestions': suggestions,
       'has_dependency': hasDependency,
       'dependencies': {
         'has_direct': directDeps.isNotEmpty,

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:http/http.dart' as http;
@@ -21,7 +20,7 @@ import 'platform.dart';
 import 'popularity_storage.dart';
 import 'utils.dart';
 
-export 'package:pana/pana.dart' show LicenseFile, PkgDependency;
+export 'package:pana/pana.dart' show LicenseFile, PkgDependency, Suggestion;
 export 'analyzer_service.dart';
 
 /// Sets the analyzer client.
@@ -199,18 +198,7 @@ class AnalysisView {
     return list;
   }
 
-  /// Returns the raw health score between -1.0 and 1.0
-  /// These need to be normalized for search and frontend purposes.
-  double get health {
-    if (_data == null) return 0.0; // missing analysis
-    if (!hasAnalysisData) return -1.0; // aborted analysis
-    if (_summary.fitness == null) return 0.0; // missing fitness
+  double get health => _summary?.fitness?.healthScore ?? 0.0;
 
-    final score = (_summary.fitness.magnitude - _summary.fitness.shortcoming) /
-        _summary.fitness.magnitude;
-    return max(-1.0, min(1.0, score));
-  }
-
-  List<String> get toolProblems =>
-      _summary.toolProblems?.map((tp) => '${tp.tool}: ${tp.message}')?.toList();
+  List<Suggestion> get suggestions => _summary?.suggestions;
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -306,7 +306,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   path:
     description:
       name: path

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   yaml: '^2.1.12'
   # pana version to be pinned
   # keep in-sync with app/lib/analyzer/versions.dart
-  pana: '0.5.1'
+  pana: '0.6.0'
   # 3rd-party packages with pinned versions
   archive: '1.0.31'
   uuid: '0.5.3'

--- a/app/test/frontend/golden/v2/analysis_tab_mock.html
+++ b/app/test/frontend/golden/v2/analysis_tab_mock.html
@@ -10,9 +10,14 @@
   <li>Maintenance: TBD</li>
 </ul>
 
-<h4>Tool problems</h4>
+<h4>Suggestions</h4>
 <ul>
-    <li>dartfmt: Unable to run.</li>
+    <li>
+      <div><p>Fix <code>dartfmt</code>.</p>
+</div>
+      <blockquote><p>Running <code>dartfmt -n .</code> failed.</p>
+</blockquote>
+    </li>
 </ul>
 
 <h4>Dependencies</h4>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -6,10 +6,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:html/parser.dart';
-import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
@@ -183,7 +183,10 @@ void main() {
         timestamp: new DateTime.utc(2017, 10, 26, 14, 03, 06),
         platforms: ['web'],
         health: 0.95,
-        toolProblems: ['dartfmt: Unable to run.'],
+        suggestions: [
+          new Suggestion.error(
+              'Fix `dartfmt`.', 'Running `dartfmt -n .` failed.'),
+        ],
         directDependencies: [
           new PkgDependency(
             'http',
@@ -479,7 +482,7 @@ class MockAnalysisView implements AnalysisView {
   List<String> platforms;
 
   @override
-  List<String> toolProblems;
+  List<Suggestion> suggestions;
 
   MockAnalysisView({
     this.analysisStatus,
@@ -489,6 +492,6 @@ class MockAnalysisView implements AnalysisView {
     this.transitiveDependencies,
     this.devDependencies,
     this.health,
-    this.toolProblems,
+    this.suggestions,
   });
 }

--- a/app/views/v2/pkg/analysis_tab.mustache
+++ b/app/views/v2/pkg/analysis_tab.mustache
@@ -10,14 +10,17 @@
   <li>Maintenance: TBD</li>
 </ul>
 
-{{#has_tool_problems}}
-<h4>Tool problems</h4>
+{{#hasSuggestions}}
+<h4>Suggestions</h4>
 <ul>
-  {{#tool_problems}}
-    <li>{{.}}</li>
-  {{/tool_problems}}
+  {{#suggestions}}
+    <li>
+      <div>{{& title}}</div>
+      <blockquote>{{& description}}</blockquote>
+    </li>
+  {{/suggestions}}
 </ul>
-{{/has_tool_problems}}
+{{/hasSuggestions}}
 
 {{#has_dependency}}
 <h4>Dependencies</h4>


### PR DESCRIPTION
Fixing immediate breaking changes and easy-to-do substitution (`AnalysisView.health`). Maintenance score will be done in a subsequent PR.