### PR TITLE
Search: scale down document size, let the overall score do the ranking.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -478,8 +478,8 @@ class TokenIndex {
       final Set<String> set = _inverseIds.putIfAbsent(token, () => new Set());
       set.add(id);
     }
-    // Document size inspired by ElasticSearch's ranking.
-    final docSize = math.sqrt(tokens.length);
+    // Document size is a highly scaled-down proxy of the length.
+    final docSize = 1 + math.log(1 + tokens.length) / 100;
     _docSizes[id] = docSize;
   }
 

--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -38,11 +38,11 @@ void main() {
         'packages': [
           {
             'package': 'angular',
-            'score': closeTo(0.236, 0.001),
+            'score': closeTo(0.971, 0.001),
           },
           {
             'package': 'angular_ui',
-            'score': closeTo(0.229, 0.001),
+            'score': closeTo(0.970, 0.001),
           },
         ],
       });

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -39,7 +39,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_blue',
-            'score': closeTo(0.15, 0.01),
+            'score': closeTo(0.916, 0.001),
           },
         ],
       });

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -57,7 +57,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.218, 0.001),
+            'score': closeTo(0.970, 0.001),
           },
         ],
       });
@@ -72,7 +72,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.218, 0.001),
+            'score': closeTo(0.970, 0.001),
           },
         ],
       });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -58,7 +58,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.14, 0.01),
+              'score': closeTo(0.33, 0.01),
             }
           ],
         });
@@ -72,7 +72,7 @@ void main() {
           'packages': [
             {
               'package': 'pkg_foo',
-              'score': closeTo(0.07, 0.01),
+              'score': closeTo(0.31, 0.01),
             }
           ],
         });
