### PR TITLE
Change dependency search: default is referenced deps, dependency* for transitive deps.

### DIFF
--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -119,7 +119,7 @@ void main() {
         popularity: 0.7,
         health: 1.0,
         maintenance: 1.0,
-        dependencies: {'async': 'direct', 'test': 'dev'},
+        dependencies: {'async': 'direct', 'test': 'dev', 'foo': 'transitive'},
       ));
       await index.addPackage(new PackageDocument(
         package: 'async',
@@ -155,6 +155,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         popularity: 0.0,
         health: 0.5,
         maintenance: 0.9,
+        dependencies: {'foo': 'direct'},
       ));
       await index.merge();
     });
@@ -399,6 +400,31 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {'package': 'async', 'score': closeTo(0.930, 0.001)},
           {'package': 'http', 'score': closeTo(0.895, 0.001)},
+        ],
+      });
+    });
+
+    test('filter by foo as direct/dev dependency', () async {
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(query: 'dependency:foo'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {'package': 'chrome_net', 'score': closeTo(0.531, 0.001)},
+        ],
+      });
+    });
+
+    test('filter by foo as transitive dependency', () async {
+      final PackageSearchResult result =
+          await index.search(new SearchQuery.parse(query: 'dependency*:foo'));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 2,
+        'packages': [
+          {'package': 'http', 'score': closeTo(0.895, 0.001)},
+          {'package': 'chrome_net', 'score': closeTo(0.531, 0.001)},
         ],
       });
     });

--- a/app/test/shared/search_service_test.dart
+++ b/app/test/shared/search_service_test.dart
@@ -31,17 +31,46 @@ void main() {
       expect(new SearchQuery.parse(query: ' text ').parsedQuery.text, 'text');
     });
 
+    test('no dependency', () {
+      final query = new SearchQuery.parse(query: 'text');
+      expect(query.parsedQuery.text, 'text');
+      expect(query.parsedQuery.refDependencies, []);
+      expect(query.parsedQuery.allDependencies, []);
+      expect(query.parsedQuery.hasAnyDependency, isFalse);
+    });
+
     test('only one dependency', () {
       final query = new SearchQuery.parse(query: 'dependency:pkg');
       expect(query.parsedQuery.text, isNull);
-      expect(query.parsedQuery.dependencies, ['pkg']);
+      expect(query.parsedQuery.refDependencies, ['pkg']);
+      expect(query.parsedQuery.allDependencies, []);
+      expect(query.parsedQuery.hasAnyDependency, isTrue);
+    });
+
+    test('only one dependency*', () {
+      final query = new SearchQuery.parse(query: 'dependency*:pkg');
+      expect(query.parsedQuery.text, isNull);
+      expect(query.parsedQuery.refDependencies, []);
+      expect(query.parsedQuery.allDependencies, ['pkg']);
+      expect(query.parsedQuery.hasAnyDependency, isTrue);
     });
 
     test('two dependencies with text blocks', () {
       final query = new SearchQuery.parse(
           query: 'text1 dependency:pkg1 text2 dependency:pkg2');
       expect(query.parsedQuery.text, 'text1 text2');
-      expect(query.parsedQuery.dependencies, ['pkg1', 'pkg2']);
+      expect(query.parsedQuery.refDependencies, ['pkg1', 'pkg2']);
+      expect(query.parsedQuery.allDependencies, []);
+      expect(query.parsedQuery.hasAnyDependency, isTrue);
+    });
+
+    test('two mixed dependencies with text blocks', () {
+      final query = new SearchQuery.parse(
+          query: 'text1 dependency:pkg1 text2 dependency*:pkg2');
+      expect(query.parsedQuery.text, 'text1 text2');
+      expect(query.parsedQuery.refDependencies, ['pkg1']);
+      expect(query.parsedQuery.allDependencies, ['pkg2']);
+      expect(query.parsedQuery.hasAnyDependency, isTrue);
     });
   });
 


### PR DESCRIPTION
- `dependency:http` will return packages that directly reference `http` as either normal or dev dependency
- `dependency*:http` will return all packages that have `http` as any kind of dependency (incl. transitive).