### PR TITLE
Increase service redundancy

### DIFF
--- a/analyzer.yaml
+++ b/analyzer.yaml
@@ -17,7 +17,7 @@ resources:
 #  instances: 1
 
 automatic_scaling:
-  min_num_instances: 1
+  min_num_instances: 2
   max_num_instances: 8
 
 skip_files:

--- a/search.yaml
+++ b/search.yaml
@@ -14,8 +14,8 @@ resources:
 #  instances: 1
 
 automatic_scaling:
-  min_num_instances: 1
-  max_num_instances: 2
+  min_num_instances: 2
+  max_num_instances: 4
 
 skip_files:
 - ^\.git/.*$


### PR DESCRIPTION
`min_num_instances: 1` is clearly not enough, because it takes a while for AppEngine to figure out that a restart is due (see site down in #801).