### PR TITLE
Copy edit of site footer

### DIFF
--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -78,9 +78,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -75,9 +75,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -109,9 +109,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -109,9 +109,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -141,9 +141,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -284,9 +284,9 @@ import 'package:foobar_pkg/foolib.dart';
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -273,9 +273,9 @@ import 'package:foobar_pkg/foolib.dart';
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -162,9 +162,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/server_landing_page.html
+++ b/app/test/frontend/golden/server_landing_page.html
@@ -109,9 +109,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -109,9 +109,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 

--- a/app/views/layout.mustache
+++ b/app/views/layout.mustache
@@ -114,9 +114,9 @@
 </main>
 
 <footer class="site-footer">
-  <a class="link" href="https://www.dartlang.org/">Dart Language</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms of Service</a>
-  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy Policy</a>
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 


### PR DESCRIPTION
Used sentence case, shortened links to Terms & Privacy to match the
links in the footer of www.dartlang.org.

Contributes to #739.