### PR TITLE
Using analysis content hash to prevent duplicates stored in Datastore.

### DIFF
--- a/app/lib/analyzer/models.dart
+++ b/app/lib/analyzer/models.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:gcloud/db.dart' as db;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -72,6 +73,9 @@ class PackageVersionAnalysis extends db.ExpandoModel {
   @AnalysisStatusProperty()
   AnalysisStatus analysisStatus;
 
+  @db.StringProperty()
+  String analysisHash;
+
   PackageVersionAnalysis();
   PackageVersionAnalysis.fromAnalysis(Analysis analysis) {
     parentKey =
@@ -82,6 +86,7 @@ class PackageVersionAnalysis extends db.ExpandoModel {
     panaVersion = analysis.panaVersion;
     flutterVersion = analysis.flutterVersion;
     analysisStatus = analysis.analysisStatus;
+    analysisHash = analysis.analysisHash;
   }
 
   /// Returns true if there was a change that warrants an update in Datastore.
@@ -96,6 +101,7 @@ class PackageVersionAnalysis extends db.ExpandoModel {
     panaVersion = analysis.panaVersion;
     flutterVersion = analysis.flutterVersion;
     analysisStatus = analysis.analysisStatus;
+    analysisHash = analysis.analysisHash;
     return true;
   }
 }
@@ -138,6 +144,9 @@ class Analysis extends db.ExpandoModel {
   @db.BlobProperty()
   List<int> analysisJsonGz;
 
+  @db.StringProperty()
+  String analysisHash;
+
   /// Empty constructor only for appengine.
   Analysis();
 
@@ -159,8 +168,10 @@ class Analysis extends db.ExpandoModel {
   set analysisJson(Map map) {
     if (map == null) {
       analysisJsonGz = null;
+      analysisHash = null;
     } else {
       analysisJsonGz = _gzipCodec.encode(UTF8.encode(JSON.encode(map)));
+      analysisHash = sha256.convert(analysisJsonGz).toString();
     }
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
     path: ../pkg/_popularity
   appengine: '^0.4.2'
   args: '^0.13.7'
+  crypto: '^2.0.2'
   gcloud: '>=0.4.0 <0.5.0'
   googleapis: '>=0.31.0 <0.37.0'
   googleapis_auth: '>=0.2.2 <0.2.4'


### PR DESCRIPTION
In the current practice we may re-analyze a package, fix a temporal issue, but would fail to store it because the decisions is based on time window, and not the actual content. With the content hash repeated analysis with the same result won't be stored, but different (non-regression) results will be, regardless of the window (the previous pana- and flutter-version related constraints still apply).