### PR TITLE
Display scores on analysis tab.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -182,7 +182,7 @@ class TemplateService {
   }
 
   /// Renders the `views/v2/pkg/analysis_tab.mustache` template.
-  String renderAnalysisTabV2(AnalysisView analysis) {
+  String renderAnalysisTabV2(AnalysisExtract extract, AnalysisView analysis) {
     if (analysis == null || !analysis.hasAnalysisData) return null;
 
     String statusText;
@@ -240,7 +240,9 @@ class TemplateService {
         'has_dev': devDeps.isNotEmpty,
         'dev': devDeps,
       },
-      'health': _formatScore(analysis.health),
+      'health': _formatScore(extract?.health),
+      'maintenance': _formatScore(extract?.maintenance),
+      'popularity': _formatScore(extract?.popularity),
     };
 
     return _renderTemplate('v2/pkg/analysis_tab', data);
@@ -453,7 +455,7 @@ class TemplateService {
         'license_html':
             _renderLicenses(selectedVersion.homepage, analysis?.licenses),
         'score_box_html': _renderScoreBox(extract?.overallScore),
-        'analysis_html': renderAnalysisTabV2(analysis),
+        'analysis_html': renderAnalysisTabV2(extract, analysis),
       },
       'versions': versionsJson,
       'show_versions_link': totalNumberOfVersions > versions.length,

--- a/app/test/frontend/golden/v2/analysis_tab_http.html
+++ b/app/test/frontend/golden/v2/analysis_tab_http.html
@@ -6,8 +6,8 @@
 
 <ul>
   <li>Health: 99</li>
-  <li>Popularity: TBD</li>
-  <li>Maintenance: TBD</li>
+  <li>Maintenance: 90</li>
+  <li>Popularity: 23</li>
 </ul>
 
 

--- a/app/test/frontend/golden/v2/analysis_tab_mock.html
+++ b/app/test/frontend/golden/v2/analysis_tab_mock.html
@@ -5,9 +5,9 @@
 <h4>Scores</h4>
 
 <ul>
-  <li>Health: 95</li>
-  <li>Popularity: TBD</li>
-  <li>Maintenance: TBD</li>
+  <li>Health: 90</li>
+  <li>Maintenance: 89</li>
+  <li>Popularity: 23</li>
 </ul>
 
 <h4>Suggestions</h4>

--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -174,8 +174,8 @@ import 'package:foobar_pkg/foolib.dart';
 
 <ul>
   <li>Health: --</li>
-  <li>Popularity: TBD</li>
-  <li>Maintenance: TBD</li>
+  <li>Maintenance: --</li>
+  <li>Popularity: --</li>
 </ul>
 
 

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -167,9 +167,9 @@ import 'package:foobar_pkg/foolib.dart';
 <h4>Scores</h4>
 
 <ul>
-  <li>Health: --</li>
-  <li>Popularity: TBD</li>
-  <li>Maintenance: TBD</li>
+  <li>Health: 99</li>
+  <li>Maintenance: 99</li>
+  <li>Popularity: 30</li>
 </ul>
 
 

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -259,7 +259,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderAnalysisTabV2(analysis) {
+  String renderAnalysisTabV2(extract, analysis) {
     return _response;
   }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -165,51 +165,60 @@ void main() {
 
     test('no content for analysis tab', () async {
       // no content
-      expect(templates.renderAnalysisTabV2(null), isNull);
+      expect(templates.renderAnalysisTabV2(null, null), isNull);
     });
 
     test('analysis tab: http', () async {
       // stored analysis of http
       final String json =
           await new File('$goldenDir/v2/analysis_tab_http.json').readAsString();
-      final String html = templates.renderAnalysisTabV2(
-          new AnalysisView(new AnalysisData.fromJson(JSON.decode(json))));
+      final view =
+          new AnalysisView(new AnalysisData.fromJson(JSON.decode(json)));
+      final extract = new AnalysisExtract(
+          health: view.health, maintenance: 0.9, popularity: 0.23);
+      final String html = templates.renderAnalysisTabV2(extract, view);
       expectGoldenFile(html, 'v2/analysis_tab_http.html', isFragment: true);
     });
 
     test('mock analysis tab', () async {
-      final String html = templates.renderAnalysisTabV2(new MockAnalysisView(
-        analysisStatus: AnalysisStatus.failure,
-        timestamp: new DateTime.utc(2017, 10, 26, 14, 03, 06),
-        platforms: ['web'],
-        health: 0.95,
-        suggestions: [
-          new Suggestion.error(
-              'Fix `dartfmt`.', 'Running `dartfmt -n .` failed.'),
-        ],
-        directDependencies: [
-          new PkgDependency(
-            'http',
-            'direct',
-            'normal',
-            new VersionConstraint.parse('^1.0.0'),
-            new Version.parse('1.0.0'),
-            new Version.parse('1.1.0'),
-            null,
+      final String html = templates.renderAnalysisTabV2(
+          new AnalysisExtract(
+            health: 0.90234,
+            maintenance: 0.8932343,
+            popularity: 0.2323232,
           ),
-        ],
-        transitiveDependencies: [
-          new PkgDependency(
-            'async',
-            'transitive',
-            'normal',
-            new VersionConstraint.parse('>=0.3.0 <1.0.0'),
-            new Version.parse('0.5.1'),
-            new Version.parse('1.0.2'),
-            null,
-          ),
-        ],
-      ));
+          new MockAnalysisView(
+            analysisStatus: AnalysisStatus.failure,
+            timestamp: new DateTime.utc(2017, 10, 26, 14, 03, 06),
+            platforms: ['web'],
+            health: 0.95,
+            suggestions: [
+              new Suggestion.error(
+                  'Fix `dartfmt`.', 'Running `dartfmt -n .` failed.'),
+            ],
+            directDependencies: [
+              new PkgDependency(
+                'http',
+                'direct',
+                'normal',
+                new VersionConstraint.parse('^1.0.0'),
+                new Version.parse('1.0.0'),
+                new Version.parse('1.1.0'),
+                null,
+              ),
+            ],
+            transitiveDependencies: [
+              new PkgDependency(
+                'async',
+                'transitive',
+                'normal',
+                new VersionConstraint.parse('>=0.3.0 <1.0.0'),
+                new Version.parse('0.5.1'),
+                new Version.parse('1.0.2'),
+                null,
+              ),
+            ],
+          ));
       expectGoldenFile(html, 'v2/analysis_tab_mock.html', isFragment: true);
     });
 

--- a/app/views/v2/pkg/analysis_tab.mustache
+++ b/app/views/v2/pkg/analysis_tab.mustache
@@ -6,8 +6,8 @@
 
 <ul>
   <li>Health: {{health}}</li>
-  <li>Popularity: TBD</li>
-  <li>Maintenance: TBD</li>
+  <li>Maintenance: {{maintenance}}</li>
+  <li>Popularity: {{popularity}}</li>
 </ul>
 
 {{#hasSuggestions}}


### PR DESCRIPTION
Using the extract because it is (a) available (b) doesn't require another call to popularity scores (c) "guaranteed" to be consistent with the listing page.