### PR TITLE
Refactor SearchQuery: handle package prefix only as part of the query.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -218,7 +218,7 @@ Future<shelf.Response> searchHandler(shelf.Request request) async {
   final int page = _pageFromUrl(request.url);
 
   final SearchQuery query = new SearchQuery.parse(
-    text: queryText,
+    query: queryText,
     platform: platform,
     offset: PageLinks.resultsPerPage * (page - 1),
     limit: PageLinks.resultsPerPage,
@@ -407,7 +407,7 @@ Future<shelf.Response> _packagesHandlerHtmlV2(
       sortParam == null ? null : parseSearchOrder(sortParam);
 
   final SearchQuery searchQuery = new SearchQuery.parse(
-      text: queryText,
+      query: queryText,
       platform: platform,
       order: sortOrder,
       offset: offset,

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -150,7 +150,7 @@ class TemplateService {
       descriptionHtml = flutterPackagesDescriptionHtml;
     }
 
-    final isSearch = searchQuery != null && searchQuery.hasText;
+    final isSearch = searchQuery != null && searchQuery.hasQuery;
     final values = {
       'is_search': isSearch,
       'title': title ?? 'Packages',
@@ -158,14 +158,14 @@ class TemplateService {
       'packages': packagesJson,
       'has_packages': packages.isNotEmpty,
       'pagination': renderPaginationV2(links),
-      'search_query': searchQuery?.text,
+      'search_query': searchQuery?.query,
       'total_count': totalCount,
     };
     final content = _renderTemplate('v2/pkg/index', values);
 
     String pageTitle = title;
     if (isSearch) {
-      pageTitle = 'Search results for ${searchQuery.text}.';
+      pageTitle = 'Search results for ${searchQuery.query}.';
     } else {
       if (links.rightmostPage > 1) {
         pageTitle = 'Page ${links.currentPage} | $pageTitle';
@@ -648,7 +648,7 @@ class TemplateService {
     SearchQuery searchQuery,
     bool includeSurvey: true,
   }) {
-    final queryText = searchQuery?.text;
+    final queryText = searchQuery?.query;
     final String escapedSearchQuery =
         queryText == null ? null : HTML_ESCAPE.convert(queryText);
     String platformTabs;
@@ -738,7 +738,7 @@ class TemplateService {
 
   /// Renders the `views/search.mustache` template.
   String renderSearchPage(SearchResultPage resultPage, PageLinks pageLinks) {
-    final String queryText = resultPage.query.text;
+    final String queryText = resultPage.query.query;
     final String paginationHtml = renderPagination(pageLinks);
     final List results = [];
     for (int i = 0; i < resultPage.packages.length; i++) {
@@ -756,7 +756,7 @@ class TemplateService {
       });
     }
     final values = {
-      'query': resultPage.query.text,
+      'query': resultPage.query.query,
       'results': results,
       'pagination': paginationHtml,
       'hasResults': results.length > 0,

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -93,19 +93,18 @@ class SimplePackageIndex implements PackageIndex {
   @override
   Future<PackageSearchResult> search(SearchQuery query) async {
     // do text matching
-    final Score textScore = _searchText(query.text, query.packagePrefix);
+    final Score textScore = _searchText(query.parsedQuery.text);
     final Score base = textScore ?? _allPackages();
 
     // The set of packages to filter on.
     final Set<String> packages = base.getKeys();
 
     // filter on package prefix
-    if (query.packagePrefix != null) {
+    if (query.parsedQuery?.packagePrefix != null) {
+      final String prefix = query.parsedQuery.packagePrefix.toLowerCase();
       packages.removeWhere(
-        (package) => !_packages[package]
-            .package
-            .toLowerCase()
-            .startsWith(query.packagePrefix.toLowerCase()),
+        (package) =>
+            !_packages[package].package.toLowerCase().startsWith(prefix),
       );
     }
 
@@ -227,7 +226,7 @@ class SimplePackageIndex implements PackageIndex {
   Score _allPackages() =>
       new Score(new Map.fromIterable(_packages.keys, value: (_) => 1.0));
 
-  Score _searchText(String text, String packagePrefix) {
+  Score _searchText(String text) {
     if (text != null && text.isNotEmpty) {
       final List<String> words = text.split(' ');
       final List<Score> wordScores = words.map((String word) {

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -213,7 +213,7 @@ void main() {
 
       tScopedTest('/search?q=foobar', () async {
         registerSearchService(new SearchServiceMock((SearchQuery query) {
-          expect(query.text, 'foobar');
+          expect(query.query, 'foobar');
           expect(query.offset, 0);
           expect(query.limit, PageSize);
           return new SearchResultPage(
@@ -230,7 +230,7 @@ void main() {
 
       tScopedTest('/search?q=foobar&page=2', () async {
         registerSearchService(new SearchServiceMock((SearchQuery query) {
-          expect(query.text, 'foobar');
+          expect(query.query, 'foobar');
           expect(query.offset, PageSize);
           expect(query.limit, PageSize);
           return new SearchResultPage(

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -264,7 +264,7 @@ void main() {
 
     test('package index page with search v2', () {
       final searchQuery =
-          new SearchQuery.parse(text: 'foobar', order: SearchOrder.top);
+          new SearchQuery.parse(query: 'foobar', order: SearchOrder.top);
       final String html = templates.renderPkgIndexPageV2(
         [
           new PackageView.fromModel(
@@ -311,7 +311,7 @@ void main() {
     });
 
     test('search page', () {
-      final query = new SearchQuery.parse(text: 'foobar', offset: 0);
+      final query = new SearchQuery.parse(query: 'foobar', offset: 0);
       final resultPage = new SearchResultPage(
         query,
         2,
@@ -366,7 +366,7 @@ void main() {
     test('platform tabs: search', () {
       final String html = templates.renderPlatformTabs(
           searchQuery: new SearchQuery.parse(
-        text: 'foo',
+        query: 'foo',
         platform: 'server',
       ));
       expectGoldenFile(html, 'v2/platform_tabs_search.html', isFragment: true);
@@ -452,7 +452,7 @@ void main() {
 
   group('URLs', () {
     test('SearchLinks defaults', () {
-      final query = new SearchQuery.parse(text: 'web framework');
+      final query = new SearchQuery.parse(query: 'web framework');
       final SearchLinks links = new SearchLinks(query, 100);
       expect(links.formatHref(1), '/search?q=web+framework&page=1');
       expect(links.formatHref(2), '/search?q=web+framework&page=2');
@@ -460,7 +460,7 @@ void main() {
 
     test('SearchLinks with type', () {
       final query =
-          new SearchQuery.parse(text: 'web framework', platform: 'server');
+          new SearchQuery.parse(query: 'web framework', platform: 'server');
       final SearchLinks links = new SearchLinks(query, 100);
       expect(links.formatHref(1),
           '/search?q=web+framework&platforms=server&page=1');

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -31,7 +31,7 @@ void main() {
 
     test('angular', () async {
       final PackageSearchResult result = await index.search(
-          new SearchQuery.parse(text: 'angular', order: SearchOrder.text));
+          new SearchQuery.parse(query: 'angular', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -93,9 +93,9 @@ void main() {
             });
       });
 
-      scopedTest('Finds package by pkg-prefix search only', () async {
+      scopedTest('Finds package by package-prefix search only', () async {
         await setUpInServiceScope();
-        expectJsonResponse(await issueGet('/search?q=&pkg-prefix=pk'), body: {
+        expectJsonResponse(await issueGet('/search?q=package:pk'), body: {
           'indexUpdated': isNotNull,
           'totalCount': 1,
           'packages': [
@@ -109,12 +109,11 @@ void main() {
 
       scopedTest('pkg-prefix filters out results', () async {
         await setUpInServiceScope();
-        expectJsonResponse(await issueGet('/search?q=json&pkg-prefix=foo'),
-            body: {
-              'indexUpdated': isNotNull,
-              'totalCount': 0,
-              'packages': [],
-            });
+        expectJsonResponse(await issueGet('/search?q=json+package:foo'), body: {
+          'indexUpdated': isNotNull,
+          'totalCount': 0,
+          'packages': [],
+        });
       });
     });
   });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -378,7 +378,7 @@ MIT'''),
 
     test('hoversine', () async {
       final PackageSearchResult result = await index.search(
-          new SearchQuery.parse(text: 'haversine', order: SearchOrder.text));
+          new SearchQuery.parse(query: 'haversine', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -183,7 +183,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package name match: async', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: 'async'));
+          await index.search(new SearchQuery.parse(query: 'async'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -198,7 +198,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('description match: composable', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: 'composable'));
+          await index.search(new SearchQuery.parse(query: 'composable'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -217,7 +217,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('readme match: chrome.sockets', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: 'chrome.sockets'));
+          await index.search(new SearchQuery.parse(query: 'chrome.sockets'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -232,7 +232,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('typo match: utilito', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: 'utilito'));
+          await index.search(new SearchQuery.parse(query: 'utilito'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -245,7 +245,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('exact phrase match: utilito', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: '"utilito"'));
+          await index.search(new SearchQuery.parse(query: '"utilito"'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 0,
@@ -255,7 +255,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('exact phrase match: utility', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: '"utility"'));
+          await index.search(new SearchQuery.parse(query: '"utility"'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -268,7 +268,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('package prefix: chrome', () async {
       final PackageSearchResult result =
-          await index.search(new SearchQuery.parse(text: 'package:chrome'));
+          await index.search(new SearchQuery.parse(query: 'package:chrome'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -283,7 +283,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by text: single-letter t', () async {
       final PackageSearchResult result = await index
-          .search(new SearchQuery.parse(text: 't', order: SearchOrder.text));
+          .search(new SearchQuery.parse(query: 't', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 0,
@@ -293,7 +293,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by text: double-letter tt', () async {
       final PackageSearchResult result = await index
-          .search(new SearchQuery.parse(text: 'tt', order: SearchOrder.text));
+          .search(new SearchQuery.parse(query: 'tt', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 1,
@@ -322,7 +322,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('order by updated: no filter', () async {
       final PackageSearchResult result = await index
-          .search(new SearchQuery.parse(text: '', order: SearchOrder.updated));
+          .search(new SearchQuery.parse(query: '', order: SearchOrder.updated));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -394,7 +394,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
 
     test('multiword query: implicit AND', () async {
       final PackageSearchResult composable = await index.search(
-          new SearchQuery.parse(text: 'composable', order: SearchOrder.text));
+          new SearchQuery.parse(query: 'composable', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(composable)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,
@@ -405,7 +405,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       });
 
       final PackageSearchResult library = await index.search(
-          new SearchQuery.parse(text: 'library', order: SearchOrder.text));
+          new SearchQuery.parse(query: 'library', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(library)), {
         'indexUpdated': isNotNull,
         'totalCount': 3,
@@ -419,7 +419,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       // Without the implicit AND, the end result would be close to the result
       // of the `library` search.
       final PackageSearchResult both = await index.search(new SearchQuery.parse(
-          text: 'composable library', order: SearchOrder.text));
+          query: 'composable library', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(both)), {
         'indexUpdated': isNotNull,
         'totalCount': 2,

--- a/app/test/search/platform_rank_test.dart
+++ b/app/test/search/platform_rank_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     test('text search without platform', () async {
       final PackageSearchResult withoutPlatform =
-          await index.search(new SearchQuery.parse(text: 'json'));
+          await index.search(new SearchQuery.parse(query: 'json'));
       expect(JSON.decode(JSON.encode(withoutPlatform)), {
         'indexUpdated': isNotNull,
         'totalCount': 4,
@@ -64,7 +64,7 @@ void main() {
     test('text search with platform', () async {
       final PackageSearchResult withPlatform =
           await index.search(new SearchQuery.parse(
-        text: 'json',
+        query: 'json',
         platform: 'flutter',
       ));
       expect(JSON.decode(JSON.encode(withPlatform)), {

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -53,7 +53,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
     test('travis', () async {
       final PackageSearchResult result = await index.search(
-          new SearchQuery.parse(text: 'travis', order: SearchOrder.text));
+          new SearchQuery.parse(query: 'travis', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
         'totalCount': 7,

--- a/app/test/shared/search_service_test.dart
+++ b/app/test/shared/search_service_test.dart
@@ -31,11 +31,11 @@ void main() {
     });
 
     test('contains text', () {
-      expect(new SearchQuery.parse(text: 'text').isValid, isTrue);
+      expect(new SearchQuery.parse(query: 'text').isValid, isTrue);
     });
 
     test('has package prefix', () {
-      expect(new SearchQuery.parse(text: 'package:angular_').isValid, isTrue);
+      expect(new SearchQuery.parse(query: 'package:angular_').isValid, isTrue);
     });
 
     test('has text-based ordering', () {
@@ -43,20 +43,20 @@ void main() {
       expect(new SearchQuery.parse(order: SearchOrder.text).isValid, isFalse);
 
       expect(
-          new SearchQuery.parse(text: 'text', order: SearchOrder.top).isValid,
+          new SearchQuery.parse(query: 'text', order: SearchOrder.top).isValid,
           isTrue);
       expect(
-          new SearchQuery.parse(text: 'text', order: SearchOrder.text).isValid,
+          new SearchQuery.parse(query: 'text', order: SearchOrder.text).isValid,
           isTrue);
 
       expect(
           new SearchQuery.parse(
-                  text: 'package:angular_', order: SearchOrder.top)
+                  query: 'package:angular_', order: SearchOrder.top)
               .isValid,
           isTrue);
       expect(
           new SearchQuery.parse(
-                  text: 'package:angular_', order: SearchOrder.text)
+                  query: 'package:angular_', order: SearchOrder.text)
               .isValid,
           isFalse);
     });
@@ -75,31 +75,32 @@ void main() {
   group('Search URLs', () {
     test('empty', () {
       final query = new SearchQuery.parse();
-      expect(query.packagePrefix, isNull);
+      expect(query.parsedQuery.text, isNull);
+      expect(query.parsedQuery.packagePrefix, isNull);
       expect(query.toSearchLink(v2: true), '/packages');
     });
 
     test('platform: flutter', () {
       final query = new SearchQuery.parse(platform: 'flutter');
-      expect(query.text, isNull);
-      expect(query.packagePrefix, isNull);
+      expect(query.parsedQuery.text, isNull);
+      expect(query.parsedQuery.packagePrefix, isNull);
       expect(query.toSearchLink(v2: true), '/flutter/packages');
     });
 
     test('package prefix: angular', () {
-      final query = new SearchQuery.parse(text: 'package:angular');
-      expect(query.text, isNull);
-      expect(query.packagePrefix, 'angular');
+      final query = new SearchQuery.parse(query: 'package:angular');
+      expect(query.parsedQuery.text, isNull);
+      expect(query.parsedQuery.packagePrefix, 'angular');
       expect(query.toSearchLink(v2: true), '/packages?q=package%3Aangular');
     });
 
     test('complex search', () {
       final query = new SearchQuery.parse(
-          text: 'package:angular widget', order: SearchOrder.top);
-      expect(query.text, 'widget');
-      expect(query.packagePrefix, 'angular');
+          query: 'package:angular widget', order: SearchOrder.top);
+      expect(query.parsedQuery.text, 'widget');
+      expect(query.parsedQuery.packagePrefix, 'angular');
       expect(query.toSearchLink(v2: true),
-          '/packages?q=widget+package%3Aangular&sort=top');
+          '/packages?q=package%3Aangular+widget&sort=top');
     });
   });
 }


### PR DESCRIPTION
This will open up simpler implementation for `key:value` search refinements (e.g. dependencies). 

I'm planning to rename a few things in later PRs, e.g. `SearchQuery` to `SearchRequest` (and field names similarly), reducing the cognitive load of `resultPage.query.query` and similar expressions.
