### PR TITLE
Do not poison the cache and search index for newly uploaded packages.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -51,8 +51,8 @@ class SearchBackend {
 
   /// Loads the list of packages, their latest stable versions and returns a
   /// matching list of [PackageDocument] objects for search.
-  /// When a package or its latest version is missing, the method returns with
-  /// null at the given index.
+  /// When a package, its latest version or its analysis is missing, the method
+  /// returns with null at the given index.
   Future<List<PackageDocument>> loadDocuments(List<String> packageNames) async {
     final List<Key> packageKeys = packageNames
         .map((String name) => _db.emptyKey.append(Package, id: name))
@@ -81,6 +81,7 @@ class SearchBackend {
       if (pv == null) continue;
 
       final analysisView = analysisViews[i];
+      if (!analysisView.hasAnalysisData) continue;
       final double popularity = popularityStorage.lookup(pv.package) ??
           mockScores[pv.package]?.toDouble() ??
           0.0;

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -114,8 +114,10 @@ class BatchIndexUpdater implements TaskRunner {
       _taskCount += tasks.length;
       _logger.info('Updating index with ${tasks.length} packages '
           '[example: ${tasks.first.package}]');
-      final List<PackageDocument> docs = await searchBackend
-          .loadDocuments(tasks.map((t) => t.package).toList());
+      final List<PackageDocument> docs = (await searchBackend
+              .loadDocuments(tasks.map((t) => t.package).toList()))
+          .where((doc) => doc != null)
+          .toList();
       _snapshot.addAll(docs);
       await packageIndex.addPackages(docs);
       final bool doMerge =

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -88,6 +88,9 @@ class AnalyzerClient {
       }
     }
     final view = await getAnalysisView(key);
+    if (!view.hasAnalysisData) {
+      return null;
+    }
     final extract = new AnalysisExtract(
       popularity: popularityStorage.lookup(key.package) ?? 0.0,
       maintenance: view.maintenanceScore,


### PR DESCRIPTION
On the `frontend` this makes sure that we (a) don't create a cache entry with zeros and (b) don't display the caches zeros as part of the scores. The UI will display the gray circle with "--" string until the new analysis completes.

On the `search` service, this prevents the premature and faulty indexing of e.g. missing platform information. The index will keep the previous version of the data, and pick up the new analysis as it is completed.