### PR TITLE
Display minimal analysis tab on aborted status too.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -408,7 +408,7 @@ class TemplateService {
 
   String _renderDependencyList(AnalysisView analysis) {
     if (analysis == null ||
-        !analysis.hasAnalysisData ||
+        !analysis.hasPanaSummary ||
         analysis.directDependencies == null) return null;
     final List<String> packages =
         analysis.directDependencies.map((pd) => pd.package).toList()..sort();

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -80,7 +80,6 @@ class SearchBackend {
       if (pv == null) continue;
 
       final analysisView = analysisViews[i];
-      if (!analysisView.hasAnalysisData) continue;
       final double popularity = popularityStorage.lookup(pv.package) ?? 0.0;
 
       results[i] = new PackageDocument(

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -89,7 +89,7 @@ class AnalyzerClient {
       }
     }
     final view = await getAnalysisView(key);
-    if (!view.hasAnalysisData) {
+    if (!view.hasPanaSummary) {
       return null;
     }
     final extract = new AnalysisExtract(
@@ -174,13 +174,14 @@ class AnalysisView {
     return new AnalysisView._(data, summary);
   }
 
-  bool get hasAnalysisData => _summary != null;
+  bool get hasAnalysisData => _data != null;
+  bool get hasPanaSummary => _summary != null;
 
   DateTime get timestamp => _data.timestamp;
   AnalysisStatus get analysisStatus => _data.analysisStatus;
 
-  String get dartSdkVersion => _summary.sdkVersion.toString();
-  String get panaVersion => _summary.panaVersion.toString();
+  String get dartSdkVersion => _summary?.sdkVersion?.toString();
+  String get panaVersion => _data?.panaVersion;
   String get flutterVersion =>
       _summary?.flutterVersion != null ? _data.flutterVersion : null;
 

--- a/app/test/frontend/golden/analysis_tab_aborted.html
+++ b/app/test/frontend/golden/analysis_tab_aborted.html
@@ -1,0 +1,79 @@
+<h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a class='github_issue' data-bug-tag='analysis' href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">feedback</a>.
+</div>
+
+<p>
+  We analyzed this package, and provided a score, details, and suggestions below.
+</p>
+
+<ul>
+  <li><i>aborted</i> on Dec 18, 2017</li>
+  <li>Dart: </li>
+  <li>pana: 0.8.0</li>
+
+</ul>
+
+<hr />
+
+<h4>Scores</h4>
+
+<table id='scores-table'>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base hoverable">
+        <span class="tooltip-dotted">Popularity:</span>
+        <div class="tooltip-content">
+          Describes how popular the package is relative to other packages.
+          <a href="/help#popularity">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">--</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base hoverable">
+        <span class="tooltip-dotted">Health:</span>
+        <div class="tooltip-content">
+          Code health derived from static analysis.
+          <a href="/help#health">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">--</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base hoverable">
+        <span class="tooltip-dotted">Maintenance:</span>
+        <div class="tooltip-content">
+          Reflects how tidy and up-to-date the package is.
+          <a href="/help#maintenance">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td class="score-value">--</td>
+  </tr>
+  <tr>
+    <td class="score-name">
+      <div class="tooltip-base hoverable">
+        <span class="tooltip-dotted"><b>Overall score:</b></span>
+        <div class="tooltip-content">
+          Weighted score of the above.
+          <a href="/help#overall-score">[more]</a>
+        </div>
+      </div>
+    </td>
+    <td><div class="score-box"><span class="number -missing" title="Awaiting analysis to complete.">--</span></div></td>
+  </tr>
+</table>
+
+<h4>Platforms</h4>
+
+<p>Detected platforms: <i>unsure</i></p>
+<blockquote></blockquote>
+
+

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -206,6 +206,20 @@ void main() {
       expectGoldenFile(html, 'analysis_tab_mock.html', isFragment: true);
     });
 
+    test('aborted analysis tab', () async {
+      final String html = templates.renderAnalysisTab(
+          null,
+          new AnalysisView(new AnalysisData(
+            packageName: 'foo',
+            packageVersion: '1.0.0',
+            panaVersion: '0.8.0',
+            flutterVersion: '0.0.20',
+            analysisStatus: AnalysisStatus.aborted,
+            timestamp: new DateTime(2017, 12, 18, 14, 26, 00),
+          )));
+      expectGoldenFile(html, 'analysis_tab_aborted.html', isFragment: true);
+    });
+
     test('package index page', () {
       final String html = templates.renderPkgIndexPage([
         new PackageView.fromModel(
@@ -398,6 +412,9 @@ void main() {
 class MockAnalysisView implements AnalysisView {
   @override
   bool hasAnalysisData = true;
+
+  @override
+  bool hasPanaSummary = true;
 
   @override
   AnalysisStatus analysisStatus;


### PR DESCRIPTION
Fixes #786 (provides aborted status and timestamp), although that specific example will be solved with the pana `0.8.0` release anyway.

The exception on abort is not exposed (not captured in `AnalysisData`), but it should be in the logs. If we want to expose that, I'd defer it until we store the full `AnalysisData` in the DataStore we could add the abort error too.