@@ -87,7 +87,7 @@ void main() {
               'packages': [
                 {
                   'package': 'pkg_foo',
-                  'score': closeTo(0.07, 0.01),
+                  'score': closeTo(0.30, 0.01),
                 }
               ],
             });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -386,17 +386,17 @@ MIT'''),
           {
             // should be the top
             'package': 'haversine',
-            'score': closeTo(0.196, 0.001),
+            'score': closeTo(0.968, 0.001),
           },
           {
             // should be present
             'package': 'great_circle_distance',
-            'score': closeTo(0.030, 0.001),
+            'score': closeTo(0.843, 0.001),
           },
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(0.026, 0.001),
+            'score': closeTo(0.841, 0.001),
           },
         ]
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -19,7 +19,7 @@ void main() {
       expect(index.search('xml'), {
         // no match for http
         // the letter 'm' matches from http_magic
-        'uri://http_magic': closeTo(0.20, 0.01),
+        'uri://http_magic': closeTo(0.97, 0.01),
       });
     });
 
@@ -28,8 +28,8 @@ void main() {
         ..add('uri://http', 'http')
         ..add('uri://http_magic', 'http_magic');
       expect(index.search('http'), {
-        'uri://http': closeTo(0.33, 0.01),
-        'uri://http_magic': closeTo(0.20, 0.01),
+        'uri://http': closeTo(0.98, 0.01),
+        'uri://http_magic': closeTo(0.97, 0.01),
       });
     });
 
@@ -40,14 +40,14 @@ void main() {
         ..add('queue_lower', queueText.toLowerCase())
         ..add('unmodifiable', 'CustomUnmodifiableMapBase');
       expect(index.search('queue'), {
-        'queue': closeTo(0.12, 0.01),
-        'queue_lower': closeTo(0.07, 0.01),
+        'queue': closeTo(0.96, 0.01),
+        'queue_lower': closeTo(0.51, 0.01),
       });
       expect(index.search('unmodifiab'), {
-        'unmodifiable': closeTo(0.09, 0.01),
+        'unmodifiable': closeTo(0.95, 0.01),
       });
       expect(index.search('unmodifiable'), {
-        'unmodifiable': closeTo(0.09, 0.01),
+        'unmodifiable': closeTo(0.95, 0.01),
       });
     });
 
@@ -58,11 +58,11 @@ void main() {
         ..add('uri://teamspeak', 'teamspeak');
 
       expect(index.search('riak'), {
-        'uri://riak_client': closeTo(0.19, 0.01),
+        'uri://riak_client': closeTo(0.97, 0.01),
       });
 
       expect(index.search('riak client'), {
-        'uri://riak_client': closeTo(0.19, 0.01),
+        'uri://riak_client': closeTo(0.97, 0.01),
       });
     });
 
@@ -195,7 +195,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'async',
-            'score': closeTo(0.29, 0.01),
+            'score': closeTo(0.91, 0.01),
           },
         ]
       });
@@ -210,7 +210,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(0.11, 0.01),
+            'score': closeTo(0.82, 0.01),
           },
         ]
       });
@@ -225,7 +225,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'chrome_net',
-            'score': closeTo(0.06, 0.01),
+            'score': closeTo(0.46, 0.01),
           },
         ]
       });
@@ -238,8 +238,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.09, 0.01)},
-          {'package': 'http', 'score': closeTo(0.04, 0.01)},
+          {'package': 'async', 'score': closeTo(0.85, 0.01)},
+          {'package': 'http', 'score': closeTo(0.76, 0.01)},
         ]
       });
     });
@@ -261,8 +261,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.09, 0.01)},
-          {'package': 'http', 'score': closeTo(0.04, 0.01)},
+          {'package': 'async', 'score': closeTo(0.85, 0.01)},
+          {'package': 'http', 'score': closeTo(0.76, 0.01)},
         ],
       });
     });
@@ -301,7 +301,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(0.41, 0.01),
+            'score': closeTo(0.98, 0.01),
           },
         ],
       });
@@ -451,7 +451,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.105, 0.001)},
+          {'package': 'http', 'score': closeTo(0.816, 0.001)},
         ],
       });
     });
@@ -488,7 +488,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.12, 0.01)},
+          {'package': 'http', 'score': closeTo(0.91, 0.01)},
         ],
       });
 
@@ -498,9 +498,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 3,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.14, 0.01)},
-          {'package': 'async', 'score': closeTo(0.10, 0.01)},
-          {'package': 'http', 'score': closeTo(0.05, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.91, 0.01)},
+          {'package': 'async', 'score': closeTo(0.90, 0.01)},
+          {'package': 'http', 'score': closeTo(0.85, 0.01)},
         ],
       });
 
@@ -512,7 +512,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.071, 0.001)},
+          {'package': 'http', 'score': closeTo(0.814, 0.001)},
         ],
       });
     });

--- a/app/test/search/platform_specificity_test.dart
+++ b/app/test/search/platform_specificity_test.dart
@@ -81,19 +81,19 @@ void main() {
         'packages': [
           {
             'package': 'json_0',
-            'score': closeTo(0.12, 0.01),
+            'score': closeTo(0.29, 0.01),
           },
           {
             'package': 'json_1',
-            'score': closeTo(0.12, 0.01),
+            'score': closeTo(0.29, 0.01),
           },
           {
             'package': 'json_2',
-            'score': closeTo(0.12, 0.01),
+            'score': closeTo(0.29, 0.01),
           },
           {
             'package': 'json_3',
-            'score': closeTo(0.12, 0.01),
+            'score': closeTo(0.29, 0.01),
           },
         ],
       });
@@ -111,15 +111,15 @@ void main() {
         'packages': [
           {
             'package': 'json_1',
-            'score': closeTo(0.1224, 0.0001),
+            'score': closeTo(0.2943, 0.0001),
           },
           {
             'package': 'json_2',
-            'score': closeTo(0.1102, 0.0001),
+            'score': closeTo(0.2648, 0.0001),
           },
           {
             'package': 'json_3',
-            'score': closeTo(0.0979, 0.0001),
+            'score': closeTo(0.2354, 0.0001),
           },
         ],
       });

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -60,7 +60,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
         'packages': [
           {
             'package': 'travis',
-            'score': closeTo(0.267, 0.001),
+            'score': closeTo(0.974, 0.001),
           },
         ],
       });


### PR DESCRIPTION
Based on top of #846.

Previously, when an expression e.g. `haversine` was present in a much longer text, the ranking gave it a lower score and the end result was further down, but it may have been only because of the more detailed example. With this tweak, we still prefer matches on shorter text, but the difference is more subtle.

Another effect: searching for `AngularDart` will not rank the `angular` package that behind, it will be likely on the first page.