### PR TITLE
 Keep only longer tokens and give more weight on description and readme.

### DIFF
--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -72,7 +72,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.04, 0.01),
+              'score': closeTo(0.07, 0.01),
             }
           ],
         });
@@ -87,7 +87,7 @@ void main() {
               'packages': [
                 {
                   'package': 'pkg_foo',
-                  'score': closeTo(0.04, 0.01),
+                  'score': closeTo(0.07, 0.01),
                 }
               ],
             });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -391,12 +391,12 @@ MIT'''),
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(0.02, 0.01),
+            'score': closeTo(0.04, 0.01),
           },
           {
             // should be present
             'package': 'great_circle_distance',
-            'score': closeTo(0.01, 0.01),
+            'score': closeTo(0.03, 0.01),
           },
         ]
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -201,15 +201,11 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           await index.search(new SearchQuery.parse(query: 'composable'));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'packages': [
           {
-            'package': 'chrome_net',
-            'score': closeTo(0.13, 0.01),
-          },
-          {
             'package': 'http',
-            'score': closeTo(0.08, 0.01),
+            'score': closeTo(0.11, 0.01),
           },
         ]
       });
@@ -237,8 +233,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.07, 0.01)},
-          {'package': 'http', 'score': closeTo(0.02, 0.01)},
+          {'package': 'async', 'score': closeTo(0.09, 0.01)},
+          {'package': 'http', 'score': closeTo(0.04, 0.01)},
         ]
       });
     });
@@ -260,8 +256,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.07, 0.01)},
-          {'package': 'http', 'score': closeTo(0.02, 0.01)},
+          {'package': 'async', 'score': closeTo(0.09, 0.01)},
+          {'package': 'http', 'score': closeTo(0.04, 0.01)},
         ],
       });
     });
@@ -397,10 +393,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           new SearchQuery.parse(query: 'composable', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(composable)), {
         'indexUpdated': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.24, 0.01)},
-          {'package': 'http', 'score': closeTo(0.09, 0.01)},
+          {'package': 'http', 'score': closeTo(0.12, 0.01)},
         ],
       });
 
@@ -410,9 +405,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 3,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.11, 0.01)},
-          {'package': 'async', 'score': closeTo(0.08, 0.01)},
-          {'package': 'http', 'score': closeTo(0.03, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.14, 0.01)},
+          {'package': 'async', 'score': closeTo(0.10, 0.01)},
+          {'package': 'http', 'score': closeTo(0.05, 0.01)},
         ],
       });
 
@@ -422,10 +417,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           query: 'composable library', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(both)), {
         'indexUpdated': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.027, 0.001)},
-          {'package': 'http', 'score': closeTo(0.003, 0.001)},
+          {'package': 'http', 'score': closeTo(0.006, 0.001)},
         ],
       });
     });

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -64,27 +64,27 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
           },
           {
             'package': 'rainbow_vis',
-            'score': closeTo(0.087, 0.001),
-          },
-          {
-            'package': 'w_transport',
-            'score': closeTo(0.055, 0.001),
-          },
-          {
-            'package': 'sass_transformer',
-            'score': closeTo(0.049, 0.001),
-          },
-          {
-            'package': 'dartemis_transformer',
-            'score': closeTo(0.043, 0.001),
+            'score': closeTo(0.047, 0.001),
           },
           {
             'package': 'mongo_dart_query',
-            'score': closeTo(0.026, 0.001),
+            'score': closeTo(0.047, 0.001),
           },
           {
             'package': 'angular_aria',
-            'score': closeTo(0.026, 0.001),
+            'score': closeTo(0.047, 0.001),
+          },
+          {
+            'package': 'w_transport',
+            'score': closeTo(0.047, 0.001),
+          },
+          {
+            'package': 'sass_transformer',
+            'score': closeTo(0.046, 0.001),
+          },
+          {
+            'package': 'dartemis_transformer',
+            'score': closeTo(0.046, 0.001),
           },
         ],
       });


### PR DESCRIPTION
The idea here is to check all of [name, description, readme], and select only the longest matching tokens in the first phase. Then in the second we score them individually and merge as usual. E.g. searching for `something7` may find the token `something`, and because it is long enough, it won't look for `so` or `ing7`, in neither of the indices.

Kept the refactor stages in separate commits.
