### PR TITLE
Separate homepage and repository for a package

### DIFF
--- a/app/lib/frontend/model_properties.dart
+++ b/app/lib/frontend/model_properties.dart
@@ -78,6 +78,11 @@ class Pubspec {
     return _asString(_json['homepage']);
   }
 
+  String get repository {
+    _load();
+    return _asString(_json['repository']);
+  }
+
   String get description {
     _load();
     return _asString(_json['description']);

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -205,10 +205,22 @@ class PackageVersion extends db.ExpandoModel {
   String get documentationNice => niceUrl(documentation);
 
   String get homepage {
+    if (pubspec.repository == null && isRepositoryUrl(pubspec.homepage)) {
+      return null;
+    }
     return pubspec.homepage;
   }
 
   String get homepageNice => niceUrl(homepage);
+
+  String get repository {
+    if (pubspec.repository == null && isRepositoryUrl(pubspec.homepage)) {
+      return pubspec.homepage;
+    }
+    return pubspec.repository;
+  }
+
+  String get repositoryNice => niceUrl(repository);
 }
 
 @db.Kind(name: 'PrivateKey', idType: db.IdType.String)

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -265,7 +265,7 @@ class TemplateService {
     if (selectedVersion.readme != null) {
       readmeFilename = selectedVersion.readme.filename;
       renderedReadme =
-          _renderFile(selectedVersion.readme, selectedVersion.homepage);
+          _renderFile(selectedVersion.readme, selectedVersion.repository);
     }
 
     String changelogFilename;
@@ -273,7 +273,7 @@ class TemplateService {
     if (selectedVersion.changelog != null) {
       changelogFilename = selectedVersion.changelog.filename;
       renderedChangelog =
-          _renderFile(selectedVersion.changelog, selectedVersion.homepage);
+          _renderFile(selectedVersion.changelog, selectedVersion.repository);
     }
 
     String exampleFilename;
@@ -281,7 +281,7 @@ class TemplateService {
     if (selectedVersion.example != null) {
       exampleFilename = selectedVersion.example.filename;
       renderedExample =
-          _renderFile(selectedVersion.example, selectedVersion.homepage);
+          _renderFile(selectedVersion.example, selectedVersion.repository);
       if (renderedExample != null) {
         renderedExample = '<p style="font-family: monospace">'
             '<b>${_htmlEscaper.convert(exampleFilename)}</b>'
@@ -346,6 +346,8 @@ class TemplateService {
             _getAuthorsHtml(selectedVersion.pubspec.getAllAuthors()),
         'homepage': selectedVersion.homepage,
         'nice_homepage': selectedVersion.homepageNice,
+        'repository': selectedVersion.repository,
+        'nice_repository': selectedVersion.repositoryNice,
         'documentation': selectedVersion.documentation,
         'nice_documentation': selectedVersion.documentationNice,
         // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
@@ -354,7 +356,7 @@ class TemplateService {
         'short_created': selectedVersion.shortCreated,
         'install_html': _renderInstall(isFlutterPackage, analysis?.platforms),
         'license_html':
-            _renderLicenses(selectedVersion.homepage, analysis?.licenses),
+            _renderLicenses(selectedVersion.repository, analysis?.licenses),
         'score_box_html': _renderScoreBox(extract?.overallScore,
             isOutdated: extract?.isOutdated,
             isNewPackage: package.isNewPackage()),

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -358,3 +358,9 @@ class StringInternPool {
     }
   }
 }
+
+bool isRepositoryUrl(String url) {
+  if (url == null) return false;
+  return url.startsWith('https://github.com/') ||
+      url.startsWith('https://gitlab.com/');
+}

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -287,6 +287,7 @@ import 'package:foobar_pkg/foolib.dart';
       <h3 class="title">Homepage</h3>
       <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
 
+
       <h3 class="title">Documentation</h3>
       <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -252,6 +252,7 @@ import 'package:foobar_pkg/foolib.dart';
       <h3 class="title">Homepage</h3>
       <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
 
+
       <h3 class="title">Documentation</h3>
       <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -261,6 +261,7 @@ import 'package:foobar_pkg/foolib.dart';
       <h3 class="title">Homepage</h3>
       <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
 
+
       <h3 class="title">Documentation</h3>
       <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -288,6 +288,7 @@ import 'package:foobar_pkg/foolib.dart';
       <h3 class="title">Homepage</h3>
       <a class="link" href="http:&#x2F;&#x2F;hans.juergen.com">hans.juergen.com</a>
 
+
       <h3 class="title">Documentation</h3>
       <a class="link" href="http:&#x2F;&#x2F;www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -99,6 +99,11 @@ import 'package:{{package}}/{{library}}';
       <a class="link" href="{{package.homepage}}">{{package.nice_homepage}}</a>
     {{/package.homepage}}
 
+    {{#package.repository}}
+      <h3 class="title">Repository</h3>
+      <a class="link" href="{{package.repository}}">{{package.nice_repository}}</a>
+    {{/package.repository}}
+
     {{#package.documentation}}
       <h3 class="title">Documentation</h3>
       <a class="link" href="{{package.documentation}}">{{package.nice_documentation}}</a>


### PR DESCRIPTION
- introduces a new `repository` field in `pubspec.yaml`
- if only `homepage` is specified and it is a known repository url, it will be displayed as "Repository" and not as "Homepage"
- if both are specified, both will be displayed

Deployed in staging, a few examples:
- https://dartlang-pub-dev.appspot.com/packages/http
- https://dartlang-pub-dev.appspot.com/packages/jaguar