### PR TITLE
New template for author and uploader rendering.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -445,6 +445,8 @@ class TemplateService {
           selectedVersion.pubspec.getAllAuthors(),
           clickableName: true,
         ),
+        'authors_v2_html':
+            _getAuthorsHtmlV2(selectedVersion.pubspec.getAllAuthors()),
         'homepage': selectedVersion.homepage,
         'nice_homepage': selectedVersion.homepageNice,
         'documentation': selectedVersion.documentation,
@@ -452,6 +454,7 @@ class TemplateService {
         // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
         'uploaders_title': 'Uploader',
         'uploaders_html': _getUploadersHtml(package),
+        'uploaders_v2_html': _getAuthorsHtmlV2(package.uploaderEmails),
         'short_created': selectedVersion.shortCreated,
         'install_html': _renderInstall(isFlutterPlugin, analysis?.platforms),
         'license_html':
@@ -909,6 +912,23 @@ String _getAuthorsHtml(List<String> authors, {bool clickableName: false}) {
           '<i class="icon-envelope"></i>$closeTag</span>';
     } else {
       return '<span class="author"><i class="icon-envelope"></i> $escapedName</span>';
+    }
+  }).join('<br/>');
+}
+
+String _getAuthorsHtmlV2(List<String> authors) {
+  return (authors ?? const []).map((String value) {
+    final Author author = new Author.parse(value);
+    final escapedName = _htmlEscaper.convert(author.name);
+    final String nameHtml =
+        '<span class="author">$escapedName</span>';
+    if (author.email != null) {
+      final escapedEmail = _attrEscaper.convert(author.email);
+      final String emailHtml =
+          '<a href="mailto:$escapedEmail" title="Email $escapedEmail">mail</a>';
+      return '$nameHtml ($emailHtml)';
+    } else {
+      return nameHtml;
     }
   }).join('<br/>');
 }

--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -259,7 +259,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
 
     <h3 class="title">Author</h3>
-    <div><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="icon-envelope"></i> Hans Juergen</a></span></div>
+    <div><span class="author">Hans Juergen</span> (<a href="mailto:hans@juergen.com" title="Email hans@juergen.com">mail</a>)</div>
 
       <h3 class="title">Homepage</h3>
       <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
@@ -268,7 +268,7 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
-    <p>hans@juergen.com</p>
+    <p><span class="author">hans@juergen.com</span> (<a href="mailto:hans@juergen.com" title="Email hans@juergen.com">mail</a>)</p>
 
       <h3 class="title">License</h3>
       <p>BSD (LICENSE.txt)</p>

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -250,7 +250,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
 
     <h3 class="title">Author</h3>
-    <div><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="icon-envelope"></i> Hans Juergen</a></span></div>
+    <div><span class="author">Hans Juergen</span> (<a href="mailto:hans@juergen.com" title="Email hans@juergen.com">mail</a>)</div>
 
       <h3 class="title">Homepage</h3>
       <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
@@ -259,7 +259,7 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
-    <p>hans@juergen.com</p>
+    <p><span class="author">hans@juergen.com</span> (<a href="mailto:hans@juergen.com" title="Email hans@juergen.com">mail</a>)</p>
 
   </aside>
 </div>

--- a/app/views/v2/pkg/show.mustache
+++ b/app/views/v2/pkg/show.mustache
@@ -109,7 +109,7 @@ import 'package:{{package}}/{{library}}';
     {{/package.description}}
 
     <h3 class="title">{{package.authors_title}}</h3>
-    <div>{{& package.authors_html}}</div>
+    <div>{{& package.authors_v2_html}}</div>
 
     {{#package.homepage}}
       <h3 class="title">Homepage</h3>
@@ -122,7 +122,7 @@ import 'package:{{package}}/{{library}}';
     {{/package.documentation}}
 
     <h3 class="title">{{package.uploaders_title}}</h3>
-    <p>{{& package.uploaders_html}}</p>
+    <p>{{& package.uploaders_v2_html}}</p>
 
     {{#package.license_html}}
       <h3 class="title">License</h3>


### PR DESCRIPTION
The idea here is to:
- have the same template and UX for authors (name and/or email) and uploaders (e-mail only)
- now it is only e-mail, but in the near future we could add `packages` there, which would link to the search that lists all of the packages that the email-address is associated to

<img width="251" alt="screen shot 2017-12-04 at 3 41 49 pm" src="https://user-images.githubusercontent.com/4778111/33558431-17e2b862-d90a-11e7-921e-01aa2de2b80b.png">

Related to #694