### PR TITLE
Analysis tab: compact preamble and slightly different meta header.

### DIFF
--- a/app/test/frontend/golden/analysis_tab_http.html
+++ b/app/test/frontend/golden/analysis_tab_http.html
@@ -6,19 +6,17 @@
 </div>
 
 <p>
-  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
-  You can see the overall score in a colored circle, and the results below.
+  We analyzed this package, and provided a score, details, and suggestions below.
 </p>
 
-<hr />
-
-<p>Last package analysis:</p>
 <ul>
   <li><i>completed</i> on Nov 29, 2017</li>
   <li>Dart: 2.0.0-dev.8.0</li>
   <li>pana: 0.7.1</li>
 
 </ul>
+
+<hr />
 
 <h4>Scores</h4>
 

--- a/app/test/frontend/golden/analysis_tab_mock.html
+++ b/app/test/frontend/golden/analysis_tab_mock.html
@@ -6,19 +6,17 @@
 </div>
 
 <p>
-  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
-  You can see the overall score in a colored circle, and the results below.
+  We analyzed this package, and provided a score, details, and suggestions below.
 </p>
 
-<hr />
-
-<p>Last package analysis:</p>
 <ul>
   <li><i>tool failures</i> on Oct 26, 2017</li>
   <li>Dart: 2.0.0-dev.7.0</li>
   <li>pana: 0.6.2</li>
 <li>Flutter: 0.0.18</li>
 </ul>
+
+<hr />
 
 <h4>Scores</h4>
 

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -177,19 +177,17 @@ import 'package:foobar_pkg/foolib.dart';
 </div>
 
 <p>
-  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
-  You can see the overall score in a colored circle, and the results below.
+  We analyzed this package, and provided a score, details, and suggestions below.
 </p>
 
-<hr />
-
-<p>Last package analysis:</p>
 <ul>
   <li><i></i> on </li>
   <li>Dart: 2.0.0-dev.7.0</li>
   <li>pana: 0.6.2</li>
 <li>Flutter: 0.0.18</li>
 </ul>
+
+<hr />
 
 <h4>Scores</h4>
 

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -168,19 +168,17 @@ import 'package:foobar_pkg/foolib.dart';
 </div>
 
 <p>
-  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
-  You can see the overall score in a colored circle, and the results below.
+  We analyzed this package, and provided a score, details, and suggestions below.
 </p>
 
-<hr />
-
-<p>Last package analysis:</p>
 <ul>
   <li><i></i> on </li>
   <li>Dart: 2.0.0-dev.7.0</li>
   <li>pana: 0.6.2</li>
 <li>Flutter: 0.0.18</li>
 </ul>
+
+<hr />
 
 <h4>Scores</h4>
 

--- a/app/views/pkg/analysis_tab.mustache
+++ b/app/views/pkg/analysis_tab.mustache
@@ -6,19 +6,17 @@
 </div>
 
 <p>
-  We are analyzing each uploaded package and provide its scores, details and our suggestions here.
-  You can see the overall score in a colored circle, and the results below.
+  We analyzed this package, and provided a score, details, and suggestions below.
 </p>
 
-<hr />
-
-<p>Last package analysis:</p>
 <ul>
   <li><i>{{analysis_status}}</i> on {{date_completed}}</li>
   <li>Dart: {{dart_sdk_version}}</li>
   <li>pana: {{pana_version}}</li>
 {{#flutter_version}}<li>Flutter: {{flutter_version}}</li>{{/flutter_version}}
 </ul>
+
+<hr />
 
 <h4>Scores</h4>
 


### PR DESCRIPTION
The new text is shorter, and the horizontal line separation looked a bit weird. The new look:

<img width="690" alt="screen shot 2017-12-07 at 10 30 25 am" src="https://user-images.githubusercontent.com/4778111/33708106-cf403738-db39-11e7-9448-ff58f448aa19.png">

Fixes #751