### PR TITLE
String interning for package documents.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -9,6 +9,7 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:pana/pana.dart' show DependencyTypes;
 
 import '../shared/search_service.dart';
+import '../shared/utils.dart' show StringInternPool;
 
 import 'platform_specificity.dart';
 import 'scoring.dart';

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -27,6 +27,7 @@ class SimplePackageIndex implements PackageIndex {
   final TokenIndex _nameIndex = new TokenIndex(minLength: 2);
   final TokenIndex _descrIndex = new TokenIndex(minLength: 3);
   final TokenIndex _readmeIndex = new TokenIndex(minLength: 3);
+  final StringInternPool _internPool = new StringInternPool();
   DateTime _lastUpdated;
   bool _isReady = false;
 
@@ -63,7 +64,8 @@ class SimplePackageIndex implements PackageIndex {
   }
 
   @override
-  Future addPackage(PackageDocument doc) async {
+  Future addPackage(PackageDocument document) async {
+    final PackageDocument doc = document.intern(_internPool.intern);
     await removePackage(doc.package);
     _packages[doc.package] = doc;
     _nameIndex.add(doc.package, doc.package);
@@ -196,6 +198,7 @@ class SimplePackageIndex implements PackageIndex {
   Future merge() async {
     _isReady = true;
     _lastUpdated = new DateTime.now().toUtc();
+    _internPool.checkUnboundGrowth();
   }
 
   // visible for testing only

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -37,3 +37,15 @@ Iterable<String> splitForIndexing(String text) {
 
 List<String> extractExactPhrases(String text) =>
     _exactTermRegExp.allMatches(text).map((m) => m.group(1)).toList();
+
+class StringInternPool {
+  final Map<String, String> _values = <String, String>{};
+
+  String intern(String value) => _values.putIfAbsent(value, () => value);
+
+  void checkUnboundGrowth() {
+    if (_values.length > 100000) {
+      _values.clear();
+    }
+  }
+}

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -37,15 +37,3 @@ Iterable<String> splitForIndexing(String text) {
 
 List<String> extractExactPhrases(String text) =>
     _exactTermRegExp.allMatches(text).map((m) => m.group(1)).toList();
-
-class StringInternPool {
-  final Map<String, String> _values = <String, String>{};
-
-  String intern(String value) => _values.putIfAbsent(value, () => value);
-
-  void checkUnboundGrowth() {
-    if (_values.length > 100000) {
-      _values.clear();
-    }
-  }
-}

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -78,6 +78,30 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
 
   factory PackageDocument.fromJson(Map<String, dynamic> json) =>
       _$PackageDocumentFromJson(json);
+
+  PackageDocument intern(String internFn(String value)) {
+    return new PackageDocument(
+      package: internFn(package),
+      version: version,
+      devVersion: devVersion,
+      description: description,
+      created: created,
+      updated: updated,
+      readme: readme,
+      platforms: platforms?.map(internFn)?.toList(),
+      health: health,
+      popularity: popularity,
+      maintenance: maintenance,
+      dependencies: dependencies == null
+          ? null
+          : new Map.fromIterable(
+              dependencies.keys,
+              key: (key) => internFn(key),
+              value: (key) => internFn(dependencies[key]),
+            ),
+      timestamp: timestamp,
+    );
+  }
 }
 
 /// How search results should be ordered.

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -335,3 +335,17 @@ Future<http.Response> getUrlWithRetry(http.Client client, String url,
 /// Returns a valid `gs://` URI for a given [bucket] + [path] combination.
 String bucketUri(Bucket bucket, String path) =>
     "gs://${bucket.bucketName}/$path";
+
+/// To avoid having the same String values many times in memory we intern them.
+/// https://en.wikipedia.org/wiki/String_interning
+class StringInternPool {
+  final Map<String, String> _values = <String, String>{};
+
+  String intern(String value) => _values.putIfAbsent(value, () => value);
+
+  void checkUnboundGrowth() {
+    if (_values.length > 100000) {
+      _values.clear();
+    }
+  }
+}


### PR DESCRIPTION
I don't think this is strictly required at the moment, but we may need it later. No measurable speed drawback during indexing, and at the moment only a little memory benefit on staging (hard to tell, lots of memory size fluctuations).
