### PR TITLE
Removing 'Server' platform from the UI.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -136,8 +136,8 @@ Future<shelf.Response> _flutterLandingHandler(shelf.Request request) =>
     _indexHandler(request, KnownPlatforms.flutter);
 
 /// Handles requests for /server
-Future<shelf.Response> _serverLandingHandler(shelf.Request request) =>
-    _indexHandler(request, KnownPlatforms.server);
+shelf.Response _serverLandingHandler(shelf.Request request) =>
+    redirectResponse('/');
 
 /// Handles requests for /web
 Future<shelf.Response> _webLandingHandler(shelf.Request request) =>
@@ -329,8 +329,14 @@ Future<shelf.Response> _flutterPackagesHandlerHtml(shelf.Request request) =>
     _packagesHandlerHtmlCore(request, KnownPlatforms.flutter);
 
 /// Handles /server/packages
-Future<shelf.Response> _serverPackagesHandlerHtml(shelf.Request request) =>
-    _packagesHandlerHtmlCore(request, KnownPlatforms.server);
+shelf.Response _serverPackagesHandlerHtml(shelf.Request request) {
+  final params = request.requestedUri.queryParameters;
+  final uri = new Uri(
+    path: '/packages',
+    queryParameters: params.isNotEmpty ? params : null,
+  );
+  return redirectResponse(uri.toString());
+}
 
 /// Handles /web/packages
 Future<shelf.Response> _webPackagesHandlerHtml(shelf.Request request) =>

