### PR TITLE
Use hash on script.dart.js for longer caching

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -48,7 +48,9 @@ class StaticsCache {
     final bytes = file.readAsBytesSync();
     final lastModified = file.lastModifiedSync();
     final String relativePath = path.relative(file.path, from: rootPath);
-    final String etag = crypto.sha256.convert(bytes).toString();
+    final digest = crypto.sha256.convert(bytes);
+    final String etag =
+        digest.bytes.map((b) => (b & 31).toRadixString(32)).join();
     return new StaticFile(relativePath, contentType, bytes, lastModified, etag);
   }
 
@@ -81,6 +83,7 @@ class StaticUrls {
   final String documentationIcon;
   final String downloadIcon;
   Map _versionsTableIcons;
+  Map _assets;
 
   StaticUrls(this.staticPath)
       : smallDartFavicon = '$staticPath/favicon.ico',
@@ -95,5 +98,25 @@ class StaticUrls {
       'documentation': documentationIcon,
       'download': downloadIcon,
     };
+  }
+
+  Map get assets {
+    return _assets ??= {
+      'script_dart_js': _getCacheableStaticUrl('/v2/js/script.dart.js'),
+    };
+  }
+}
+
+/// Returns the URL of a static resource
+String _getCacheableStaticUrl(String relativePath) {
+  if (!relativePath.startsWith('/')) {
+    relativePath = '/$relativePath';
+  }
+  final String requestPath = '${staticUrls.staticPath}$relativePath';
+  final file = staticsCache.getFile(requestPath);
+  if (file == null) {
+    throw new Exception('Static resource not found: $relativePath');
+  } else {
+    return '$requestPath?hash=${file.etag}';
   }
 }

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -579,6 +579,7 @@ class TemplateService {
     final platformDict = getPlatformDict(platform);
     final values = {
       'static_assets_dir': staticUrls.newDesignAssetsDir,
+      'static_assets': staticUrls.assets,
       'favicon': faviconUrl ?? staticUrls.smallDartFavicon,
       'package': packageName == null
           ? false

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -15,7 +15,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -15,7 +15,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/server_landing_page.html
+++ b/app/test/frontend/golden/server_landing_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -14,7 +14,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/v2/highlight/github.css" rel="stylesheet" />
   <link href="/static/v2/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="/static/v2/js/script.dart.js" defer></script>
+  <script src="/static/v2/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layout.mustache
+++ b/app/views/layout.mustache
@@ -26,7 +26,7 @@
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="{{{static_assets_dir}}}/highlight/github.css" rel="stylesheet" />
   <link href="{{{static_assets_dir}}}/css/style.css" rel="stylesheet" type="text/css" />
-  <script src="{{{static_assets_dir}}}/js/script.dart.js" defer></script>
+  <script src="{{{static_assets.script_dart_js}}}" defer></script>
   <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
- Makes ETag shorter (half in size).
- Changes the URL structure of static resources (only the `script.dart.js` for now, if we like the pattern then rest can be migrated to it).
- Increased the cache period for resources with matching hash (with protection agains version mismatches).