### PR TITLE
Analysis tab: several updates

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -80,6 +80,7 @@ const _handlers = const <String, shelf.Handler>{
   '/experimental/server/packages': serverPackagesHandlerHtmlV2,
   '/experimental/web': webLandingHandlerV2,
   '/experimental/web/packages': webPackagesHandlerHtmlV2,
+  '/experimental/help': helpHandlerHtmlV2,
   '/debug': debugHandler,
   '/feed.atom': atomFeedHandler,
   '/authorized': authorizedHandler,
@@ -166,6 +167,11 @@ Future<shelf.Response> _indexHandlerV2(
     await backend.uiPackageCache?.setUIIndexPage(true, platform, pageContent);
   }
   return htmlResponse(pageContent);
+}
+
+/// Handles requests for /experimental/help
+Future<shelf.Response> helpHandlerHtmlV2(shelf.Request request) async {
+  return htmlResponse(templateService.renderHelpPageV2());
 }
 
 /// Handles requests for /feed.atom

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -247,6 +247,7 @@ class TemplateService {
       'health': _formatScore(extract?.health),
       'maintenance': _formatScore(extract?.maintenance),
       'popularity': _formatScore(extract?.popularity),
+      'overall': _formatScore(extract?.overallScore),
     };
 
     return _renderTemplate('v2/pkg/analysis_tab', data);
@@ -568,6 +569,12 @@ class TemplateService {
     };
     return _renderPage('error', values,
         title: 'Error $status', includeSurvey: false);
+  }
+
+  /// Renders the `views/v2/help.mustache` template.
+  String renderHelpPageV2() {
+    final String content = _renderTemplate('v2/help', {});
+    return renderLayoutPageV2(PageType.package, content);
   }
 
   /// Renders the `views/index.mustache` template.

--- a/app/test/frontend/golden/v2/analysis_tab_http.html
+++ b/app/test/frontend/golden/v2/analysis_tab_http.html
@@ -1,4 +1,16 @@
-<h4>Analysis</h4>
+<h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a href="https://github.com/dart-lang/pub-dartlang-dart/issues/new?title=Analysis+tab:">feedback</a>.
+</div>
+
+<p>
+  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
+  You can see the overall score in a colored circle, and the results below.
+</p>
+
+<hr />
 
 <p>Last package analysis: <i>completed</i> on Oct 25, 2017.</p>
 <p>(Dart: 2.0.0-dev.4.0, pana: 0.5.0).</p>
@@ -6,9 +18,54 @@
 <h4>Scores</h4>
 
 <table id='scores-table'>
-  <tr><td>Popularity</td><td>23</td></tr>
-  <tr><td>Health</td><td>99</td></tr>
-  <tr><td>Maintenance</td><td>90</td></tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Popularity:</span>
+        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          <a href="/experimental/help#popularity">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">23</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Health:</span>
+        <div class="tooltip-content">
+          Code health derived from static analysis.
+          <a href="/experimental/help#health">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">99</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Maintenance:</span>
+        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          <a href="/experimental/help#maintenance">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">90</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted"><b>Overall score:</b></span>
+        <div class="tooltip-content">
+          Weighted score of the above.
+          <a href="/experimental/help#overall-score">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value"><b>59</b></td>
+  </tr>
 </table>
 
 <h4>Platforms</h4>

--- a/app/test/frontend/golden/v2/analysis_tab_mock.html
+++ b/app/test/frontend/golden/v2/analysis_tab_mock.html
@@ -1,4 +1,16 @@
-<h4>Analysis</h4>
+<h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a href="https://github.com/dart-lang/pub-dartlang-dart/issues/new?title=Analysis+tab:">feedback</a>.
+</div>
+
+<p>
+  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
+  You can see the overall score in a colored circle, and the results below.
+</p>
+
+<hr />
 
 <p>Last package analysis: <i>tool failures</i> on Oct 26, 2017.</p>
 <p>(Dart: 2.0.0-dev.7.0, pana: 0.6.2, Flutter: 0.0.17).</p>
@@ -6,9 +18,54 @@
 <h4>Scores</h4>
 
 <table id='scores-table'>
-  <tr><td>Popularity</td><td>23</td></tr>
-  <tr><td>Health</td><td>90</td></tr>
-  <tr><td>Maintenance</td><td>89</td></tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Popularity:</span>
+        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          <a href="/experimental/help#popularity">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">23</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Health:</span>
+        <div class="tooltip-content">
+          Code health derived from static analysis.
+          <a href="/experimental/help#health">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">90</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Maintenance:</span>
+        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          <a href="/experimental/help#maintenance">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">89</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted"><b>Overall score:</b></span>
+        <div class="tooltip-content">
+          Weighted score of the above.
+          <a href="/experimental/help#overall-score">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value"><b>57</b></td>
+  </tr>
 </table>
 
 <h4>Platforms</h4>

--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -169,7 +169,19 @@ import 'package:foobar_pkg/foolib.dart';
       </table>
     </section>
     <section class="content js-content markdown-body" data-name="-analysis-tab-">
