### PR TITLE
Skip the analysis of packages older than two years with newer stable version.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -295,16 +295,30 @@ class AnalysisBackend {
     }
   }
 
-  /// Returns the publish date of a package.
-  Future<DateTime> getPublishDate(String package, String version) async {
-    final List<PackageVersion> list = await db.lookup([
-      db.emptyKey
-          .append(Package, id: package)
-          .append(PackageVersion, id: version)
-    ]);
-    final PackageVersion pv = list.single;
-    return pv?.created;
+  /// Returns the status of a package and version.
+  Future<PackageStatus> getPackageStatus(String package, String version) async {
+    final packageKey = db.emptyKey.append(Package, id: package);
+    final List list = await db
+        .lookup([packageKey, packageKey.append(PackageVersion, id: version)]);
+    final Package p = list[0];
+    final PackageVersion pv = list[1];
+    if (p == null || pv == null) {
+      return new PackageStatus(exists: false);
+    }
+    return new PackageStatus(
+      exists: true,
+      publishDate: pv.created,
+      isLatestStable: p.latestVersion == version,
+    );
   }
+}
+
+class PackageStatus {
+  final bool exists;
+  final DateTime publishDate;
+  final bool isLatestStable;
+
+  PackageStatus({this.exists, this.publishDate, this.isLatestStable: false});
 }
 
 class BackendAnalysisStatus {

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -150,6 +150,9 @@ class TemplateService {
       case AnalysisStatus.failure:
         statusText = 'tool failures';
         break;
+      case AnalysisStatus.outdated:
+        statusText = 'skipped (outdated)';
+        break;
       case AnalysisStatus.success:
         statusText = 'completed';
         break;

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -40,6 +40,10 @@ enum AnalysisStatus {
   /// One or more tools failed to produce the expected output.
   failure,
 
+  /// Analysis was not started, because package is considered old and has a
+  /// newer stable release.
+  outdated,
+
   /// Analysis was completed without issues.
   success,
 }
@@ -52,6 +56,7 @@ int analysisStatusLevel(AnalysisStatus status) {
       return 0;
     case AnalysisStatus.failure:
       return 1;
+    case AnalysisStatus.outdated:
     case AnalysisStatus.success:
       return 2;
   }

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -170,7 +170,7 @@ class MockAnalysisBackend implements AnalysisBackend {
   }
 
   @override
-  Future<DateTime> getPublishDate(String package, String version) {
+  Future<PackageStatus> getPackageStatus(String package, String version) {
     throw 'Not implemented yet.';
   }
 }


### PR DESCRIPTION
Fixes #828. We could be more fancy on displaying the reason of not analysis a version, but I'd rather keep it simple for now, and we can revisit it later. After all these versions are not that easy to navigate to.