### PR TITLE
More diverse platform specificity scores.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -10,6 +10,7 @@ import 'package:pana/pana.dart' show DependencyTypes;
 
 import '../shared/search_service.dart';
 
+import 'platform_specificity.dart';
 import 'scoring.dart';
 import 'text_utils.dart';
 
@@ -113,7 +114,7 @@ class SimplePackageIndex implements PackageIndex {
       packages.forEach((String package) {
         final PackageDocument doc = _packages[package];
         platformSpecificity[package] =
-            _scorePlatformMatch(doc.platforms, query.platformPredicate);
+            scorePlatformSpecificity(doc.platforms, query.platformPredicate);
       });
     }
 
@@ -326,20 +327,6 @@ class SimplePackageIndex implements PackageIndex {
     if (a.updated == null) return -1;
     if (b.updated == null) return 1;
     return -a.updated.compareTo(b.updated);
-  }
-
-  double _scorePlatformMatch(List<String> platforms, PlatformPredicate p) {
-    double score = 1.0;
-    final int requiredCount = p.required?.length ?? 0;
-    final int platformCount = platforms?.length ?? 0;
-    if (requiredCount > 0) {
-      if (platformCount == requiredCount + 1) {
-        score *= 0.99;
-      } else if (platformCount > requiredCount + 1) {
-        score *= 0.80;
-      }
-    }
-    return score;
   }
 }
 

--- a/app/lib/search/platform_specificity.dart
+++ b/app/lib/search/platform_specificity.dart
@@ -1,0 +1,81 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../shared/platform.dart';
+
+double scorePlatformSpecificity(List<String> platforms, PlatformPredicate p) {
+  _SpecificityFn fn;
+  if (p != null && p.isNotEmpty) {
+    if (p.isSingle) {
+      fn = _platformFns[p.single];
+    }
+    fn ??= _lightSingle;
+  } else {
+    fn = _allPlatforms;
+  }
+  return fn(platforms);
+}
+
+/// Returns the platform specificity score given the package's platforms.
+typedef double _SpecificityFn(List<String> platforms);
+
+final _platformFns = const <String, _SpecificityFn>{
+  KnownPlatforms.flutter: _heavySingle,
+  KnownPlatforms.server: _nonGeneric,
+  KnownPlatforms.web: _lightSingle,
+};
+
+/// Bias towards all platforms: ['a', 'b', 'c'] > ['a', 'b'] > ['a'].
+double _allPlatforms(List<String> platforms) {
+  final int count = platforms?.length ?? 0;
+  final int diff = KnownPlatforms.all.length - count;
+  if (diff <= 0) {
+    return 1.0;
+  } else if (diff == 1) {
+    return 0.95;
+  } else if (diff == 2) {
+    return 0.90;
+  } else {
+    return 0.80;
+  }
+}
+
+/// Heavy bias towards a single platform: ['a'] >> ['a', 'b'] >> ['a', 'b', 'c'].
+double _heavySingle(List<String> platforms) {
+  final int count = platforms?.length ?? 0;
+  if (count == 1) {
+    return 1.0;
+  } else if (count == 2) {
+    return 0.90;
+  } else {
+    return 0.80;
+  }
+}
+
+/// Light bias towards single platform: ['a'] > ['a', 'b'] > ['a', 'b', 'c'].
+double _lightSingle(List<String> platforms) {
+  final int count = platforms?.length ?? 0;
+  if (count == 1) {
+    return 1.0;
+  } else if (count == 2) {
+    return 0.95;
+  } else {
+    return 0.90;
+  }
+}
+
+/// Bias towards being non-generic (one step below all-platforms):
+/// - ['a', 'b'] > ['a', 'b', 'c']
+/// - ['a', 'b'] > ['a']
+double _nonGeneric(List<String> platforms) {
+  final int count = platforms?.length ?? 0;
+  final int diff = (KnownPlatforms.all.length - 1 - count).abs();
+  if (diff == 0) {
+    return 1.0;
+  } else if (diff == 1) {
+    return 0.95;
+  } else {
+    return 0.90;
+  }
+}


### PR DESCRIPTION
Reflecting on multiple feedback on the list of top scoring:
- 'All packages' will prefer generic packages.
- 'Web' and 'Flutter' will prefer single-platform packages (Flutter heavily, Web lightly).
- 'Server' will prefer almost-generic packages (e.g. flutter+server or server+web).
