### PR TITLE
Add a special package name that causes a 500 response – useful for testing

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -27,6 +27,12 @@ import 'models.dart';
 import 'search_service.dart';
 import 'templates.dart';
 
+// TODO(kevmoo): Disallow package publish packages that start w/ this String
+//               Unlikely, but might be worth-wile.
+/// [String] that triggers an exception in the request handler for packages with
+/// this name.
+final forceRuntimeErrorPackageName = 'abc_force_package_site_crash_xyz';
+
 final _pubHeaderLogger = new Logger('pub.header_logger');
 
 final String _staticPath = Platform.script.resolve('../../static').toFilePath();
@@ -76,6 +82,12 @@ Future<shelf.Response> appHandler(
     return apiPackagesHandler(request);
   } else if (path.startsWith('/api') ||
       path.startsWith('/packages') && path.endsWith('.tar.gz')) {
+    // Allows validating client behavior against a known-bad end-point
+    if (path.startsWith('/api/packages/$forceRuntimeErrorPackageName')) {
+      throw new UnsupportedError(
+          'Requested "trigger" package `$forceRuntimeErrorPackageName`.');
+    }
+
     return shelfPubApi(request);
   } else if (path.startsWith('/packages/')) {
     return packageHandler(request);

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -444,4 +444,13 @@ void main() {
       });
     });
   });
+
+  tScopedTest('Validate error behavior', () {
+    expect(
+        () => issueGet('/api/packages/abc_force_package_site_crash_xyz'),
+        throwsA((Object e) =>
+            e is UnsupportedError &&
+            e.message ==
+                'Requested "trigger" package `abc_force_package_site_crash_xyz`.'));
+  });
 }

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -18,6 +18,9 @@ import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
+export 'package:pub_dartlang_org/frontend/handlers.dart'
+    show forceRuntimeErrorPackageName;
+
 Future<shelf.Response> issueGet(String path) async {
   final uri = 'https://pub.dartlang.org$path';
   final request = new shelf.Request('GET', Uri.parse(uri));


### PR DESCRIPTION
CC @nex3 – would this be useful? If we wire up the pub client for such logic, It'd be good to make sure it works consistently