### PR TITLE
Store maintenance score in Analysis and serve it to both search and frontend.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -264,6 +264,17 @@ class AnalysisBackend {
       await db.commit(deletes: obsoleteKeys);
     }
   }
+
+  /// Returns the publish date of a package.
+  Future<DateTime> getPublishDate(String package, String version) async {
+    final List<PackageVersion> list = await db.lookup([
+      db.emptyKey
+          .append(Package, id: package)
+          .append(PackageVersion, id: version)
+    ]);
+    final PackageVersion pv = list.single;
+    return pv?.created;
+  }
 }
 
 class BackendAnalysisStatus {

--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -80,6 +80,7 @@ Future<shelf.Response> packageHandler(shelf.Request request) async {
             panaVersion: analysis.panaVersion,
             flutterVersion: analysis.flutterVersion,
             analysisStatus: analysis.analysisStatus,
+            maintenanceScore: analysis.maintenanceScore,
             analysisContent: analysisContent)
         .toJson());
   } else if (requestMethod == 'POST') {

--- a/app/lib/analyzer/models.dart
+++ b/app/lib/analyzer/models.dart
@@ -132,6 +132,9 @@ class Analysis extends db.ExpandoModel {
   @AnalysisStatusProperty()
   AnalysisStatus analysisStatus;
 
+  @db.DoubleProperty()
+  double maintenanceScore;
+
   @db.BlobProperty()
   List<int> analysisJsonGz;
 

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -80,6 +80,11 @@ class PanaRunner implements TaskRunner {
       analysis.analysisJson = summary.toJson();
     }
 
+    final DateTime publishDate =
+        await _analysisBackend.getPublishDate(task.package, task.version);
+    analysis.maintenanceScore =
+        summary?.maintenance?.getMaintenanceScore(publishDate);
+
     final backendStatus = await _analysisBackend.storeAnalysis(analysis);
 
     try {

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -90,7 +90,7 @@ class AnalyzerClient {
     final view = await getAnalysisView(key);
     final extract = new AnalysisExtract(
       popularity: popularityStorage.lookup(key.package) ?? 0.0,
-      // TODO: set maintenance
+      maintenance: view.maintenanceScore,
       health: view.health,
       platforms: view.platforms,
       timestamp: new DateTime.now().toUtc(),
@@ -201,4 +201,6 @@ class AnalysisView {
   double get health => _summary?.fitness?.healthScore ?? 0.0;
 
   List<Suggestion> get suggestions => _summary?.suggestions;
+
+  double get maintenanceScore => _data?.maintenanceScore ?? 0.0;
 }

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -70,6 +70,7 @@ class AnalysisData extends Object with _$AnalysisDataSerializerMixin {
   final String flutterVersion;
   final AnalysisStatus analysisStatus;
   final Map analysisContent;
+  final double maintenanceScore;
 
   AnalysisData({
     this.packageName,
@@ -80,6 +81,7 @@ class AnalysisData extends Object with _$AnalysisDataSerializerMixin {
     this.flutterVersion,
     this.analysisStatus,
     this.analysisContent,
+    this.maintenanceScore,
   });
 
   factory AnalysisData.fromJson(Map json) => _$AnalysisDataFromJson(json);

--- a/app/lib/shared/analyzer_service.g.dart
+++ b/app/lib/shared/analyzer_service.g.dart
@@ -26,7 +26,8 @@ AnalysisData _$AnalysisDataFromJson(Map<String, dynamic> json) =>
             ? null
             : AnalysisStatus.values.singleWhere((x) =>
                 x.toString() == "AnalysisStatus.${json['analysisStatus']}"),
-        analysisContent: json['analysisContent'] as Map<String, dynamic>);
+        analysisContent: json['analysisContent'] as Map<String, dynamic>,
+        maintenanceScore: (json['maintenanceScore'] as num)?.toDouble());
 
 abstract class _$AnalysisDataSerializerMixin {
   String get packageName;
@@ -37,6 +38,7 @@ abstract class _$AnalysisDataSerializerMixin {
   String get flutterVersion;
   AnalysisStatus get analysisStatus;
   Map<dynamic, dynamic> get analysisContent;
+  double get maintenanceScore;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'packageName': packageName,
         'packageVersion': packageVersion,
@@ -47,7 +49,8 @@ abstract class _$AnalysisDataSerializerMixin {
         'analysisStatus': analysisStatus == null
             ? null
             : analysisStatus.toString().split('.')[1],
-        'analysisContent': analysisContent
+        'analysisContent': analysisContent,
+        'maintenanceScore': maintenanceScore
       };
 }
 

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -64,7 +64,8 @@ void main() {
           'panaVersion': '0.2.0',
           'flutterVersion': '0.0.11',
           'analysisStatus': 'success',
-          'analysisContent': {'content': 'from-pana'}
+          'analysisContent': {'content': 'from-pana'},
+          'maintenanceScore': 0.86,
         });
       });
 
@@ -81,6 +82,7 @@ void main() {
               'flutterVersion': '0.0.11',
               'analysisStatus': 'success',
               'analysisContent': null,
+              'maintenanceScore': 0.86,
             });
       });
 
@@ -95,7 +97,8 @@ void main() {
               'panaVersion': '0.2.0',
               'flutterVersion': '0.0.11',
               'analysisStatus': 'success',
-              'analysisContent': {'content': 'from-pana'}
+              'analysisContent': {'content': 'from-pana'},
+              'maintenanceScore': 0.86,
             });
       });
 
@@ -111,7 +114,8 @@ void main() {
               'panaVersion': '0.2.0',
               'flutterVersion': '0.0.11',
               'analysisStatus': 'success',
-              'analysisContent': {'content': 'from-pana'}
+              'analysisContent': {'content': 'from-pana'},
+              'maintenanceScore': 0.86,
             });
       });
     });
@@ -172,6 +176,11 @@ class MockAnalysisBackend implements AnalysisBackend {
   Future deleteObsoleteAnalysis(String package, String version) {
     throw 'Not implemented yet.';
   }
+
+  @override
+  Future<DateTime> getPublishDate(String package, String version) {
+    throw 'Not implemented yet.';
+  }
 }
 
 final Analysis testAnalysis = new Analysis()
@@ -182,4 +191,5 @@ final Analysis testAnalysis = new Analysis()
   ..panaVersion = '0.2.0'
   ..flutterVersion = '0.0.11'
   ..timestamp = new DateTime(2017, 06, 26, 12, 48, 00)
+  ..maintenanceScore = 0.86
   ..analysisJson = {'content': 'from-pana'};

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -484,6 +484,9 @@ class MockAnalysisView implements AnalysisView {
   @override
   List<Suggestion> suggestions;
 
+  @override
+  double maintenanceScore;
+
   MockAnalysisView({
     this.analysisStatus,
     this.timestamp,


### PR DESCRIPTION
Maintenance score depends on the publish date, and either we apply it in `AnalyzerClient` by querying the Datastore at the time of the query, or we store the score alongside the `Analysis` instance. I think the later is much better latency-wise, and we don't lose too much if the score drops only at regular analysis intervals (~ a month). 

Note: some of the staging data does not contain this field yet, because the version I've deployed in the morning didn't store it.