### PR TITLE
Indexing dependencies and searching using them.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -98,10 +98,19 @@ class SearchBackend {
         health: analysisView.health,
         popularity: popularity,
         maintenance: analysisView.maintenanceScore,
+        dependencies: _buildDependencies(analysisView),
         timestamp: new DateTime.now().toUtc(),
       );
     }
     return results;
+  }
+
+  Map<String, String> _buildDependencies(AnalysisView view) {
+    final Map<String, String> dependencies = <String, String>{};
+    view.allDependencies?.forEach((pd) {
+      dependencies[pd.package] = pd.dependencyType;
+    });
+    return dependencies;
   }
 }
 

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -116,6 +116,20 @@ class SimplePackageIndex implements PackageIndex {
       });
     }
 
+    // filter on dependency
+    if (query.parsedQuery.dependencies != null &&
+        query.parsedQuery.dependencies.isNotEmpty) {
+      for (String dependency in query.parsedQuery.dependencies) {
+        packages.removeWhere((package) {
+          final doc = _packages[package];
+          if (doc.dependencies == null) return true;
+          final bool hasDependency = doc.dependencies != null &&
+              doc.dependencies.containsKey(dependency);
+          return !hasDependency;
+        });
+      }
+    }
+
     // do text matching
     final Score textScore = _searchText(packages, query.parsedQuery.text);
     final Score filtered = textScore ?? _initScore(packages);

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -197,6 +197,9 @@ class AnalysisView {
   List<PkgDependency> get devDependencies =>
       _getDependencies(DependencyTypes.dev);
 
+  List<PkgDependency> get allDependencies =>
+      _summary?.pkgResolution?.dependencies;
+
   List<PkgDependency> _getDependencies(String type) {
     final List<PkgDependency> list = _summary?.pkgResolution?.dependencies
         ?.where((pd) => pd.dependencyType == type)

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -30,6 +30,9 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
         health: (json['health'] as num)?.toDouble(),
         popularity: (json['popularity'] as num)?.toDouble(),
         maintenance: (json['maintenance'] as num)?.toDouble(),
+        dependencies: json['dependencies'] == null
+            ? null
+            : new Map<String, String>.from(json['dependencies'] as Map),
         timestamp: json['timestamp'] == null
             ? null
             : DateTime.parse(json['timestamp'] as String));
@@ -46,6 +49,7 @@ abstract class _$PackageDocumentSerializerMixin {
   double get health;
   double get popularity;
   double get maintenance;
+  Map<String, String> get dependencies;
   DateTime get timestamp;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'package': package,
@@ -59,6 +63,7 @@ abstract class _$PackageDocumentSerializerMixin {
         'health': health,
         'popularity': popularity,
         'maintenance': maintenance,
+        'dependencies': dependencies,
         'timestamp': timestamp?.toIso8601String()
       };
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -496,6 +496,9 @@ class MockAnalysisView implements AnalysisView {
   List<PkgDependency> devDependencies;
 
   @override
+  List<PkgDependency> allDependencies;
+
+  @override
   double health;
 
   @override

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -119,6 +119,7 @@ void main() {
         popularity: 0.7,
         health: 1.0,
         maintenance: 1.0,
+        dependencies: {'async': 'direct', 'test': 'dev'},
       ));
       await index.addPackage(new PackageDocument(
         package: 'async',
@@ -138,6 +139,7 @@ The delegating wrapper classes allow users to easily add functionality on top of
         popularity: 0.8,
         health: 1.0,
         maintenance: 1.0,
+        dependencies: {'test': 'dev'},
       ));
       await index.addPackage(new PackageDocument(
         package: 'chrome_net',
@@ -384,6 +386,43 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
           {'package': 'http', 'score': 1.0},
           {'package': 'async', 'score': 1.0},
           {'package': 'chrome_net', 'score': 0.9},
+        ],
+      });
+    });
+
+    test('filter by one dependency', () async {
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(query: 'dependency:test'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 2,
+        'packages': [
+          {'package': 'async', 'score': closeTo(0.930, 0.001)},
+          {'package': 'http', 'score': closeTo(0.895, 0.001)},
+        ],
+      });
+    });
+
+    test('filter by text and dependency', () async {
+      final PackageSearchResult result = await index
+          .search(new SearchQuery.parse(query: 'composable dependency:test'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {'package': 'http', 'score': closeTo(0.105, 0.001)},
+        ],
+      });
+    });
+
+    test('filter by two dependencies', () async {
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(query: 'dependency:async dependency:test'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {'package': 'http', 'score': closeTo(0.895, 0.001)},
         ],
       });
     });

--- a/app/test/shared/search_service_test.dart
+++ b/app/test/shared/search_service_test.dart
@@ -30,6 +30,19 @@ void main() {
       expect(new SearchQuery.parse(query: ' text ').query, 'text');
       expect(new SearchQuery.parse(query: ' text ').parsedQuery.text, 'text');
     });
+
+    test('only one dependency', () {
+      final query = new SearchQuery.parse(query: 'dependency:pkg');
+      expect(query.parsedQuery.text, isNull);
+      expect(query.parsedQuery.dependencies, ['pkg']);
+    });
+
+    test('two dependencies with text blocks', () {
+      final query = new SearchQuery.parse(
+          query: 'text1 dependency:pkg1 text2 dependency:pkg2');
+      expect(query.parsedQuery.text, 'text1 text2');
+      expect(query.parsedQuery.dependencies, ['pkg1', 'pkg2']);
+    });
   });
 
   group('SearchQuery.isValid', () {


### PR DESCRIPTION
I'm not sure in what format we want to expose this, but seems to be useful in general. Some possible alternatives (for later refinement):
- we could use different keywords for direct- dev- or transitive dependencies (e.g. `devDependency:packageName`)
- we could default to search only `direct` and `dev` dependencies, and include all if: `dependency*:package` or `*dependency:package` is specified

Besides search, we could put a link on each package page: "Who is using this?"