### PR TITLE
Hint and help about search expressions.

### DIFF
--- a/app/test/frontend/golden/v2/search_page.html
+++ b/app/test/frontend/golden/v2/search_page.html
@@ -85,7 +85,7 @@
   </div>
 </div>
 
-<p class="package-count"><span>2</span> results for <span>foobar</span></p>
+<p class="package-count"><span>2</span> results for <code>foobar</code></p>
 
 <ul class="package-list">
     <li class="list-item -full">
@@ -157,6 +157,7 @@
     </li>
 </ul>
 
+  <p>Check our help page for <a href="/experimental/help#search">advanced search expressions</a>.</p>
 
 </main>
 

--- a/app/views/v2/help.mustache
+++ b/app/views/v2/help.mustache
@@ -2,6 +2,14 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 <div style="max-width: 600px">
+  <h2 id="search">Search</h2>
+  <p>We support the following search expressions:</p>
+  <ul>
+    <li><code>"exact phrases"</code> - normally we return results with similar phrases, but putting it inside quotes makes sure that we return only results that have the expression in that form somewhere.</li>
+    <li><code>package:prefix</code> - return only packages that begin with <code>prefix</code>. Useful to search for packages of the same framework.</li>
+    <li><code>dependency:package_name</code> - return only packages that reference <code>package_name</code> in their pubspec</li>
+    <li><code>dependency*:package_name</code> - return only packages that depend on <code>package_name</code> (direct, dev or transitive dependencies)</li>
+  </ul>
   <h2 id="scoring">Scoring</h2>
   <p>
     We calculate <a href="#popularity">popularity</a>, <a href="#health">health</a> and

--- a/app/views/v2/pkg/index.mustache
+++ b/app/views/v2/pkg/index.mustache
@@ -16,7 +16,7 @@
 <h2 class="listing-page-title">{{title}}</h2>
 {{/is_search}}
 {{#is_search}}
-<p class="package-count"><span>{{total_count}}</span> results for <span>{{search_query}}</span></p>
+<p class="package-count"><span>{{total_count}}</span> results for <code>{{search_query}}</code></p>
 {{/is_search}}
 
 <ul class="package-list">
@@ -38,3 +38,6 @@
 {{#has_packages}}
   {{{pagination}}}
 {{/has_packages}}
+{{#is_search}}
+  <p>Check our help page for <a href="/experimental/help#search">advanced search expressions</a>.</p>
+{{/is_search}}


### PR DESCRIPTION
- `<code>` makes the expression more visible
- started a section on the help page, we shall iterate on it, but at least it is linked to and visible