### PR TITLE
Search: remove token length tolerance.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -251,11 +251,9 @@ class SimplePackageIndex implements PackageIndex {
 
         final maxTokenLength = math.max(nameTokens.maxLength,
             math.max(descrTokens.maxLength, readmeTokens.maxLength));
-        final minTokenLength =
-            maxTokenLength - math.max(1, maxTokenLength ~/ 3);
-        nameTokens.removeShortTokens(minTokenLength);
-        descrTokens.removeShortTokens(minTokenLength);
-        readmeTokens.removeShortTokens(minTokenLength);
+        nameTokens.removeShortTokens(maxTokenLength);
+        descrTokens.removeShortTokens(maxTokenLength);
+        readmeTokens.removeShortTokens(maxTokenLength);
 
         final name = new Score(_nameIndex.scoreDocs(nameTokens,
             weight: 1.00, wordCount: wordCount));

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -223,7 +223,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.13, 0.01),
+            'score': closeTo(0.03, 0.01),
           },
         ]
       });


### PR DESCRIPTION
This fixes #705, where the root cause of the issue was the `dart` token. With the max token length of 6, we were searching with all of the 4-, 5- and 6-long tokens, including the `dart` token, which skewed the results.

I've tried various alternatives to `maxTokenLength ~/ 3`, and `maxTokenLength-1` was an effective alternative. However, that wouldn't solve the names with 1 character off, and eventually decided to remove the tolerance now. We can easily re-introduce it later if need.