### PR TITLE
Indicating sort order and tooltip for more help.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -146,7 +146,13 @@ class TemplateService {
 
     final PlatformDict platformDict = getPlatformDict(currentPlatform);
     final isSearch = searchQuery != null && searchQuery.hasQuery;
+    final String sortName = isSearch ? 'relevance' : 'overall score';
+    final String sortTooltipHtml = isSearch
+        ? 'Packages are sorted by the combination of text match and overall score.'
+        : 'Packages are sorted by the overall score.';
     final values = {
+      'sort_name': sortName,
+      'sort_tooltip_html': sortTooltipHtml,
       'is_search': isSearch,
       'title': platformDict.pageTitle,
       'packages': packagesJson,

--- a/app/test/frontend/golden/v2/pkg_index_page.html
+++ b/app/test/frontend/golden/v2/pkg_index_page.html
@@ -75,6 +75,16 @@
 
 <main>
   
+<div class="listing-sort-header">
+  <div class="tooltip-base">
+    <span class="tooltip-dotted">Sorted by:</span> overall score
+    <div class="tooltip-content tooltip-bottom-left">
+      Packages are sorted by the overall score.
+      More information on <a href="/experimental/help#ranking">ranking</a>.
+    </div>
+  </div>
+</div>
+
 <h2 class="listing-page-title">Top Dart packages</h2>
 
 <ul class="package-list">

--- a/app/test/frontend/golden/v2/search_page.html
+++ b/app/test/frontend/golden/v2/search_page.html
@@ -75,6 +75,16 @@
 
 <main>
   
+<div class="listing-sort-header">
+  <div class="tooltip-base">
+    <span class="tooltip-dotted">Sorted by:</span> relevance
+    <div class="tooltip-content tooltip-bottom-left">
+      Packages are sorted by the combination of text match and overall score.
+      More information on <a href="/experimental/help#ranking">ranking</a>.
+    </div>
+  </div>
+</div>
+
 <p class="package-count"><span>2</span> results for <span>foobar</span></p>
 
 <ul class="package-list">

--- a/app/views/v2/help.mustache
+++ b/app/views/v2/help.mustache
@@ -70,4 +70,14 @@ linter:
     <a href="#health">health</a> and <a href="#maintenance">maintenance</a>.
   </p>
 
+  <h2 id="ranking">Ranking</h2>
+  <p>
+    We use the overall score to sort packages in default listings. When searching,
+    the overall score is combined with the text match relevancy score, and their
+    composite score will be used for sorting.
+  </p>
+  <p>
+    We are always displaying the package's overall score at the side of the results,
+    regardless of which sort order is applied on it.
+  </p>
 </div>

--- a/app/views/v2/pkg/index.mustache
+++ b/app/views/v2/pkg/index.mustache
@@ -2,6 +2,16 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
+<div class="listing-sort-header">
+  <div class="tooltip-base">
+    <span class="tooltip-dotted">Sorted by:</span> {{sort_name}}
+    <div class="tooltip-content tooltip-bottom-left">
+      {{& sort_tooltip_html }}
+      More information on <a href="/experimental/help#ranking">ranking</a>.
+    </div>
+  </div>
+</div>
+
 {{^is_search}}
 <h2 class="listing-page-title">{{title}}</h2>
 {{/is_search}}

--- a/static/v2/css/style.css
+++ b/static/v2/css/style.css
@@ -518,6 +518,11 @@ main, .site-header {
   font-weight: 500;
 }
 
+.listing-sort-header {
+  float: right;
+  margin: 0 1em 0.5em 2em;
+}
+
 .home-banner{
   text-align: center;
   padding: 40px 20px 10px 20px;
@@ -950,6 +955,16 @@ main, .site-header {
   border-width: 5px;
   border-style: solid;
   border-color: transparent transparent #ddd transparent;
+}
+
+.tooltip-bottom-left {
+  left: inherit;
+  right: -24px;
+}
+
+.tooltip-bottom-left.tooltip-content::after {
+  left: inherit;
+  right: 48px;
 }
 
 .tooltip-base:hover .tooltip-content {


### PR DESCRIPTION
I've tried a few things for #661 and this looks a reasonable first step. Displaying a tooltip over each score circle was a bit awkward-looking for me. This header also has the benefit that we can expand it to a dropdown to change the sort order.
![screen shot 2017-11-29 at 5 00 47 pm](https://user-images.githubusercontent.com/4778111/33384688-05993820-d527-11e7-8fa9-937fbeebe026.png)
