### PR TITLE
Fix image size for landing page main logo.

### DIFF
--- a/static/v2/css/style.css
+++ b/static/v2/css/style.css
@@ -577,9 +577,30 @@ pre > code {
 }
 
 
-.home-banner > .logo{
-  width: 100%;
-  max-width: 520px
+.home-banner > .logo {
+  width: 520px;
+  height: 72px;
+}
+
+@media (max-width: 520px) {
+  .home-banner > .logo {
+    width: 455px;
+    height: 63px;
+  }
+}
+
+@media (max-width: 460px) {
+  .home-banner > .logo {
+    width: 390px;
+    height: 54px;
+  }
+}
+
+@media (max-width: 400px) {
+  .home-banner > .logo {
+    width: 325px;
+    height: 45px;
+  }
 }
 
 


### PR DESCRIPTION
Fixes #839. I decided against the `<picture>` element for now, as the CSS-based solution seems to be good enough. It requires fixed sizes per resolution, because otherwise it would "flicker" a bit on platform changes.