### PR TITLE
Score range indicator on the analysis tab.

### DIFF
--- a/app/test/frontend/golden/analysis_tab_aborted.html
+++ b/app/test/frontend/golden/analysis_tab_aborted.html
@@ -33,6 +33,7 @@
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -45,6 +46,7 @@
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -57,6 +59,7 @@
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/test/frontend/golden/analysis_tab_http.html
+++ b/app/test/frontend/golden/analysis_tab_http.html
@@ -33,6 +33,7 @@
       </div>
     </td>
     <td class="score-value">23</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -45,6 +46,7 @@
       </div>
     </td>
     <td class="score-value">99</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -57,6 +59,7 @@
       </div>
     </td>
     <td class="score-value">90</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/test/frontend/golden/analysis_tab_mock.html
+++ b/app/test/frontend/golden/analysis_tab_mock.html
@@ -33,6 +33,7 @@
       </div>
     </td>
     <td class="score-value">23</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -45,6 +46,7 @@
       </div>
     </td>
     <td class="score-value">90</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -57,6 +59,7 @@
       </div>
     </td>
     <td class="score-value">89</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -203,6 +203,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -215,6 +216,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -227,6 +229,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -194,6 +194,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">30</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -206,6 +207,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">99</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -218,6 +220,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">99</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -203,6 +203,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -215,6 +216,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -227,6 +229,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -204,6 +204,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -216,6 +217,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -228,6 +230,7 @@ import 'package:foobar_pkg/foolib.dart';
       </div>
     </td>
     <td class="score-value">--</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/app/views/pkg/analysis_tab.mustache
+++ b/app/views/pkg/analysis_tab.mustache
@@ -40,6 +40,7 @@
       </div>
     </td>
     <td class="score-value">{{popularity}}</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -52,6 +53,7 @@
       </div>
     </td>
     <td class="score-value">{{health}}</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">
@@ -64,6 +66,7 @@
       </div>
     </td>
     <td class="score-value">{{maintenance}}</td>
+    <td class="score-range">/ 100</td>
   </tr>
   <tr>
     <td class="score-name">

--- a/static/v2/css/style.css
+++ b/static/v2/css/style.css
@@ -1012,6 +1012,11 @@ pre > code {
   padding-right: 18px;
 }
 
+#scores-table .score-range {
+  color: #666;
+  font-size: 10pt;
+}
+
 .tooltip-base {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
<img width="252" alt="screen shot 2018-01-10 at 10 38 42 am" src="https://user-images.githubusercontent.com/4778111/34765745-9bf22a70-f5f2-11e7-87f4-bae6238e6695.png">

- I think the overall score doesn't need the same indicator, it feels less crowded without it.
- Using a new cell in the table layout increases the gap between the actual value and the "/ 100", but keeps the style and layout simple.