--- a/app/lib/frontend/template_consts.dart
+++ b/app/lib/frontend/template_consts.dart
@@ -74,9 +74,8 @@ String _landingPageTitle(String platform) {
 
 final Map<String, String> _landingBlurbs = const {
   'default':
-      '<p class="text">Find and use packages to build <a href="/flutter">Flutter</a>, '
-      '<a href="/web">web</a> and <a href="/server">server</a> apps '
-      'with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>',
+      '<p class="text">Find and use packages to build <a href="/flutter">Flutter</a> and '
+      '<a href="/web">web</a> apps with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>',
   KnownPlatforms.flutter:
       '<p class="text"><a href="https://flutter.io/">Flutter<sup><small>↗</small></sup></a> '
       'makes it easy and fast to build beautiful mobile apps<br/> for iOS and Android.</p>',

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -748,7 +748,6 @@ class TemplateService {
       'tabs': [
         platformTabData('Flutter', KnownPlatforms.flutter),
         platformTabData('Web', KnownPlatforms.web),
-        platformTabData('Server', KnownPlatforms.server),
         platformTabData('All', null),
       ]
     };

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -681,13 +681,17 @@ class TemplateService {
         'href': href,
       });
     } else {
-      tags.addAll(platforms.map((platform) {
-        final platformDict = getPlatformDict(platform, nullIfMissing: true);
-        return {
-          'text': platformDict.name ?? platform,
-          'href': platformDict?.listingUrl,
-        };
-      }));
+      tags.addAll(
+        platforms
+            .where((platform) => platform != KnownPlatforms.server)
+            .map((platform) {
+          final platformDict = getPlatformDict(platform, nullIfMissing: true);
+          return {
+            'text': platformDict.name ?? platform,
+            'href': platformDict?.listingUrl,
+          };
+        }),
+      );
     }
     return _renderTemplate('pkg/tags', {
       'has_tags': tags.isNotEmpty,

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -72,7 +72,6 @@
       <div class="list-filters">
     <a class="filter -active" href="/flutter">Flutter</a>
     <a class="filter " href="/web">Web</a>
-    <a class="filter " href="/server">Server</a>
     <a class="filter " href="/">All</a>
 </div>
       <p class="text"><a href="https://flutter.io/">Flutter<sup><small>↗</small></sup></a> makes it easy and fast to build beautiful mobile apps<br/> for iOS and Android.</p>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -75,7 +75,7 @@
     <a class="filter " href="/server">Server</a>
     <a class="filter -active" href="/">All</a>
 </div>
-      <p class="text">Find and use packages to build <a href="/flutter">Flutter</a>, <a href="/web">web</a> and <a href="/server">server</a> apps with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>
+      <p class="text">Find and use packages to build <a href="/flutter">Flutter</a> and <a href="/web">web</a> apps with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>
     </main>
   </div>
 

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -72,7 +72,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter">Flutter</a>
     <a class="filter " href="/web">Web</a>
-    <a class="filter " href="/server">Server</a>
     <a class="filter -active" href="/">All</a>
 </div>
       <p class="text">Find and use packages to build <a href="/flutter">Flutter</a> and <a href="/web">web</a> apps with <a target="_blank" href="https://www.dartlang.org">Dart</a>.</p>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -70,7 +70,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter/packages">Flutter</a>
     <a class="filter " href="/web/packages">Web</a>
-    <a class="filter " href="/server/packages">Server</a>
     <a class="filter -active" href="/packages">All</a>
 </div>
     </main>

--- a/app/test/frontend/golden/platform_tabs_list.html
+++ b/app/test/frontend/golden/platform_tabs_list.html
@@ -1,6 +1,5 @@
 <div class="list-filters">
     <a class="filter " href="/flutter/packages">Flutter</a>
     <a class="filter -active" href="/web/packages">Web</a>
-    <a class="filter " href="/server/packages">Server</a>
     <a class="filter " href="/packages">All</a>
 </div>

--- a/app/test/frontend/golden/platform_tabs_search.html
+++ b/app/test/frontend/golden/platform_tabs_search.html
@@ -1,6 +1,5 @@
 <div class="list-filters">
     <a class="filter " href="/flutter/packages?q=foo">Flutter</a>
     <a class="filter " href="/web/packages?q=foo">Web</a>
-    <a class="filter -active" href="/server/packages?q=foo">Server</a>
     <a class="filter " href="/packages?q=foo">All</a>
 </div>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -70,7 +70,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter/packages?q=foobar&amp;sort=top">Flutter</a>
     <a class="filter " href="/web/packages?q=foobar&amp;sort=top">Web</a>
-    <a class="filter " href="/server/packages?q=foobar&amp;sort=top">Server</a>
     <a class="filter -active" href="/packages?q=foobar&amp;sort=top">All</a>
 </div>
     </main>

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -70,7 +70,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter/packages?q=email%3Auser%40domain.com">Flutter</a>
     <a class="filter " href="/web/packages?q=email%3Auser%40domain.com">Web</a>
-    <a class="filter " href="/server/packages?q=email%3Auser%40domain.com">Server</a>
     <a class="filter -active" href="/packages?q=email%3Auser%40domain.com">All</a>
 </div>
     </main>

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -70,7 +70,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter/packages?q=foo%3Abar">Flutter</a>
     <a class="filter " href="/web/packages?q=foo%3Abar">Web</a>
-    <a class="filter " href="/server/packages?q=foo%3Abar">Server</a>
     <a class="filter -active" href="/packages?q=foo%3Abar">All</a>
 </div>
     </main>

--- a/app/test/frontend/golden/server_landing_page.html
+++ b/app/test/frontend/golden/server_landing_page.html
@@ -72,7 +72,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter">Flutter</a>
     <a class="filter " href="/web">Web</a>
-    <a class="filter -active" href="/server">Server</a>
     <a class="filter " href="/">All</a>
 </div>
       <p class="text">Use Dart to create command line and server applications.<br/> Start with the <a href="https://www.dartlang.org/tutorials/dart-vm/get-started">Dart VM tutorial<sup><small>↗</small></sup></a>.</p>

--- a/app/test/frontend/golden/server_landing_page.html
+++ b/app/test/frontend/golden/server_landing_page.html
@@ -95,10 +95,7 @@
     <li class="list-item -simple">
       <h3 class="title"><a href="/packages/foobar_pkg">foobar_pkg</a></h3>
       <p class="metadata">
-          
-        <a class="package-tag" href="/server/packages">server</a>
-  
-
+        
       </p>
       <p class="description">my package description</p>
     </li>

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -72,7 +72,6 @@
       <div class="list-filters">
     <a class="filter " href="/flutter">Flutter</a>
     <a class="filter -active" href="/web">Web</a>
-    <a class="filter " href="/server">Server</a>
     <a class="filter " href="/">All</a>
 </div>
       <p class="text">Use Dart to create web applications that run on any modern browser.<br/> Start with <a href="https://webdev.dartlang.org/angular">AngularDart<sup><small>↗</small></sup></a>.</p>

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -325,6 +325,19 @@ void main() {
         await expectHtmlResponse(await issueGet('/flutter/packages?page=2'));
       });
 
+      tScopedTest('/server', () async {
+        expectRedirectResponse(await issueGet('/server'), '/');
+      });
+
+      tScopedTest('/server/packages with parameters', () async {
+        expectRedirectResponse(
+            await issueGet('/server/packages?sort=top'), '/packages?sort=top');
+      });
+
+      tScopedTest('/server/packages', () async {
+        expectRedirectResponse(await issueGet('/server/packages'), '/packages');
+      });
+
       tScopedTest('/doc', () async {
         for (var path in redirectPaths.keys) {
           final redirectUrl =


### PR DESCRIPTION
This is the first part of the short-term fix around the platform classifications (#858). We cannot provide the same level of classification consistency for 'Server' (including build tools and Node.js) as for Web or Flutter, and in many cases this results in a wrong classification. This removes:
- the landing blurb text
- the platform selection tab
- the package platform tag
- the listing page

/cc @mit-mit