### PR TITLE
Remove 'all platforms' specificity.

### DIFF
--- a/app/lib/search/platform_specificity.dart
+++ b/app/lib/search/platform_specificity.dart
@@ -12,7 +12,7 @@ double scorePlatformSpecificity(List<String> platforms, PlatformPredicate p) {
     }
     fn ??= _lightSingle;
   } else {
-    fn = _allPlatforms;
+    fn = _defaultScore;
   }
   return fn(platforms);
 }
@@ -26,20 +26,7 @@ final _platformFns = const <String, _SpecificityFn>{
   KnownPlatforms.web: _lightSingle,
 };
 
-/// Bias towards all platforms: ['a', 'b', 'c'] > ['a', 'b'] > ['a'].
-double _allPlatforms(List<String> platforms) {
-  final int count = platforms?.length ?? 0;
-  final int diff = KnownPlatforms.all.length - count;
-  if (diff <= 0) {
-    return 1.0;
-  } else if (diff == 1) {
-    return 0.95;
-  } else if (diff == 2) {
-    return 0.90;
-  } else {
-    return 0.80;
-  }
-}
+double _defaultScore(List<String> platforms) => 1.0;
 
 /// Heavy bias towards a single platform: ['a'] >> ['a', 'b'] >> ['a', 'b', 'c'].
 double _heavySingle(List<String> platforms) {

--- a/app/test/search/platform_specificity_test.dart
+++ b/app/test/search/platform_specificity_test.dart
@@ -19,23 +19,23 @@ void main() {
     final PlatformPredicate web = new PlatformPredicate.parse('web');
 
     test('empty or null values', () {
-      expect(scorePlatformSpecificity(null, empty), 0.8);
-      expect(scorePlatformSpecificity([], empty), 0.8);
-      expect(scorePlatformSpecificity([], null), 0.8);
+      expect(scorePlatformSpecificity(null, empty), 1.0);
+      expect(scorePlatformSpecificity([], empty), 1.0);
+      expect(scorePlatformSpecificity([], null), 1.0);
       expect(scorePlatformSpecificity([], flutter), 0.8);
       expect(scorePlatformSpecificity([], server), 0.9);
       expect(scorePlatformSpecificity([], web), 0.9);
     });
 
     test('single', () {
-      expect(scorePlatformSpecificity(['flutter'], null), 0.9);
+      expect(scorePlatformSpecificity(['flutter'], null), 1.0);
       expect(scorePlatformSpecificity(['flutter'], flutter), 1.0);
       expect(scorePlatformSpecificity(['server'], server), 0.95);
       expect(scorePlatformSpecificity(['web'], web), 1.0);
     });
 
     test('two platforms', () {
-      expect(scorePlatformSpecificity(['flutter', 'server'], null), 0.95);
+      expect(scorePlatformSpecificity(['flutter', 'server'], null), 1.0);
       expect(scorePlatformSpecificity(['flutter', 'server'], flutter), 0.9);
       expect(scorePlatformSpecificity(['flutter', 'server'], server), 1.0);
       expect(scorePlatformSpecificity(['flutter', 'server'], web), 0.95);


### PR DESCRIPTION
This was never hit by the search ranking anyway, and when I've fixed that part, the listing of top packages looked a bit weird. I'd rather to use only popularity for those packages.