### PR TITLE
Refactor template consts to separate place.

### DIFF
--- a/app/lib/frontend/template_consts.dart
+++ b/app/lib/frontend/template_consts.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_dartlang_org/shared/platform.dart' show KnownPlatforms;
+
+class PlatformDict {
+  final String name;
+  final String landingBlurb;
+  final String landingUrl;
+  final String listingUrl;
+
+  PlatformDict({
+    this.name,
+    this.landingBlurb,
+    this.landingUrl,
+    this.listingUrl,
+  });
+
+  factory PlatformDict.forPlatform(String platform) {
+    return new PlatformDict(
+      name: _formattedPlatformName(platform),
+      landingBlurb: _landingBlurb(platform),
+      landingUrl:
+          platform == null ? '/experimental' : '/experimental/$platform',
+      listingUrl: platform == null
+          ? '/experimental/packages'
+          : '/experimental/$platform/packages',
+    );
+  }
+}
+
+PlatformDict getPlatformDict(String platform, {bool nullIfMissing: false}) {
+  final dict = _dictionaries[platform ?? 'default'];
+  if (dict == null) {
+    return nullIfMissing ? null : _dictionaries['default'];
+  } else {
+    return dict;
+  }
+}
+
+final _dictionaries = <String, PlatformDict>{
+  'default': new PlatformDict.forPlatform(null),
+  KnownPlatforms.flutter: new PlatformDict.forPlatform(KnownPlatforms.flutter),
+  KnownPlatforms.server: new PlatformDict.forPlatform(KnownPlatforms.server),
+  KnownPlatforms.web: new PlatformDict.forPlatform(KnownPlatforms.web),
+};
+
+String _formattedPlatformName(String platform) {
+  if (platform == null) {
+    return 'Dart';
+  }
+  switch (platform) {
+    case KnownPlatforms.flutter:
+      return 'Flutter';
+    default:
+      return platform;
+  }
+}
+
+final Map<String, String> _landingBlurbs = const {
+  'default':
+      '<p class="text">Find and use packages to build <a href="/experimental/flutter">Flutter</a>, '
+      '<a href="/experimental/web">web</a> and <a href="/experimental/server">server</a> apps '
+      'with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>',
+  KnownPlatforms.flutter:
+      '<p class="text"><a href="https://flutter.io/">Flutter<sup><small>↗</small></sup></a> '
+      'makes it easy and fast to build beautiful mobile apps<br/> for iOS and Android.</p>',
+  KnownPlatforms.server:
+      '<p class="text">Use Dart to create command line and server applications.<br/> Start with the '
+      '<a href="https://www.dartlang.org/tutorials/dart-vm/get-started">Dart VM tutorial<sup><small>↗</small></sup></a>.</p>',
+  KnownPlatforms.web:
+      '<p class="text">Use Dart to create web applications that run on any modern browser.<br/> Start '
+      'with <a href="https://webdev.dartlang.org/angular">AngularDart<sup><small>↗</small></sup></a>.</p>'
+};
+
+String _landingBlurb(String platform) =>
+    _landingBlurbs[platform ?? 'default'] ?? _landingBlurbs['default'];

--- a/app/test/frontend/golden/v2/index_page.html
+++ b/app/test/frontend/golden/v2/index_page.html
@@ -78,14 +78,14 @@
 <main>
   
 <div class="home-lists-container">
-  <h2 class="center">Top packages</h2>
+  <h2 class="center">Top Dart packages</h2>
   
 <ul class="package-list">
     <li class="list-item -simple">
       <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/web/packages">Web</a>
+        <a class="package-tag" href="/experimental/web/packages">web</a>
   
 
       </p>
@@ -94,7 +94,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/packages">More packages...</a>
+    <a href="/experimental/packages">More Dart packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/server_landing_page.html
+++ b/app/test/frontend/golden/v2/server_landing_page.html
@@ -85,7 +85,7 @@
       <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/server/packages">Server</a>
+        <a class="package-tag" href="/experimental/server/packages">server</a>
   
 
       </p>

--- a/app/test/frontend/golden/v2/web_landing_page.html
+++ b/app/test/frontend/golden/v2/web_landing_page.html
@@ -85,7 +85,7 @@
       <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/web/packages">Web</a>
+        <a class="package-tag" href="/experimental/web/packages">web</a>
   
 
       </p>


### PR DESCRIPTION
`templates.dart` is getting too large, and these were easy to extract.