### PR TITLE
Decrease dual-platform specificity penalty.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -303,7 +303,7 @@ class SimplePackageIndex implements PackageIndex {
     final int platformCount = platforms?.length ?? 0;
     if (requiredCount > 0) {
       if (platformCount == requiredCount + 1) {
-        score *= 0.90;
+        score *= 0.99;
       } else if (platformCount > requiredCount + 1) {
         score *= 0.80;
       }

--- a/app/test/search/platform_rank_test.dart
+++ b/app/test/search/platform_rank_test.dart
@@ -73,15 +73,15 @@ void main() {
         'packages': [
           {
             'package': 'json_1',
-            'score': closeTo(0.122, 0.005),
+            'score': closeTo(0.1224, 0.0001),
           },
           {
             'package': 'json_2',
-            'score': closeTo(0.110, 0.005),
+            'score': closeTo(0.1212, 0.0001),
           },
           {
             'package': 'json_3',
-            'score': closeTo(0.098, 0.005),
+            'score': closeTo(0.0979, 0.0001),
           },
         ],
       });


### PR DESCRIPTION
I've checked on staging, the diversity of the results are still okay, I think this should close #600.