### PR TITLE
Show package dependencies in the sidebar.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -375,6 +375,7 @@ class TemplateService {
             _renderLicenses(selectedVersion.homepage, analysis?.licenses),
         'score_box_html': _renderScoreBox(extract?.overallScore,
             isNewPackage: package.isNewPackage()),
+        'dependencies_html': _renderDependencyList(analysis),
         'analysis_html': renderAnalysisTab(extract, analysis),
       },
       'version_table_rows': versionTableRows,
@@ -403,6 +404,16 @@ class TemplateService {
       }
       return html;
     }).join('<br/>');
+  }
+
+  String _renderDependencyList(AnalysisView analysis) {
+    if (analysis == null ||
+        !analysis.hasAnalysisData ||
+        analysis.directDependencies == null) return null;
+    final List<String> packages =
+        analysis.directDependencies.map((pd) => pd.package).toList()..sort();
+    if (packages.isEmpty) return null;
+    return packages.map((p) => '<a href="/packages/$p">$p</a>').join(', ');
   }
 
   String _renderInstall(bool isFlutter, List<String> platforms) {

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -250,6 +250,32 @@ import 'package:foobar_pkg/foolib.dart';
 <blockquote></blockquote>
 
 
+<h4>Dependencies</h4>
+<div class="overflow-x">
+<table class="dependency-table">
+  <tr>
+    <th>Package</th>
+    <th>Constraint</th>
+    <th>Resolved</th>
+    <th>Available</th>
+  </tr>
+  <tr>
+    <th colspan="4" class="sub-header">Direct dependencies</th>
+  </tr>
+  <tr>
+    <td><a href="/packages/quiver">quiver</a></td>
+    <td>^1.0.0</td>
+    <td>1.0.0</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a href="/packages/http">http</a></td>
+    <td>&gt;=1.0.0 &lt;1.2.0</td>
+    <td>1.2.0</td>
+    <td>1.3.0</td>
+  </tr>
+</table>
+</div>
 
     </section>
   </div>
@@ -272,6 +298,9 @@ import 'package:foobar_pkg/foolib.dart';
 
       <h3 class="title">License</h3>
       <p>BSD (LICENSE.txt)</p>
+
+      <h3 class="title">Dependencies</h3>
+      <p><a href="/packages/http">http</a>, <a href="/packages/quiver">quiver</a></p>
 
     <h3 class="title">More</h3>
     <p><a href="/packages?q=dependency%3Afoobar_pkg">Packages that depend on foobar_pkg</a></p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -262,6 +262,7 @@ import 'package:foobar_pkg/foolib.dart';
     <p>hans@juergen.com</p>
 
 
+
     <h3 class="title">More</h3>
     <p><a href="/packages?q=dependency%3Afoobar_pkg">Packages that depend on foobar_pkg</a></p>
   </aside>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -105,6 +105,24 @@ void main() {
           1,
           null,
           new MockAnalysisView()
+            ..directDependencies = [
+              new PkgDependency(
+                  'quiver',
+                  'direct',
+                  'normal',
+                  new VersionConstraint.parse('^1.0.0'),
+                  new Version.parse('1.0.0'),
+                  null,
+                  null),
+              new PkgDependency(
+                  'http',
+                  'direct',
+                  'normal',
+                  new VersionConstraint.parse('>=1.0.0 <1.2.0'),
+                  new Version.parse('1.2.0'),
+                  new Version.parse('1.3.0'),
+                  null)
+            ]
             ..licenses = [new LicenseFile('LICENSE.txt', 'BSD')]);
       expectGoldenFile(html, 'pkg_show_page.html');
     });

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -112,6 +112,11 @@ import 'package:{{package}}/{{library}}';
       <p>{{& package.license_html}}</p>
     {{/package.license_html}}
 
+    {{#package.dependencies_html}}
+      <h3 class="title">Dependencies</h3>
+      <p>{{& package.dependencies_html}}</p>
+    {{/package.dependencies_html}}
+
     <h3 class="title">More</h3>
     <p><a href="{{{search_deps_link}}}">Packages that depend on {{package.name}}</a></p>
   </aside>


### PR DESCRIPTION
This fixes #721. There is no trim of the list yet (e.g. if the list is larger than 20 items), because ideally we'd like to select the most popular ones, and that would be an expensive operation at the time of the package show page. We could implement showing the first 20 alphabetically but then selecting them at random would be more fair. Let's try it without trim, and fix it once we have an outlier that has too many dependencies.