### PR TITLE
Process readme as markdown->html->text for search.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:html/parser.dart';
+
+import '../shared/markdown.dart';
+
 final RegExp _separators =
     new RegExp(r'[_\.,;=\(\)\>\<\[\]\{\}\|\?\!\/\+\-\*]|\s');
 final RegExp _nonCharacterRegExp = new RegExp('[^a-z0-9]');
@@ -18,7 +22,13 @@ String compactText(String text, {int maxLength: -1}) {
 }
 
 String compactDescription(String text) => compactText(text, maxLength: 500);
-String compactReadme(String text) => compactText(text, maxLength: 5000);
+
+String compactReadme(String text) {
+  if (text == null || text.isEmpty) return '';
+  final html = markdownToHtml(text, null);
+  final root = parseFragment(html);
+  return compactText(root.text, maxLength: 5000);
+}
 
 String normalizeBeforeIndexing(String text) {
   if (text == null) return '';

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -391,12 +391,12 @@ MIT'''),
           {
             // should be present
             'package': 'great_circle_distance',
-            'score': closeTo(0.029, 0.001),
+            'score': closeTo(0.030, 0.001),
           },
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(0.025, 0.001),
+            'score': closeTo(0.026, 0.001),
           },
         ]
       });

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -43,4 +43,15 @@ void main() {
           ['abc', 'cde', '123 456']);
     });
   });
+
+  group('compact readme', () {
+    test('No formatting', () {
+      expect(compactReadme('abc  123 '), 'abc 123');
+    });
+
+    test('link', () {
+      expect(compactReadme('some [link](http://example.com) with text'),
+          'some link with text');
+    });
+  });
 }

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -56,35 +56,11 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
           new SearchQuery.parse(query: 'travis', order: SearchOrder.text));
       expect(JSON.decode(JSON.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 7,
+        'totalCount': 1,
         'packages': [
           {
             'package': 'travis',
             'score': closeTo(0.267, 0.001),
-          },
-          {
-            'package': 'rainbow_vis',
-            'score': closeTo(0.047, 0.001),
-          },
-          {
-            'package': 'mongo_dart_query',
-            'score': closeTo(0.047, 0.001),
-          },
-          {
-            'package': 'angular_aria',
-            'score': closeTo(0.047, 0.001),
-          },
-          {
-            'package': 'w_transport',
-            'score': closeTo(0.047, 0.001),
-          },
-          {
-            'package': 'sass_transformer',
-            'score': closeTo(0.046, 0.001),
-          },
-          {
-            'package': 'dartemis_transformer',
-            'score': closeTo(0.046, 0.001),
           },
         ],
       });


### PR DESCRIPTION
This clears up the search of `travis` by a big margin, and also makes the index less cluttered with linked URL fragments. Deployed and tested in staging, looks good there.