-      <h4>Analysis</h4>
+      <h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a href="https://github.com/dart-lang/pub-dartlang-dart/issues/new?title=Analysis+tab:">feedback</a>.
+</div>
+
+<p>
+  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
+  You can see the overall score in a colored circle, and the results below.
+</p>
+
+<hr />
 
 <p>Last package analysis: <i></i> on .</p>
 <p>(Dart: 2.0.0-dev.7.0, pana: 0.6.2, Flutter: 0.0.17).</p>
@@ -177,9 +189,54 @@ import 'package:foobar_pkg/foolib.dart';
 <h4>Scores</h4>
 
 <table id='scores-table'>
-  <tr><td>Popularity</td><td>--</td></tr>
-  <tr><td>Health</td><td>--</td></tr>
-  <tr><td>Maintenance</td><td>--</td></tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Popularity:</span>
+        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          <a href="/experimental/help#popularity">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">--</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Health:</span>
+        <div class="tooltip-content">
+          Code health derived from static analysis.
+          <a href="/experimental/help#health">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">--</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Maintenance:</span>
+        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          <a href="/experimental/help#maintenance">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">--</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted"><b>Overall score:</b></span>
+        <div class="tooltip-content">
+          Weighted score of the above.
+          <a href="/experimental/help#overall-score">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value"><b>--</b></td>
+  </tr>
 </table>
 
 <h4>Platforms</h4>

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -160,7 +160,19 @@ import 'package:foobar_pkg/foolib.dart';
       </table>
     </section>
     <section class="content js-content markdown-body" data-name="-analysis-tab-">
-      <h4>Analysis</h4>
+      <h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a href="https://github.com/dart-lang/pub-dartlang-dart/issues/new?title=Analysis+tab:">feedback</a>.
+</div>
+
+<p>
+  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
+  You can see the overall score in a colored circle, and the results below.
+</p>
+
+<hr />
 
 <p>Last package analysis: <i></i> on .</p>
 <p>(Dart: 2.0.0-dev.7.0, pana: 0.6.2, Flutter: 0.0.17).</p>
@@ -168,9 +180,54 @@ import 'package:foobar_pkg/foolib.dart';
 <h4>Scores</h4>
 
 <table id='scores-table'>
-  <tr><td>Popularity</td><td>30</td></tr>
-  <tr><td>Health</td><td>99</td></tr>
-  <tr><td>Maintenance</td><td>99</td></tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Popularity:</span>
+        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          <a href="/experimental/help#popularity">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">30</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Health:</span>
+        <div class="tooltip-content">
+          Code health derived from static analysis.
+          <a href="/experimental/help#health">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">99</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Maintenance:</span>
+        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          <a href="/experimental/help#maintenance">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">99</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted"><b>Overall score:</b></span>
+        <div class="tooltip-content">
+          Weighted score of the above.
+          <a href="/experimental/help#overall-score">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value"><b>65</b></td>
+  </tr>
 </table>
 
 <h4>Platforms</h4>

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -152,6 +152,11 @@ class TemplateMock implements TemplateService {
   }
 
   @override
