### PR TITLE
Filter packages on text match even if the match score is ignored.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -153,6 +153,12 @@ class SimplePackageIndex implements PackageIndex {
     // do text matching
     final Score textScore = _searchText(packages, query.parsedQuery.text);
 
+    // filter packages that doesn't match text query
+    if (textScore != null) {
+      final keys = textScore.getKeys();
+      packages.removeWhere((x) => !keys.contains(x));
+    }
+
     List<PackageScore> results;
     switch (query.order ?? SearchOrder.top) {
       case SearchOrder.top:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -518,4 +518,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev <=2.0.0-dev.12.0"
+  dart: ">=2.0.0-dev <=2.0.0-dev.7.0"

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -335,6 +335,19 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
       });
     });
 
+    test('order by updated: query text filter', () async {
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(query: 'http', order: SearchOrder.updated));
+      expect(JSON.decode(JSON.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 2,
+        'packages': [
+          {'package': 'http'},
+          {'package': 'chrome_net'},
+        ],
+      });
+    });
+
     test('order by updated: platform filter', () async {
       final PackageSearchResult result =
           await index.search(new SearchQuery.parse(


### PR DESCRIPTION
Fixes #817. I believe the regression was introduced in #673 (~3 weeks ago).