### PR TITLE
Listing page's default sort order: overall score.

### DIFF
--- a/app/test/frontend/golden/v2/flutter_landing_page.html
+++ b/app/test/frontend/golden/v2/flutter_landing_page.html
@@ -92,7 +92,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/flutter/packages?sort=top">More Flutter packages...</a>
+    <a href="/experimental/flutter/packages">More Flutter packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/index_page.html
+++ b/app/test/frontend/golden/v2/index_page.html
@@ -92,7 +92,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/packages?sort=top">More packages...</a>
+    <a href="/experimental/packages">More packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/server_landing_page.html
+++ b/app/test/frontend/golden/v2/server_landing_page.html
@@ -92,7 +92,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/server/packages?sort=top">More server packages...</a>
+    <a href="/experimental/server/packages">More server packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/web_landing_page.html
+++ b/app/test/frontend/golden/v2/web_landing_page.html
@@ -92,7 +92,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/web/packages?sort=top">More web packages...</a>
+    <a href="/experimental/web/packages">More web packages...</a>
   </div>
 </div>
 

--- a/app/views/v2/index.mustache
+++ b/app/views/v2/index.mustache
@@ -5,6 +5,6 @@
 <div class="home-lists-container">
   {{& top_html}}
   <div class="more">
-    <a href="/experimental{{{packages_url}}}?sort=top">{{more_packages}}</a>
+    <a href="/experimental{{{packages_url}}}">{{more_packages}}</a>
   </div>
 </div>


### PR DESCRIPTION
Per discussion with @kevmoo yesterday (sort by updated will be available via dropdown).

I could preserve the Datastore-only query path, but since the default will be using search, I see no reason to keep it.