### PR TITLE
Invalidate analyzer cache only if new Analysis was stored.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -172,13 +172,15 @@ class AnalysisBackend {
       if (preventRegression || preventIdentical) {
         await tx.rollback();
       } else {
+        _logger.info(
+            'Storing analysis for: ${analysis.packageName} ${analysis.packageVersion}');
         inserts.add(analysis);
         tx.queueMutations(inserts: inserts);
         await tx.commit();
-      }
 
-      analyzerMemcache.invalidateContent(
-          analysis.packageName, analysis.packageVersion, analysis.panaVersion);
+        analyzerMemcache.invalidateContent(analysis.packageName,
+            analysis.packageVersion, analysis.panaVersion);
+      }
 
       return new BackendAnalysisStatus(wasRace, isLatestStable, isNewVersion);
     });


### PR DESCRIPTION
By moving the invalidation inside the same block as the commit, it partially handles #887.