### PR TITLE
Upgrade pana to 0.8.2

### DIFF
--- a/app/lib/analyzer/versions.dart
+++ b/app/lib/analyzer/versions.dart
@@ -5,7 +5,7 @@
 import 'package:pub_semver/pub_semver.dart';
 
 // keep in-sync with app/pubspec.yaml
-final String panaVersion = '0.8.1';
+final String panaVersion = '0.8.2';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
 // keep in-sync with app/script/setup-flutter.sh

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -348,7 +348,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.1"
+    version: "0.8.2"
   path:
     description:
       name: path

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   yaml: '^2.1.12'
   # pana version to be pinned
   # keep in-sync with app/lib/analyzer/versions.dart
-  pana: '0.8.1'
+  pana: '0.8.2'
   # 3rd-party packages with pinned versions
   archive: '1.0.33'
   uuid: '0.5.3'


### PR DESCRIPTION
Unblocked platform classification verified: [0.8.2](http://analyzer-dot-dartlang-pub-dev.appspot.com/packages/firebase/3.0.1) vs [0.8.1](http://analyzer-dot-dartlang-pub.appspot.com/packages/firebase/3.0.1)