### PR TITLE
Fix analysis tab when package version is outdated.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -145,7 +145,8 @@ class TemplateService {
   }
 
   /// Renders the `views/pkg/analysis_tab.mustache` template.
-  String renderAnalysisTab(AnalysisExtract extract, AnalysisView analysis) {
+  String renderAnalysisTab(
+      String package, AnalysisExtract extract, AnalysisView analysis) {
     if (analysis == null || !analysis.hasAnalysisData) return null;
 
     String statusText;
@@ -191,6 +192,8 @@ class TemplateService {
         devDeps.isNotEmpty;
 
     final Map<String, dynamic> data = {
+      'package': package,
+      'show_outdated': analysis.analysisStatus == AnalysisStatus.outdated,
       'date_completed': analysis.timestamp == null
           ? null
           : shortDateFormat.format(analysis.timestamp),
@@ -350,7 +353,7 @@ class TemplateService {
         'score_box_html': _renderScoreBox(extract?.overallScore,
             isNewPackage: package.isNewPackage()),
         'dependencies_html': _renderDependencyList(analysis),
-        'analysis_html': renderAnalysisTab(extract, analysis),
+        'analysis_html': renderAnalysisTab(package.name, extract, analysis),
         'schema_org_pkgmeta_json':
             JSON.encode(_schemaOrgPkgMeta(package, selectedVersion, analysis)),
       },

--- a/app/test/frontend/golden/analysis_tab_outdated.html
+++ b/app/test/frontend/golden/analysis_tab_outdated.html
@@ -1,0 +1,11 @@
+<h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a class='github_issue' data-bug-tag='analysis' href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">feedback</a>.
+</div>
+
+<p>
+  This package version is not analyzed, because it is more than two years old.
+  Check the <a href="/packages/pkg_foo#-analysis-tab-">latest stable version</a> for its analysis.
+</p>

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -220,7 +220,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderAnalysisTab(extract, analysis) {
+  String renderAnalysisTab(String package, extract, analysis) {
     return _response;
   }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -184,7 +184,7 @@ void main() {
 
     test('no content for analysis tab', () async {
       // no content
-      expect(templates.renderAnalysisTab(null, null), isNull);
+      expect(templates.renderAnalysisTab('pkg_foo', null, null), isNull);
     });
 
     test('analysis tab: http', () async {
@@ -195,12 +195,13 @@ void main() {
           new AnalysisView(new AnalysisData.fromJson(JSON.decode(json)));
       final extract = new AnalysisExtract(
           health: view.health, maintenance: 0.9, popularity: 0.23);
-      final String html = templates.renderAnalysisTab(extract, view);
+      final String html = templates.renderAnalysisTab('http', extract, view);
       expectGoldenFile(html, 'analysis_tab_http.html', isFragment: true);
     });
 
     test('mock analysis tab', () async {
       final String html = templates.renderAnalysisTab(
+          'pkg_foo',
           new AnalysisExtract(
             health: 0.90234,
             maintenance: 0.8932343,
@@ -244,6 +245,7 @@ void main() {
 
     test('aborted analysis tab', () async {
       final String html = templates.renderAnalysisTab(
+          'pkg_foo',
           null,
           new AnalysisView(new AnalysisData(
             packageName: 'foo',
@@ -254,6 +256,21 @@ void main() {
             timestamp: new DateTime(2017, 12, 18, 14, 26, 00),
           )));
       expectGoldenFile(html, 'analysis_tab_aborted.html', isFragment: true);
+    });
+
+    test('outdated analysis tab', () async {
+      final String html = templates.renderAnalysisTab(
+          'pkg_foo',
+          null,
+          new AnalysisView(new AnalysisData(
+            packageName: 'foo',
+            packageVersion: '1.0.0',
+            panaVersion: '0.8.0',
+            flutterVersion: '0.0.20',
+            analysisStatus: AnalysisStatus.outdated,
+            timestamp: new DateTime(2017, 12, 18, 14, 26, 00),
+          )));
+      expectGoldenFile(html, 'analysis_tab_outdated.html', isFragment: true);
     });
 
     test('package index page', () {

--- a/app/views/pkg/analysis_tab.mustache
+++ b/app/views/pkg/analysis_tab.mustache
@@ -5,6 +5,13 @@
   We welcome <a class='github_issue' data-bug-tag='analysis' href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">feedback</a>.
 </div>
 
+{{#show_outdated}}
+<p>
+  This package version is not analyzed, because it is more than two years old.
+  Check the <a href="/packages/{{{package}}}#-analysis-tab-">latest stable version</a> for its analysis.
+</p>
+{{/show_outdated}}
+{{^show_outdated}}
 <p>
   We analyzed this package, and provided a score, details, and suggestions below.
 </p>
@@ -140,3 +147,4 @@
 </table>
 </div>
 {{/has_dependency}}
+{{/show_outdated}}


### PR DESCRIPTION
When a package version is too old, we provide a link to the latest stable's analysis.

#888