### PR TITLE
V2 release

### DIFF
--- a/app/lib/frontend/template_consts.dart
+++ b/app/lib/frontend/template_consts.dart
@@ -24,11 +24,8 @@ class PlatformDict {
     return new PlatformDict(
       name: _formattedPlatformName(platform),
       landingBlurb: _landingBlurb(platform),
-      landingUrl:
-          platform == null ? '/experimental' : '/experimental/$platform',
-      listingUrl: platform == null
-          ? '/experimental/packages'
-          : '/experimental/$platform/packages',
+      landingUrl: platform == null ? '/' : '/$platform',
+      listingUrl: platform == null ? '/packages' : '/$platform/packages',
     );
   }
 }
@@ -63,8 +60,8 @@ String _formattedPlatformName(String platform) {
 
 final Map<String, String> _landingBlurbs = const {
   'default':
-      '<p class="text">Find and use packages to build <a href="/experimental/flutter">Flutter</a>, '
-      '<a href="/experimental/web">web</a> and <a href="/experimental/server">server</a> apps '
+      '<p class="text">Find and use packages to build <a href="/flutter">Flutter</a>, '
+      '<a href="/web">web</a> and <a href="/server">server</a> apps '
       'with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>',
   KnownPlatforms.flutter:
       '<p class="text"><a href="https://flutter.io/">Flutter<sup><small>↗</small></sup></a> '

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -542,7 +542,7 @@ class TemplateService {
     );
     values['search_deps_link'] = _attrEscaper.convert(
       new Uri(
-        path: '/experimental/packages',
+        path: '/packages',
         queryParameters: {'q': 'dependency:${package.name}'},
       ).toString(),
     );
@@ -826,8 +826,7 @@ class TemplateService {
       });
     } else if (platforms.isEmpty) {
       final String hash = '#-analysis-tab-';
-      final String href =
-          package == null ? hash : '/experimental/packages/$package$hash';
+      final String href = package == null ? hash : '/packages/$package$hash';
       tags.add({
         'status': 'unidentified',
         'text': '[unidentified]',
@@ -931,7 +930,7 @@ String _renderScoreBox(double overallScore, {String package}) {
       // TODO: decide on label - {{! <span class="text">?????</span> }}
       '</div>';
   if (package != null) {
-    return '<a href="/experimental/packages/$package#-analysis-tab-">$boxHtml</a>';
+    return '<a href="/packages/$package#-analysis-tab-">$boxHtml</a>';
   } else {
     return boxHtml;
   }
@@ -1106,6 +1105,6 @@ String _rankingTooltip(bool isSearch) {
       ? 'Packages are sorted by the combination of text match and overall score.'
       : 'Packages are sorted by the overall score.';
   final String rankingLinkHtml =
-      'More information on <a href="/experimental/help#ranking">ranking</a>.';
+      'More information on <a href="/help#ranking">ranking</a>.';
   return '$sortTooltipHtml $rankingLinkHtml';
 }

--- a/app/lib/shared/memcache.dart
+++ b/app/lib/shared/memcache.dart
@@ -16,7 +16,6 @@ const Duration searchUiPageExpiration = const Duration(minutes: 10);
 const Duration memcacheRequestTimeout = const Duration(seconds: 5);
 
 const String indexUiPageKey = 'pub_index';
-const String v2IndexUiPageKey = 'experimental/pub_index';
 const String packageJsonPrefix = 'package_json_';
 const String packageUiPagePrefix = 'package_ui_';
 const String analyzerDataPrefix = 'dart_analyzer_api_';

--- a/app/lib/shared/package_memcache.dart
+++ b/app/lib/shared/package_memcache.dart
@@ -18,16 +18,15 @@ final Logger _logger = new Logger('pub.package_memcache');
 abstract class UIPackageCache {
   // If [version] is `null` then it corresponds to the cache entry which can be
   // invalidated via [invalidateUiPackagePage].
-  Future<String> getUIPackagePage(bool isV2, String package, String version);
+  Future<String> getUIPackagePage(String package, String version);
 
   // If [version] is `null` then it corresponds to the cache entry which can be
   // invalidated via [invalidateUiPackagePage].
-  Future setUIPackagePage(
-      bool isV2, String package, String version, String data);
+  Future setUIPackagePage(String package, String version, String data);
 
-  Future<String> getUIIndexPage(bool isV2, String platform);
+  Future<String> getUIIndexPage(String platform);
 
-  Future setUIIndexPage(bool isV2, String platform, String content);
+  Future setUIIndexPage(String platform, String content);
 
   Future invalidateUIPackagePage(String package);
 }
@@ -54,13 +53,12 @@ class AppEnginePackageMemcache implements PackageCache, UIPackageCache {
       _json.setBytes(package, data);
 
   @override
-  Future<String> getUIPackagePage(bool isV2, String package, String version) =>
-      _uiPage.getText(_pvKey(isV2, package, version));
+  Future<String> getUIPackagePage(String package, String version) =>
+      _uiPage.getText(_pvKey(package, version));
 
   @override
-  Future setUIPackagePage(
-          bool isV2, String package, String version, String data) =>
-      _uiPage.setText(_pvKey(isV2, package, version), data);
+  Future setUIPackagePage(String package, String version, String data) =>
+      _uiPage.setText(_pvKey(package, version), data);
 
   @override
   Future invalidateUIPackagePage(String package) =>
@@ -75,31 +73,26 @@ class AppEnginePackageMemcache implements PackageCache, UIPackageCache {
     if (invalidateData) {
       yield _json.invalidate(package);
     }
-    yield _uiPage.invalidate(_pvKey(false, package, null));
-    yield _uiPage.invalidate(_pvKey(true, package, null));
-    yield _uiIndexPage.invalidate(_indexPageKey(false, null));
-    yield _uiIndexPage.invalidate(_indexPageKey(true, null));
+    yield _uiPage.invalidate(_pvKey(package, null));
+    yield _uiIndexPage.invalidate(_indexPageKey(null));
     for (String platform in KnownPlatforms.all) {
-      yield _uiIndexPage.invalidate(_indexPageKey(false, platform));
-      yield _uiIndexPage.invalidate(_indexPageKey(true, platform));
+      yield _uiIndexPage.invalidate(_indexPageKey(platform));
     }
   }
 
   @override
-  Future<String> getUIIndexPage(bool isV2, String platform) =>
-      _uiIndexPage.getText(_indexPageKey(isV2, platform));
+  Future<String> getUIIndexPage(String platform) =>
+      _uiIndexPage.getText(_indexPageKey(platform));
 
   @override
-  Future setUIIndexPage(bool isV2, String platform, String content) =>
-      _uiIndexPage.setText(_indexPageKey(isV2, platform), content);
+  Future setUIIndexPage(String platform, String content) =>
+      _uiIndexPage.setText(_indexPageKey(platform), content);
 
-  String _indexPageKey(bool isV2, String platform) {
-    final String prefix = isV2 ? v2IndexUiPageKey : indexUiPageKey;
-    return '$prefix/$platform';
+  String _indexPageKey(String platform) {
+    return '$indexUiPageKey/$platform';
   }
 
-  String _pvKey(bool isV2, String package, String version) {
-    final String prefix = isV2 ? '/experimental' : '';
-    return '$prefix/$package/$version';
+  String _pvKey(String package, String version) {
+    return '$package/$version';
   }
 }

--- a/app/test/frontend/golden/v2/analysis_tab_http.html
+++ b/app/test/frontend/golden/v2/analysis_tab_http.html
@@ -29,7 +29,7 @@
         <span class="tooltip-dotted">Popularity:</span>
         <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
-          <a href="/experimental/help#popularity">[more]</a>
+          <a href="/help#popularity">[more]</a>
         </div>
       </div>
     </td>
@@ -41,7 +41,7 @@
         <span class="tooltip-dotted">Health:</span>
         <div class="tooltip-content">
           Code health derived from static analysis.
-          <a href="/experimental/help#health">[more]</a>
+          <a href="/help#health">[more]</a>
         </div>
       </div>
     </td>
@@ -53,7 +53,7 @@
         <span class="tooltip-dotted">Maintenance:</span>
         <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
-          <a href="/experimental/help#maintenance">[more]</a>
+          <a href="/help#maintenance">[more]</a>
         </div>
       </div>
     </td>
@@ -65,7 +65,7 @@
         <span class="tooltip-dotted"><b>Overall score:</b></span>
         <div class="tooltip-content">
           Weighted score of the above.
-          <a href="/experimental/help#overall-score">[more]</a>
+          <a href="/help#overall-score">[more]</a>
         </div>
       </div>
     </td>
@@ -101,31 +101,31 @@
     <th colspan="4" class="sub-header">Direct dependencies</th>
   </tr>
   <tr>
-    <td><a href="/experimental/packages/async">async</a></td>
+    <td><a href="/packages/async">async</a></td>
     <td>^1.10.0</td>
     <td>1.13.3</td>
     <td>2.0.1</td>
   </tr>
   <tr>
-    <td><a href="/experimental/packages/collection">collection</a></td>
+    <td><a href="/packages/collection">collection</a></td>
     <td>^1.5.0</td>
     <td>1.14.3</td>
     <td></td>
   </tr>
   <tr>
-    <td><a href="/experimental/packages/http_parser">http_parser</a></td>
+    <td><a href="/packages/http_parser">http_parser</a></td>
     <td>&gt;=0.0.1 &lt;4.0.0</td>
     <td>3.1.1</td>
     <td></td>
   </tr>
   <tr>
-    <td><a href="/experimental/packages/path">path</a></td>
+    <td><a href="/packages/path">path</a></td>
     <td>&gt;=0.9.0 &lt;2.0.0</td>
     <td>1.5.1</td>
     <td></td>
   </tr>
   <tr>
-    <td><a href="/experimental/packages/stack_trace">stack_trace</a></td>
+    <td><a href="/packages/stack_trace">stack_trace</a></td>
     <td>&gt;=0.9.1 &lt;2.0.0</td>
     <td>1.9.1</td>
     <td></td>
@@ -134,25 +134,25 @@
     <th colspan="4" class="sub-header">Transitive dependencies</th>
   </tr>
     <tr>
-      <td><a href="/experimental/packages/charcode">charcode</a></td>
+      <td><a href="/packages/charcode">charcode</a></td>
       <td></td>
       <td>1.1.1</td>
       <td></td>
     </tr>
     <tr>
-      <td><a href="/experimental/packages/source_span">source_span</a></td>
+      <td><a href="/packages/source_span">source_span</a></td>
       <td></td>
       <td>1.4.0</td>
       <td></td>
     </tr>
     <tr>
-      <td><a href="/experimental/packages/string_scanner">string_scanner</a></td>
+      <td><a href="/packages/string_scanner">string_scanner</a></td>
       <td></td>
       <td>1.0.2</td>
       <td></td>
     </tr>
     <tr>
-      <td><a href="/experimental/packages/typed_data">typed_data</a></td>
+      <td><a href="/packages/typed_data">typed_data</a></td>
       <td></td>
       <td>1.1.5</td>
       <td></td>
@@ -161,7 +161,7 @@
     <th colspan="4" class="sub-header">Dev dependencies</th>
   </tr>
     <tr>
-      <td><a href="/experimental/packages/unittest">unittest</a></td>
+      <td><a href="/packages/unittest">unittest</a></td>
       <td>&gt;=0.9.0 &lt;0.12.0</td>
       <td></td>
       <td></td>

--- a/app/test/frontend/golden/v2/analysis_tab_mock.html
+++ b/app/test/frontend/golden/v2/analysis_tab_mock.html
@@ -29,7 +29,7 @@
         <span class="tooltip-dotted">Popularity:</span>
         <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
-          <a href="/experimental/help#popularity">[more]</a>
+          <a href="/help#popularity">[more]</a>
         </div>
       </div>
     </td>
@@ -41,7 +41,7 @@
         <span class="tooltip-dotted">Health:</span>
         <div class="tooltip-content">
           Code health derived from static analysis.
-          <a href="/experimental/help#health">[more]</a>
+          <a href="/help#health">[more]</a>
         </div>
       </div>
     </td>
@@ -53,7 +53,7 @@
         <span class="tooltip-dotted">Maintenance:</span>
         <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
-          <a href="/experimental/help#maintenance">[more]</a>
+          <a href="/help#maintenance">[more]</a>
         </div>
       </div>
     </td>
@@ -65,7 +65,7 @@
         <span class="tooltip-dotted"><b>Overall score:</b></span>
         <div class="tooltip-content">
           Weighted score of the above.
-          <a href="/experimental/help#overall-score">[more]</a>
+          <a href="/help#overall-score">[more]</a>
         </div>
       </div>
     </td>
@@ -101,7 +101,7 @@
     <th colspan="4" class="sub-header">Direct dependencies</th>
   </tr>
   <tr>
-    <td><a href="/experimental/packages/http">http</a></td>
+    <td><a href="/packages/http">http</a></td>
     <td>^1.0.0</td>
     <td>1.0.0</td>
     <td>1.1.0</td>
@@ -110,7 +110,7 @@
     <th colspan="4" class="sub-header">Transitive dependencies</th>
   </tr>
     <tr>
-      <td><a href="/experimental/packages/async">async</a></td>
+      <td><a href="/packages/async">async</a></td>
       <td>&gt;=0.3.0 &lt;1.0.0</td>
       <td>0.5.1</td>
       <td>1.0.2</td>

--- a/app/test/frontend/golden/v2/flutter_landing_page.html
+++ b/app/test/frontend/golden/v2/flutter_landing_page.html
@@ -31,7 +31,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -62,15 +62,15 @@
     <main class="home-banner">
       <h2 class="_visuallyhidden">Dart package manager</h2>
       <img class="logo" src="/static/v2/img/flutter-packages.png" alt="Flutter packages" />
-      <form class="search-bar" action="/experimental/flutter/packages">
+      <form class="search-bar" action="/flutter/packages">
         <input class="input" name="q" placeholder="Search Flutter packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
       <div class="list-filters">
-    <a class="filter -active" href="/experimental/flutter">Flutter</a>
-    <a class="filter " href="/experimental/web">Web</a>
-    <a class="filter " href="/experimental/server">Server</a>
-    <a class="filter " href="/experimental">All</a>
+    <a class="filter -active" href="/flutter">Flutter</a>
+    <a class="filter " href="/web">Web</a>
+    <a class="filter " href="/server">Server</a>
+    <a class="filter " href="">All</a>
 </div>
       <p class="text"><a href="https://flutter.io/">Flutter<sup><small>↗</small></sup></a> makes it easy and fast to build beautiful mobile apps<br/> for iOS and Android.</p>
     </main>
@@ -83,17 +83,17 @@
     <div class="tooltip-base">
       <h2 class="center landing-page-title tooltip-dotted">Top Flutter packages</h2>
       <div class="tooltip-content">
-        Packages are sorted by the overall score. More information on <a href="/experimental/help#ranking">ranking</a>.
+        Packages are sorted by the overall score. More information on <a href="/help#ranking">ranking</a>.
       </div>
     </div>
   </div>
   
 <ul class="package-list">
     <li class="list-item -simple">
-      <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
+      <h3 class="title"><a href="/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/flutter/packages">Flutter</a>
+        <a class="package-tag" href="/flutter/packages">Flutter</a>
   
 
       </p>
@@ -102,7 +102,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/flutter/packages">More Flutter packages...</a>
+    <a href="/flutter/packages">More Flutter packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/index_page.html
+++ b/app/test/frontend/golden/v2/index_page.html
@@ -31,7 +31,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -62,17 +62,17 @@
     <main class="home-banner">
       <h2 class="_visuallyhidden">Dart package manager</h2>
       <img class="logo" src="/static/v2/img/dart-packages.png" alt="Dart packages" />
-      <form class="search-bar" action="/experimental/packages">
+      <form class="search-bar" action="/packages">
         <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
       <div class="list-filters">
-    <a class="filter " href="/experimental/flutter">Flutter</a>
-    <a class="filter " href="/experimental/web">Web</a>
-    <a class="filter " href="/experimental/server">Server</a>
-    <a class="filter -active" href="/experimental">All</a>
+    <a class="filter " href="/flutter">Flutter</a>
+    <a class="filter " href="/web">Web</a>
+    <a class="filter " href="/server">Server</a>
+    <a class="filter -active" href="">All</a>
 </div>
-      <p class="text">Find and use packages to build <a href="/experimental/flutter">Flutter</a>, <a href="/experimental/web">web</a> and <a href="/experimental/server">server</a> apps with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>
+      <p class="text">Find and use packages to build <a href="/flutter">Flutter</a>, <a href="/web">web</a> and <a href="/server">server</a> apps with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>
     </main>
   </div>
 
@@ -83,17 +83,17 @@
     <div class="tooltip-base">
       <h2 class="center landing-page-title tooltip-dotted">Top Dart packages</h2>
       <div class="tooltip-content">
-        Packages are sorted by the overall score. More information on <a href="/experimental/help#ranking">ranking</a>.
+        Packages are sorted by the overall score. More information on <a href="/help#ranking">ranking</a>.
       </div>
     </div>
   </div>
   
 <ul class="package-list">
     <li class="list-item -simple">
-      <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
+      <h3 class="title"><a href="/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/web/packages">web</a>
+        <a class="package-tag" href="/web/packages">web</a>
   
 
       </p>
@@ -102,7 +102,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/packages">More Dart packages...</a>
+    <a href="/packages">More Dart packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/pkg_index_page.html
+++ b/app/test/frontend/golden/v2/pkg_index_page.html
@@ -31,7 +31,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -59,16 +59,16 @@
 
   <div class="_banner-bg">
     <main class="package-banner">
-      <form class="search-bar" action="/experimental/packages">
+      <form class="search-bar" action="/packages">
         <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus>
         <button class="icon"></button>
         
       </form>
       <div class="list-filters">
-    <a class="filter " href="/experimental/flutter/packages">Flutter</a>
-    <a class="filter " href="/experimental/web/packages">Web</a>
-    <a class="filter " href="/experimental/server/packages">Server</a>
-    <a class="filter -active" href="/experimental/packages">All</a>
+    <a class="filter " href="/flutter/packages">Flutter</a>
+    <a class="filter " href="/web/packages">Web</a>
+    <a class="filter " href="/server/packages">Server</a>
+    <a class="filter -active" href="/packages">All</a>
 </div>
     </main>
   </div>
@@ -80,7 +80,7 @@
   <div class="tooltip-base">
     <span class="tooltip-dotted">Sorted by:</span> overall score
     <div class="tooltip-content tooltip-bottom-left">
-      Packages are sorted by the overall score. More information on <a href="/experimental/help#ranking">ranking</a>.
+      Packages are sorted by the overall score. More information on <a href="/help#ranking">ranking</a>.
     </div>
   </div>
 </div>
@@ -89,11 +89,11 @@
 
 <ul class="package-list">
     <li class="list-item -full">
-      <a href="/experimental/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
-      <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
+      <a href="/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
+      <h3 class="title"><a href="&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>
       <p class="metadata">
-        v <a href="/experimental&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
+        v <a href="&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
         
         • Updated: <span>Jan 1, 2014</span>
           
@@ -103,15 +103,15 @@
       </p>
     </li>
     <li class="list-item -full">
-      <a href="/experimental/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
-      <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
+      <a href="/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
+      <h3 class="title"><a href="&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>
       <p class="metadata">
-        v <a href="/experimental&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
+        v <a href="&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
         
         • Updated: <span>Jan 1, 2015</span>
           
-        <a class="package-tag" href="/experimental/flutter/packages">Flutter</a>
+        <a class="package-tag" href="/flutter/packages">Flutter</a>
   
 
       </p>

--- a/app/test/frontend/golden/v2/pkg_show_page.html
+++ b/app/test/frontend/golden/v2/pkg_show_page.html
@@ -32,7 +32,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -59,7 +59,7 @@
 
   <div class="_banner-bg">
     <main class="package-banner">
-      <form class="search-bar" action="/experimental/packages">
+      <form class="search-bar" action="/packages">
         <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
@@ -151,7 +151,7 @@ import 'package:foobar_pkg/foolib.dart';
         </tr>
         </thead>
           <tr>
-            <th><a href="/experimental/packages/foobar_pkg/versions/0.1.1">0.1.1</a></th>
+            <th><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></th>
             <td>Jan 1, 2014</td>
             <td class="documentation">
               <a href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;"
@@ -200,7 +200,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted">Popularity:</span>
         <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
-          <a href="/experimental/help#popularity">[more]</a>
+          <a href="/help#popularity">[more]</a>
         </div>
       </div>
     </td>
@@ -212,7 +212,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted">Health:</span>
         <div class="tooltip-content">
           Code health derived from static analysis.
-          <a href="/experimental/help#health">[more]</a>
+          <a href="/help#health">[more]</a>
         </div>
       </div>
     </td>
@@ -224,7 +224,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted">Maintenance:</span>
         <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
-          <a href="/experimental/help#maintenance">[more]</a>
+          <a href="/help#maintenance">[more]</a>
         </div>
       </div>
     </td>
@@ -236,7 +236,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted"><b>Overall score:</b></span>
         <div class="tooltip-content">
           Weighted score of the above.
-          <a href="/experimental/help#overall-score">[more]</a>
+          <a href="/help#overall-score">[more]</a>
         </div>
       </div>
     </td>
@@ -274,7 +274,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>BSD (LICENSE.txt)</p>
 
     <h3 class="title">More</h3>
-    <p><a href="/experimental/packages?q=dependency%3Afoobar_pkg">Packages that depend on foobar_pkg</a></p>
+    <p><a href="/packages?q=dependency%3Afoobar_pkg">Packages that depend on foobar_pkg</a></p>
   </aside>
 </div>
 

--- a/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/v2/pkg_show_page_flutter_plugin.html
@@ -32,7 +32,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -59,7 +59,7 @@
 
   <div class="_banner-bg">
     <main class="package-banner">
-      <form class="search-bar" action="/experimental/packages">
+      <form class="search-bar" action="/packages">
         <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
@@ -76,7 +76,7 @@
     Published <span>Jan 1, 2015</span>
     <!-- &bull; Downloads: X -->
       <div class="tags">
-        <a class="package-tag" href="/experimental/flutter/packages">Flutter</a>
+        <a class="package-tag" href="/flutter/packages">Flutter</a>
   </div>
 
   </div>
@@ -142,7 +142,7 @@ import 'package:foobar_pkg/foolib.dart';
         </tr>
         </thead>
           <tr>
-            <th><a href="/experimental/packages/foobar_pkg/versions/0.1.1">0.1.1</a></th>
+            <th><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></th>
             <td>Jan 1, 2015</td>
             <td class="documentation">
               <a href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;"
@@ -191,7 +191,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted">Popularity:</span>
         <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
-          <a href="/experimental/help#popularity">[more]</a>
+          <a href="/help#popularity">[more]</a>
         </div>
       </div>
     </td>
@@ -203,7 +203,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted">Health:</span>
         <div class="tooltip-content">
           Code health derived from static analysis.
-          <a href="/experimental/help#health">[more]</a>
+          <a href="/help#health">[more]</a>
         </div>
       </div>
     </td>
@@ -215,7 +215,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted">Maintenance:</span>
         <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
-          <a href="/experimental/help#maintenance">[more]</a>
+          <a href="/help#maintenance">[more]</a>
         </div>
       </div>
     </td>
@@ -227,7 +227,7 @@ import 'package:foobar_pkg/foolib.dart';
         <span class="tooltip-dotted"><b>Overall score:</b></span>
         <div class="tooltip-content">
           Weighted score of the above.
-          <a href="/experimental/help#overall-score">[more]</a>
+          <a href="/help#overall-score">[more]</a>
         </div>
       </div>
     </td>
@@ -263,7 +263,7 @@ import 'package:foobar_pkg/foolib.dart';
 
 
     <h3 class="title">More</h3>
-    <p><a href="/experimental/packages?q=dependency%3Afoobar_pkg">Packages that depend on foobar_pkg</a></p>
+    <p><a href="/packages?q=dependency%3Afoobar_pkg">Packages that depend on foobar_pkg</a></p>
   </aside>
 </div>
 

--- a/app/test/frontend/golden/v2/platform_tabs_list.html
+++ b/app/test/frontend/golden/v2/platform_tabs_list.html
@@ -1,6 +1,6 @@
 <div class="list-filters">
-    <a class="filter " href="/experimental/flutter/packages">Flutter</a>
-    <a class="filter -active" href="/experimental/web/packages">Web</a>
-    <a class="filter " href="/experimental/server/packages">Server</a>
-    <a class="filter " href="/experimental/packages">All</a>
+    <a class="filter " href="/flutter/packages">Flutter</a>
+    <a class="filter -active" href="/web/packages">Web</a>
+    <a class="filter " href="/server/packages">Server</a>
+    <a class="filter " href="/packages">All</a>
 </div>

--- a/app/test/frontend/golden/v2/platform_tabs_search.html
+++ b/app/test/frontend/golden/v2/platform_tabs_search.html
@@ -1,6 +1,6 @@
 <div class="list-filters">
-    <a class="filter " href="/experimental/flutter/packages?q=foo">Flutter</a>
-    <a class="filter " href="/experimental/web/packages?q=foo">Web</a>
-    <a class="filter -active" href="/experimental/server/packages?q=foo">Server</a>
-    <a class="filter " href="/experimental/packages?q=foo">All</a>
+    <a class="filter " href="/flutter/packages?q=foo">Flutter</a>
+    <a class="filter " href="/web/packages?q=foo">Web</a>
+    <a class="filter -active" href="/server/packages?q=foo">Server</a>
+    <a class="filter " href="/packages?q=foo">All</a>
 </div>

--- a/app/test/frontend/golden/v2/search_page.html
+++ b/app/test/frontend/golden/v2/search_page.html
@@ -31,7 +31,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -59,16 +59,16 @@
 
   <div class="_banner-bg">
     <main class="package-banner">
-      <form class="search-bar" action="/experimental/packages">
+      <form class="search-bar" action="/packages">
         <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus value="foobar">
         <button class="icon"></button>
         <input type="hidden" name="sort" value="top"/>
       </form>
       <div class="list-filters">
-    <a class="filter " href="/experimental/flutter/packages?q=foobar&amp;sort=top">Flutter</a>
-    <a class="filter " href="/experimental/web/packages?q=foobar&amp;sort=top">Web</a>
-    <a class="filter " href="/experimental/server/packages?q=foobar&amp;sort=top">Server</a>
-    <a class="filter -active" href="/experimental/packages?q=foobar&amp;sort=top">All</a>
+    <a class="filter " href="/flutter/packages?q=foobar&amp;sort=top">Flutter</a>
+    <a class="filter " href="/web/packages?q=foobar&amp;sort=top">Web</a>
+    <a class="filter " href="/server/packages?q=foobar&amp;sort=top">Server</a>
+    <a class="filter -active" href="/packages?q=foobar&amp;sort=top">All</a>
 </div>
     </main>
   </div>
@@ -80,7 +80,7 @@
   <div class="tooltip-base">
     <span class="tooltip-dotted">Sorted by:</span> relevance
     <div class="tooltip-content tooltip-bottom-left">
-      Packages are sorted by the combination of text match and overall score. More information on <a href="/experimental/help#ranking">ranking</a>.
+      Packages are sorted by the combination of text match and overall score. More information on <a href="/help#ranking">ranking</a>.
     </div>
   </div>
 </div>
@@ -89,11 +89,11 @@
 
 <ul class="package-list">
     <li class="list-item -full">
-      <a href="/experimental/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
-      <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
+      <a href="/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
+      <h3 class="title"><a href="&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>
       <p class="metadata">
-        v <a href="/experimental&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
+        v <a href="&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
         
         • Updated: <span>Jan 1, 2014</span>
           
@@ -103,15 +103,15 @@
       </p>
     </li>
     <li class="list-item -full">
-      <a href="/experimental/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
-      <h3 class="title"><a href="/experimental&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
+      <a href="/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>
+      <h3 class="title"><a href="&#x2F;packages&#x2F;foobar_pkg">foobar_pkg</a></h3>
       <p class="description">my package description</p>
       <p class="metadata">
-        v <a href="/experimental&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
+        v <a href="&#x2F;packages&#x2F;foobar_pkg">0.1.1</a>
         
         • Updated: <span>Jan 1, 2015</span>
           
-        <a class="package-tag" href="/experimental/flutter/packages">Flutter</a>
+        <a class="package-tag" href="/flutter/packages">Flutter</a>
   
 
       </p>
@@ -131,33 +131,33 @@
       </a>
     </li>
     <li class="">
-      <a href="/experimental/packages?q=foobar&amp;sort=top&amp;page=2">
+      <a href="/packages?q=foobar&amp;sort=top&amp;page=2">
         <span>2</span>
       </a>
     </li>
     <li class="">
-      <a href="/experimental/packages?q=foobar&amp;sort=top&amp;page=3">
+      <a href="/packages?q=foobar&amp;sort=top&amp;page=3">
         <span>3</span>
       </a>
     </li>
     <li class="">
-      <a href="/experimental/packages?q=foobar&amp;sort=top&amp;page=4">
+      <a href="/packages?q=foobar&amp;sort=top&amp;page=4">
         <span>4</span>
       </a>
     </li>
     <li class="">
-      <a href="/experimental/packages?q=foobar&amp;sort=top&amp;page=5">
+      <a href="/packages?q=foobar&amp;sort=top&amp;page=5">
         <span>5</span>
       </a>
     </li>
     <li class="">
-      <a href="/experimental/packages?q=foobar&amp;sort=top&amp;page=2">
+      <a href="/packages?q=foobar&amp;sort=top&amp;page=2">
         <span>&raquo;</span>
       </a>
     </li>
 </ul>
 
-  <p>Check our help page for <a href="/experimental/help#search">advanced search expressions</a>.</p>
+  <p>Check our help page for <a href="/help#search">advanced search expressions</a>.</p>
 
 </main>
 

--- a/app/test/frontend/golden/v2/server_landing_page.html
+++ b/app/test/frontend/golden/v2/server_landing_page.html
@@ -31,7 +31,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -62,15 +62,15 @@
     <main class="home-banner">
       <h2 class="_visuallyhidden">Dart package manager</h2>
       <img class="logo" src="/static/v2/img/dart-packages.png" alt="Dart packages" />
-      <form class="search-bar" action="/experimental/server/packages">
+      <form class="search-bar" action="/server/packages">
         <input class="input" name="q" placeholder="Search server packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
       <div class="list-filters">
-    <a class="filter " href="/experimental/flutter">Flutter</a>
-    <a class="filter " href="/experimental/web">Web</a>
-    <a class="filter -active" href="/experimental/server">Server</a>
-    <a class="filter " href="/experimental">All</a>
+    <a class="filter " href="/flutter">Flutter</a>
+    <a class="filter " href="/web">Web</a>
+    <a class="filter -active" href="/server">Server</a>
+    <a class="filter " href="">All</a>
 </div>
       <p class="text">Use Dart to create command line and server applications.<br/> Start with the <a href="https://www.dartlang.org/tutorials/dart-vm/get-started">Dart VM tutorial<sup><small>↗</small></sup></a>.</p>
     </main>
@@ -83,17 +83,17 @@
     <div class="tooltip-base">
       <h2 class="center landing-page-title tooltip-dotted">Top server packages</h2>
       <div class="tooltip-content">
-        Packages are sorted by the overall score. More information on <a href="/experimental/help#ranking">ranking</a>.
+        Packages are sorted by the overall score. More information on <a href="/help#ranking">ranking</a>.
       </div>
     </div>
   </div>
   
 <ul class="package-list">
     <li class="list-item -simple">
-      <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
+      <h3 class="title"><a href="/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/server/packages">server</a>
+        <a class="package-tag" href="/server/packages">server</a>
   
 
       </p>
@@ -102,7 +102,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/server/packages">More server packages...</a>
+    <a href="/server/packages">More server packages...</a>
   </div>
 </div>
 

--- a/app/test/frontend/golden/v2/web_landing_page.html
+++ b/app/test/frontend/golden/v2/web_landing_page.html
@@ -31,7 +31,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/v2/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -62,15 +62,15 @@
     <main class="home-banner">
       <h2 class="_visuallyhidden">Dart package manager</h2>
       <img class="logo" src="/static/v2/img/dart-packages.png" alt="Dart packages" />
-      <form class="search-bar" action="/experimental/web/packages">
+      <form class="search-bar" action="/web/packages">
         <input class="input" name="q" placeholder="Search web packages" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
       <div class="list-filters">
-    <a class="filter " href="/experimental/flutter">Flutter</a>
-    <a class="filter -active" href="/experimental/web">Web</a>
-    <a class="filter " href="/experimental/server">Server</a>
-    <a class="filter " href="/experimental">All</a>
+    <a class="filter " href="/flutter">Flutter</a>
+    <a class="filter -active" href="/web">Web</a>
+    <a class="filter " href="/server">Server</a>
+    <a class="filter " href="">All</a>
 </div>
       <p class="text">Use Dart to create web applications that run on any modern browser.<br/> Start with <a href="https://webdev.dartlang.org/angular">AngularDart<sup><small>↗</small></sup></a>.</p>
     </main>
@@ -83,17 +83,17 @@
     <div class="tooltip-base">
       <h2 class="center landing-page-title tooltip-dotted">Top web packages</h2>
       <div class="tooltip-content">
-        Packages are sorted by the overall score. More information on <a href="/experimental/help#ranking">ranking</a>.
+        Packages are sorted by the overall score. More information on <a href="/help#ranking">ranking</a>.
       </div>
     </div>
   </div>
   
 <ul class="package-list">
     <li class="list-item -simple">
-      <h3 class="title"><a href="/experimental/packages/foobar_pkg">foobar_pkg</a></h3>
+      <h3 class="title"><a href="/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
           
-        <a class="package-tag" href="/experimental/web/packages">web</a>
+        <a class="package-tag" href="/web/packages">web</a>
   
 
       </p>
@@ -102,7 +102,7 @@
 </ul>
 
   <div class="more">
-    <a href="/experimental/web/packages">More web packages...</a>
+    <a href="/web/packages">More web packages...</a>
   </div>
 </div>
 

--- a/app/views/v2/index.mustache
+++ b/app/views/v2/index.mustache
@@ -13,6 +13,6 @@
   </div>
   {{& top_html}}
   <div class="more">
-    <a href="/experimental{{{packages_url}}}">{{more_packages}}</a>
+    <a href="{{{packages_url}}}">{{more_packages}}</a>
   </div>
 </div>

--- a/app/views/v2/layout.mustache
+++ b/app/views/v2/layout.mustache
@@ -45,7 +45,7 @@
   <button class="hamburger"></button>
   <div class="mask"></div>
   <div class="nav-wrap">
-    <div class="nav-header"><a class="logo" href="/experimental/"><img src="{{{static_assets_dir}}}/img/dart-logo.svg" alt="dart pub logo"></a>
+    <div class="nav-header"><a class="logo" href="/"><img src="{{{static_assets_dir}}}/img/dart-logo.svg" alt="dart pub logo"></a>
       <div class="_flex-space"></div>
       <button class="close"></button>
     </div>
@@ -73,7 +73,7 @@
 {{#package_banner}}
   <div class="_banner-bg">
     <main class="package-banner">
-      <form class="search-bar" action="/experimental/packages">
+      <form class="search-bar" action="/packages">
         <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>
@@ -84,7 +84,7 @@
 {{#listing_banner}}
   <div class="_banner-bg">
     <main class="package-banner">
-      <form class="search-bar" action="/experimental/{{#search_platform}}{{search_platform}}/{{/search_platform}}packages">
+      <form class="search-bar" action="/{{#search_platform}}{{search_platform}}/{{/search_platform}}packages">
         <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus{{#search_query}} value="{{search_query}}"{{/search_query}}>
         <button class="icon"></button>
         {{#search_sort_param}}<input type="hidden" name="sort" value="{{search_sort_param}}"/>{{/search_sort_param}}
@@ -99,7 +99,7 @@
     <main class="home-banner">
       <h2 class="_visuallyhidden">Dart package manager</h2>
       <img class="logo" src="{{{static_assets_dir}}}/img/{{{landing_banner_image}}}" alt="{{landing_banner_alt}}" />
-      <form class="search-bar" action="/experimental/{{#search_platform}}{{search_platform}}/{{/search_platform}}packages">
+      <form class="search-bar" action="/{{#search_platform}}{{search_platform}}/{{/search_platform}}packages">
         <input class="input" name="q" placeholder="{{search_query_placeholder}}" autocomplete="on" autofocus />
         <button class="icon"></button>
       </form>

--- a/app/views/v2/mini_list.mustache
+++ b/app/views/v2/mini_list.mustache
@@ -5,7 +5,7 @@
 <ul class="package-list">
   {{#packages}}
     <li class="list-item -simple">
-      <h3 class="title"><a href="/experimental/packages/{{name}}">{{name}}</a></h3>
+      <h3 class="title"><a href="/packages/{{name}}">{{name}}</a></h3>
       <p class="metadata">
         {{& tags_html}}
       </p>

--- a/app/views/v2/pagination.mustache
+++ b/app/views/v2/pagination.mustache
@@ -5,7 +5,7 @@
 <ul class="pagination">
   {{#page_links}}
     <li class="{{#active}}-active{{/active}}{{#disabled}}-disabled{{/disabled}}">
-      <a href="{{#render_link}}/experimental{{href}}{{/render_link}}">
+      <a href="{{#render_link}}{{href}}{{/render_link}}">
         <span>{{{text}}}</span>
       </a>
     </li>

--- a/app/views/v2/pkg/analysis_tab.mustache
+++ b/app/views/v2/pkg/analysis_tab.mustache
@@ -29,7 +29,7 @@
         <span class="tooltip-dotted">Popularity:</span>
         <div class="tooltip-content">
           Describes how popular the package is relative to other packages.
-          <a href="/experimental/help#popularity">[more]</a>
+          <a href="/help#popularity">[more]</a>
         </div>
       </div>
     </td>
@@ -41,7 +41,7 @@
         <span class="tooltip-dotted">Health:</span>
         <div class="tooltip-content">
           Code health derived from static analysis.
-          <a href="/experimental/help#health">[more]</a>
+          <a href="/help#health">[more]</a>
         </div>
       </div>
     </td>
@@ -53,7 +53,7 @@
         <span class="tooltip-dotted">Maintenance:</span>
         <div class="tooltip-content">
           Reflects how tidy and up-to-date the package is.
-          <a href="/experimental/help#maintenance">[more]</a>
+          <a href="/help#maintenance">[more]</a>
         </div>
       </div>
     </td>
@@ -65,7 +65,7 @@
         <span class="tooltip-dotted"><b>Overall score:</b></span>
         <div class="tooltip-content">
           Weighted score of the above.
-          <a href="/experimental/help#overall-score">[more]</a>
+          <a href="/help#overall-score">[more]</a>
         </div>
       </div>
     </td>
@@ -106,7 +106,7 @@
   {{/dependencies.has_direct}}
   {{#dependencies.direct}}
   <tr>
-    <td><a href="/experimental/packages/{{package}}">{{package}}</a></td>
+    <td><a href="/packages/{{package}}">{{package}}</a></td>
     <td>{{constraint}}</td>
     <td>{{resolved}}</td>
     <td>{{available}}</td>
@@ -119,7 +119,7 @@
   {{/dependencies.has_transitive}}
   {{#dependencies.transitive}}
     <tr>
-      <td><a href="/experimental/packages/{{package}}">{{package}}</a></td>
+      <td><a href="/packages/{{package}}">{{package}}</a></td>
       <td>{{constraint}}</td>
       <td>{{resolved}}</td>
       <td>{{available}}</td>
@@ -132,7 +132,7 @@
   {{/dependencies.has_dev}}
   {{#dependencies.dev}}
     <tr>
-      <td><a href="/experimental/packages/{{package}}">{{package}}</a></td>
+      <td><a href="/packages/{{package}}">{{package}}</a></td>
       <td>{{constraint}}</td>
       <td>{{resolved}}</td>
       <td>{{available}}</td>

--- a/app/views/v2/pkg/index.mustache
+++ b/app/views/v2/pkg/index.mustache
@@ -22,11 +22,11 @@
   {{#packages}}
     <li class="list-item -full">
       {{& score_box_html }}
-      <h3 class="title"><a href="/experimental{{url}}">{{name}}</a></h3>
+      <h3 class="title"><a href="{{url}}">{{name}}</a></h3>
       <p class="description">{{desc}}</p>
       <p class="metadata">
-        v <a href="/experimental{{url}}">{{version}}</a>
-        {{#show_dev_version}} / <a href="/experimental{{url}}/versions/{{dev_version_href}}">{{dev_version}}</a> {{/show_dev_version}}
+        v <a href="{{url}}">{{version}}</a>
+        {{#show_dev_version}} / <a href="{{url}}/versions/{{dev_version_href}}">{{dev_version}}</a> {{/show_dev_version}}
         • Updated: <span>{{last_uploaded}}</span>
         {{& tags_html}}
       </p>
@@ -38,5 +38,5 @@
   {{{pagination}}}
 {{/has_packages}}
 {{#is_search}}
-  <p>Check our help page for <a href="/experimental/help#search">advanced search expressions</a>.</p>
+  <p>Check our help page for <a href="/help#search">advanced search expressions</a>.</p>
 {{/is_search}}

--- a/app/views/v2/pkg/show.mustache
+++ b/app/views/v2/pkg/show.mustache
@@ -9,10 +9,10 @@
     <!-- &bull; Downloads: X -->
     {{#package.latest.should_show}}
       &bull; Updated:
-      <span><a href="/experimental/packages/{{package.name}}/versions/{{package.latest.stable_href}}">{{package.latest.stable_name}}</a></span>
+      <span><a href="/packages/{{package.name}}/versions/{{package.latest.stable_href}}">{{package.latest.stable_name}}</a></span>
       {{#package.latest.should_show_dev}}
         /
-        <span><a href="/experimental/packages/{{package.name}}/versions/{{package.latest.dev_href}}">{{package.latest.dev_name}}</a></span>
+        <span><a href="/packages/{{package.name}}/versions/{{package.latest.dev_href}}">{{package.latest.dev_name}}</a></span>
       {{/package.latest.should_show_dev}}
     {{/package.latest.should_show}}
     {{& package.tags_html}}
@@ -69,7 +69,7 @@ import 'package:{{package}}/{{library}}';
         </thead>
         {{#versions}}
           <tr>
-            <th><a href="/experimental/packages/{{package.name}}/versions/{{version}}">{{version}}</a></th>
+            <th><a href="/packages/{{package.name}}/versions/{{version}}">{{version}}</a></th>
             <td>{{short_created}}</td>
             <td class="documentation">
               <a href="{{documentation}}"
@@ -88,7 +88,7 @@ import 'package:{{package}}/{{library}}';
       </table>
       {{#show_versions_link}}
         <p>
-          <a href="/experimental/packages/{{package.name}}/versions">
+          <a href="/packages/{{package.name}}/versions">
             All {{version_count}} versions...
           </a>
         </p>

--- a/app/views/v2/pkg/versions/index.mustache
+++ b/app/views/v2/pkg/versions/index.mustache
@@ -15,7 +15,7 @@
   <tbody>
   {{#versions}}
     <tr>
-      <td><strong><a href="/experimental/packages/{{package.name}}/versions/{{version}}">{{version}}</a></strong></td>
+      <td><strong><a href="/packages/{{package.name}}/versions/{{version}}">{{version}}</a></strong></td>
       <td>{{short_created}}</td>
       <td class="documentation">
         <a href="{{documentation}}"

--- a/app/views/v2/platform_tabs.mustache
+++ b/app/views/v2/platform_tabs.mustache
@@ -3,6 +3,6 @@
     BSD-style license that can be found in the LICENSE file. }}
 <div class="list-filters">
   {{#tabs}}
-    <a class="filter {{#active}}-active{{/active}}" href="/experimental{{{href}}}">{{text}}</a>
+    <a class="filter {{#active}}-active{{/active}}" href="{{{href}}}">{{text}}</a>
   {{/tabs}}
 </div>


### PR DESCRIPTION
- removed/updated old handler paths
- updated templates
- redirecting `/experimental[/*]` -> `[/*]`

I kept the migration of templates to a follow-up PR, this one got big enough without it, and that can be done without affecting the release of V2 design.

I've deployed this on staging: https://20171206t132931-dot-dartlang-pub-dev.appspot.com/