+  String renderHelpPageV2() {
+    return _response;
+  }
+
+  @override
   String renderIndexPage(List<PackageVersion> recentPackages,
       List<AnalysisExtract> analysisExtracts) {
     return _response;

--- a/app/views/v2/help.mustache
+++ b/app/views/v2/help.mustache
@@ -1,0 +1,73 @@
+{{! Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+<div style="max-width: 600px">
+  <h2 id="scoring">Scoring</h2>
+  <p>
+    We calculate <a href="#popularity">popularity</a>, <a href="#health">health</a> and
+    <a href="#maintenance">maintenance</a> scores independently, and combine them into
+    an <a href="#overall-score">overall score</a>. The score you see in the colored circle
+    is always this overall score.
+  </p>
+
+  <h3 id="popularity">Popularity</h3>
+  <p>
+    Popularity score is good proxy for a package's use, derived from download statistics.
+    It is based on actual download counts, but compensated for automated tools (like
+    continuous builds fetching the package on each change request).
+  </p>
+
+  <p><i>How can you improve your popularity score?</i></p>
+  <p>Create useful packages that others needs and love to use.</p>
+
+  <h3 id="health">Health</h3>
+  <p>
+    The code health score is based on the static analysis of the package with <code class="hljs">dartanalyzer</code>.
+  </p>
+  <p><i>How can you improve your health score?</i></p>
+  <p>Use strong-mode checks and some linter rules, and make sure you fix all the warnings and errors before publishing. An example <code>analysis_options.yaml</code>:</p>
+  <pre><code class="hljs">
+# https://www.dartlang.org/guides/language/analysis-options
+analyzer:
+  strong-mode: true
+
+# Source of linter options:
+# http://dart-lang.github.io/linter/lints/options/options.html
+linter:
+  rules:
+    - camel_case_types
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - unrelated_type_equality_checks
+    - valid_regexps
+
+  </code></pre>
+
+  <h3 id="maintenance">Maintenance</h3>
+
+  <p>
+    Maintenance score reflects how tidy and up-to-date a package is.
+    Some of aspects that influence the score:
+  </p>
+  <ul>
+    <li>Last publish date: a package starts to loose score a year its last publish data.</li>
+    <li>Up-to-date dependencies: great if all of the dependencies are on the latest version.</li>
+    <li>Readme, changelog and example files.</li>
+    <li><code class="hljs">analysis_options.yaml</code> with strong-mode enabled.</li>
+  </ul>
+
+  <p><i>How can you improve your maintenance score?</i></p>
+  <p>
+    Follow the suggestions on the analysis tab on the package page, or
+    run <a href="https://pub.dartlang.org/packages/pana">pana</a> manually
+    to check these before publishing.
+  </p>
+
+  <h3 id="overall-score">Overall score</h3>
+  <p>
+    The overall score is the combination of <a href="#popularity">popularity</a>,
+    <a href="#health">health</a> and <a href="#maintenance">maintenance</a>.
+  </p>
+
+</div>

--- a/app/views/v2/pkg/analysis_tab.mustache
+++ b/app/views/v2/pkg/analysis_tab.mustache
@@ -1,4 +1,16 @@
-<h4>Analysis</h4>
+<h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a href="https://github.com/dart-lang/pub-dartlang-dart/issues/new?title=Analysis+tab:">feedback</a>.
+</div>
+
+<p>
+  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
+  You can see the overall score in a colored circle, and the results below.
+</p>
+
+<hr />
 
 <p>Last package analysis: <i>{{analysis_status}}</i> on {{date_completed}}.</p>
 <p>(Dart: {{dart_sdk_version}}, pana: {{pana_version}}{{#flutter_version}}, Flutter: {{flutter_version}}{{/flutter_version}}).</p>
@@ -6,9 +18,54 @@
 <h4>Scores</h4>
 
 <table id='scores-table'>
-  <tr><td>Popularity</td><td>{{popularity}}</td></tr>
-  <tr><td>Health</td><td>{{health}}</td></tr>
-  <tr><td>Maintenance</td><td>{{maintenance}}</td></tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Popularity:</span>
+        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          <a href="/experimental/help#popularity">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">{{popularity}}</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Health:</span>
+        <div class="tooltip-content">
+          Code health derived from static analysis.
+          <a href="/experimental/help#health">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">{{health}}</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted">Maintenance:</span>
+        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          <a href="/experimental/help#maintenance">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">{{maintenance}}</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base">
+        <span class="tooltip-dotted"><b>Overall score:</b></span>
+        <div class="tooltip-content">
+          Weighted score of the above.
+          <a href="/experimental/help#overall-score">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value"><b>{{overall}}</b></td>
+  </tr>
 </table>
 
 <h4>Platforms</h4>

--- a/static/v2/css/style.css
+++ b/static/v2/css/style.css
@@ -795,10 +795,6 @@ main, .site-header {
     top: -1px;
 }
 
-.package-container #scores-table td {
-  text-align: right;
-}
-
 .sidebar-content{
     font-size: 14px
 }
@@ -880,6 +876,73 @@ main, .site-header {
 .dependency-table th.sub-header {
   font-weight: 500;
   font-style: italic;
+}
+
+/******************************************************
+  Analysis tab
+******************************************************/
+
+.analysis-disclaimer {
+  float: right;
+  margin-left: 24px;
+  margin-bottom: 12px;
+  padding: 8px;
+  border-left: 4px solid #00c4b3;
+}
+
+#scores-table {
+  margin-bottom: 1em;
+}
+
+#scores-table .score-name {
+  min-width: 100px;
+  padding-right: 24px;
+}
+
+#scores-table .score-value {
+  min-width: 60px;
+  text-align: right;
+}
+
+.tooltip-base {
+  position: relative;
+  display: inline-block;
+  padding: 4px;
+}
+
+.tooltip-dotted {
+  border-bottom: 1px dotted #ddd;
+}
+
+.tooltip-content {
+  visibility: hidden;
+  background: #f8f8f8;
+  color: black;
+  opacity: 0.95;
+  padding: 12px 12px;
+  border: 1px solid #ddd;
+  border-radius: 2px;
+
+  position: absolute;
+  width: 300px;
+  top: 100%;
+  left: -24px;
+  z-index: 3;
+}
+
+.tooltip-content::after {
+  content: " ";
+  position: absolute;
+  bottom: 100%;  /* At the top of the tooltip */
+  left: 48px;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: transparent transparent #ddd transparent;
+}
+
+.tooltip-base:hover .tooltip-content {
+  visibility: visible;
 }
 
 /******************************************************


### PR DESCRIPTION
Sorry for the one big bang PR, but it wasn't easy to separate it in non-conflicting PRs.

- new page: `/help` with longer description on the scoring.
  (TODO: `#relative-link` do not jump to the element at first, probably some conflicting code with the tab handling in the JS script, will address separately)

- top disclaimers for the analysis tab

- updated scoring with some formatting and a tooltip that provides further links to the help page
