### PR TITLE
Fix(?) sitelink search box metadata

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -549,6 +549,7 @@ class TemplateService {
         ? null
         : serializeSearchOrder(searchQuery.order);
     final platformDict = getPlatformDict(platform);
+    final isRoot = type == PageType.landing && platform == null;
     final values = {
       'static_assets_dir': staticUrls.newDesignAssetsDir,
       'favicon': faviconUrl ?? staticUrls.smallDartFavicon,
@@ -574,7 +575,8 @@ class TemplateService {
           platform == 'flutter' ? 'Flutter packages' : 'Dart packages',
       'listing_banner': type == PageType.listing,
       'package_banner': type == PageType.package,
-      'schema_org_searchaction_json': JSON.encode(_schemaOrgSearchAction),
+      'schema_org_searchaction_json':
+          isRoot ? JSON.encode(_schemaOrgSearchAction) : null,
     };
     return _renderTemplate('layout', values, escapeValues: false);
   }
@@ -839,8 +841,8 @@ const _schemaOrgSearchAction = const {
   'url': '$siteRoot/',
   'potentialAction': const {
     '@type': 'SearchAction',
-    'target': '$siteRoot/packages?q={query}',
-    'query-input': 'required name=query',
+    'target': '$siteRoot/packages?q={search_term_string}',
+    'query-input': 'required name=search_term_string',
   },
 };
 

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -83,8 +83,5 @@
 </footer>
 <script src="/static/v2/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -80,8 +80,5 @@
 </footer>
 <script src="/static/v2/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -112,8 +112,5 @@
   <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -113,7 +113,7 @@
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
+{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={search_term_string}","query-input":"required name=search_term_string"}}
 </script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -145,8 +145,5 @@
   <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -318,8 +318,5 @@ import 'package:foobar_pkg/foolib.dart';
 </footer>
 <script src="/static/v2/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -279,8 +279,5 @@ import 'package:foobar_pkg/foolib.dart';
 </footer>
 <script src="/static/v2/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -319,8 +319,5 @@ import 'package:foobar_pkg/foolib.dart';
 </footer>
 <script src="/static/v2/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -110,8 +110,5 @@
 </footer>
 <script src="/static/v2/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -166,8 +166,5 @@
   <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/server_landing_page.html
+++ b/app/test/frontend/golden/server_landing_page.html
@@ -112,8 +112,5 @@
   <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -112,8 +112,5 @@
   <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
-<script type="application/ld+json">
-{"@context":"http://schema.org","@type":"WebSite","url":"https://pub.dartlang.org/","potentialAction":{"@type":"SearchAction","target":"https://pub.dartlang.org/packages?q={query}","query-input":"required name=query"}}
-</script>
 </body>
 </html>

--- a/app/views/layout.mustache
+++ b/app/views/layout.mustache
@@ -117,8 +117,10 @@
 <script src="{{{static_assets_dir}}}/highlight/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>
 {{/include_highlight}}
+{{#schema_org_searchaction_json}}
 <script type="application/ld+json">
 {{& schema_org_searchaction_json}}
 </script>
+{{/schema_org_searchaction_json}}
 </body>
 </html>


### PR DESCRIPTION
#708 was deployed weeks ago, yet, Google doesn't display the search box in the sitelinks section. As most online examples (including the official one) uses the `search_term_string` expression, I'd rather use that too, just to make sure we are doing it by the book.