### PR TITLE
Rewrite relative URLs of both links and images.

### DIFF
--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -4,7 +4,6 @@
 
 import 'package:logging/logging.dart';
 import 'package:markdown/markdown.dart' as m;
-import 'package:path/path.dart' as p;
 
 import 'package:pana/src/download_utils.dart' show getRepositoryUrl;
 
@@ -17,61 +16,89 @@ final List<m.InlineSyntax> _inlineSyntaxes = m
 
 String markdownToHtml(String text, String baseUrl) {
   if (text == null) return null;
-  final m.InlineSyntax relativeLink = _RelativeLinkSyntax.parse(baseUrl);
-  final inlineSyntaxes = <m.InlineSyntax>[];
-  if (relativeLink != null) {
-    inlineSyntaxes.insert(0, relativeLink);
+  final sanitizedBaseUrl = _pruneBaseUrl(baseUrl);
+
+  final document = new m.Document(
+      extensionSet: m.ExtensionSet.none,
+      blockSyntaxes: m.ExtensionSet.gitHubWeb.blockSyntaxes,
+      inlineSyntaxes: _inlineSyntaxes);
+
+  final lines = text.replaceAll('\r\n', '\n').split('\n');
+  final nodes = document.parseLines(lines);
+
+  if (sanitizedBaseUrl != null) {
+    final visitor = new _RelativeUrlRewriter(sanitizedBaseUrl);
+    for (final node in nodes) {
+      node.accept(visitor);
+    }
   }
-  inlineSyntaxes.addAll(_inlineSyntaxes);
-  return m.markdownToHtml(
-    text,
-    extensionSet: m.ExtensionSet.none,
-    blockSyntaxes: m.ExtensionSet.gitHubWeb.blockSyntaxes,
-    inlineSyntaxes: inlineSyntaxes,
-  );
+
+  return m.renderToHtml(nodes) + '\n';
 }
 
-class _RelativeLinkSyntax extends m.LinkSyntax {
+class _RelativeUrlRewriter implements m.NodeVisitor {
   final String url;
-  _RelativeLinkSyntax(this.url);
-
-  static _RelativeLinkSyntax parse(String url) {
-    try {
-      final Uri uri = Uri.parse(url);
-      if (uri.scheme != 'http' && uri.scheme != 'https') {
-        return null;
-      }
-      if (uri.host == null || uri.host.isEmpty || !uri.host.contains('.')) {
-        return null;
-      }
-      return new _RelativeLinkSyntax(url);
-    } catch (e) {
-      // url is user-provided, may be malicious, ignoring errors.
-    }
-    return null;
-  }
+  _RelativeUrlRewriter(this.url);
 
   @override
-  m.Link getLink(m.InlineParser parser, Match match, m.TagState state) {
-    final m.Link link = super.getLink(parser, match, state);
-    if (link != null && _isRelativePathUrl(link.url)) {
-      try {
-        final List<String> fragmentParts = link.url.split('#');
-        final String relativeUrl = fragmentParts.first;
-        final String fragment =
-            fragmentParts.length == 2 ? fragmentParts[1] : null;
-        String newUrl = getRepositoryUrl(url, relativeUrl);
-        if (fragment != null) {
-          newUrl = '$newUrl#$fragment';
-        }
-        return new m.Link(link.id, newUrl, link.title);
-      } catch (e, st) {
-        _logger.warning('Relative link rewrite failed: ${link.url}', e, st);
+  void visitText(m.Text text) {}
+
+  @override
+  bool visitElementBefore(m.Element element) => true;
+
+  @override
+  void visitElementAfter(m.Element element) {
+    if (element.tag == 'a') {
+      element.attributes['href'] =
+          _rewriteLink(element.attributes['href'], true);
+    } else if (element.tag == 'img') {
+      element.attributes['src'] =
+          _rewriteLink(element.attributes['src'], false);
+    }
+  }
+
+  String _rewriteLink(String link, bool includeFragments) {
+    if (link == null || link.startsWith('#') || link.contains(':')) {
+      return link;
+    }
+    try {
+      final linkUri = Uri.parse(link);
+      final linkPath = linkUri.path;
+      final linkFragment = linkUri.fragment;
+      if (linkPath == null || linkPath.isEmpty) {
+        return link;
       }
+      String newUrl;
+      if (linkPath.startsWith('/')) {
+        newUrl = Uri.parse(url).replace(path: linkPath).toString();
+      } else {
+        newUrl = getRepositoryUrl(url, linkPath);
+      }
+      if (linkFragment != null && linkFragment.isNotEmpty) {
+        newUrl = '$newUrl#$linkFragment';
+      }
+      return newUrl;
+    } catch (e, st) {
+      _logger.warning('Relative link rewrite failed: $link', e, st);
     }
     return link;
   }
+}
 
-  bool _isRelativePathUrl(String url) =>
-      url != null && !url.startsWith('#') && !url.contains(':');
+/// Returns null if the [url] looks invalid.
+String _pruneBaseUrl(String url) {
+  if (url == null) return null;
+  try {
+    final Uri uri = Uri.parse(url);
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
+      return null;
+    }
+    if (uri.host == null || uri.host.isEmpty || !uri.host.contains('.')) {
+      return null;
+    }
+    return uri.toString();
+  } catch (e) {
+    // url is user-provided, may be malicious, ignoring errors.
+  }
+  return null;
 }

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -20,7 +20,7 @@ void main() {
   group('Valid custom base URL', () {
     final String baseUrl = 'https://github.com/example/project';
 
-    test('relative within page', () {
+    test('relative link within page', () {
       expect(markdownToHtml('[text](#relative)', null),
           '<p><a href="#relative">text</a></p>\n');
       expect(markdownToHtml('[text](#relative)', baseUrl),
@@ -29,7 +29,7 @@ void main() {
           '<p><a href="#relative">text</a></p>\n');
     });
 
-    test('absolute URL', () {
+    test('absolute link URL', () {
       expect(markdownToHtml('[text](http://dartlang.org/)', null),
           '<p><a href="http://dartlang.org/">text</a></p>\n');
       expect(markdownToHtml('[text](http://dartlang.org/)', baseUrl),
@@ -38,7 +38,17 @@ void main() {
           '<p><a href="http://dartlang.org/">text</a></p>\n');
     });
 
-    test('sibling within site', () {
+    test('absolute image URL', () {
+      expect(markdownToHtml('![text](http://dartlang.org/image.png)', null),
+          '<p><img alt="text" src="http://dartlang.org/image.png" /></p>\n');
+      expect(markdownToHtml('![text](http://dartlang.org/image.png)', baseUrl),
+          '<p><img alt="text" src="http://dartlang.org/image.png" /></p>\n');
+      expect(
+          markdownToHtml('![text](http://dartlang.org/image.png)', '$baseUrl/'),
+          '<p><img alt="text" src="http://dartlang.org/image.png" /></p>\n');
+    });
+
+    test('sibling link within site', () {
       expect(markdownToHtml('[text](README.md)', null),
           '<p><a href="README.md">text</a></p>\n');
       expect(markdownToHtml('[text](README.md)', baseUrl),
@@ -47,7 +57,16 @@ void main() {
           '<p><a href="https://github.com/example/project/blob/master/README.md">text</a></p>\n');
     });
 
-    test('sibling plus relative link', () {
+    test('sibling image within site', () {
+      expect(markdownToHtml('![text](image.png)', null),
+          '<p><img alt="text" src="image.png" /></p>\n');
+      expect(markdownToHtml('![text](image.png)', baseUrl),
+          '<p><img alt="text" src="https://github.com/example/project/raw/master/image.png" /></p>\n');
+      expect(markdownToHtml('![text](image.png)', '$baseUrl/'),
+          '<p><img alt="text" src="https://github.com/example/project/raw/master/image.png" /></p>\n');
+    });
+
+    test('sibling link plus relative link', () {
       expect(markdownToHtml('[text](README.md#section)', null),
           '<p><a href="README.md#section">text</a></p>\n');
       expect(markdownToHtml('[text](README.md#section)', baseUrl),
@@ -56,7 +75,7 @@ void main() {
           '<p><a href="https://github.com/example/project/blob/master/README.md#section">text</a></p>\n');
     });
 
-    test('child within site', () {
+    test('child link within site', () {
       expect(markdownToHtml('[text](example/README.md)', null),
           '<p><a href="example/README.md">text</a></p>\n');
       expect(markdownToHtml('[text](example/README.md)', baseUrl),
@@ -65,13 +84,31 @@ void main() {
           '<p><a href="https://github.com/example/project/blob/master/example/README.md">text</a></p>\n');
     });
 
-    test('root within site', () {
+    test('child image within site', () {
+      expect(markdownToHtml('![text](example/image.png)', null),
+          '<p><img alt="text" src="example/image.png" /></p>\n');
+      expect(markdownToHtml('![text](example/image.png)', baseUrl),
+          '<p><img alt="text" src="https://github.com/example/project/raw/master/example/image.png" /></p>\n');
+      expect(markdownToHtml('![text](example/image.png)', '$baseUrl/'),
+          '<p><img alt="text" src="https://github.com/example/project/raw/master/example/image.png" /></p>\n');
+    });
+
+    test('root link within site', () {
       expect(markdownToHtml('[text](/README.md)', null),
           '<p><a href="/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](example/README.md)', baseUrl),
-          '<p><a href="https://github.com/example/project/blob/master/example/README.md">text</a></p>\n');
-      expect(markdownToHtml('[text](example/README.md)', '$baseUrl/'),
-          '<p><a href="https://github.com/example/project/blob/master/example/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](/example/README.md)', baseUrl),
+          '<p><a href="https://github.com/example/README.md">text</a></p>\n');
+      expect(markdownToHtml('[text](/example/README.md)', '$baseUrl/'),
+          '<p><a href="https://github.com/example/README.md">text</a></p>\n');
+    });
+
+    test('root image within site', () {
+      expect(markdownToHtml('![text](/image.png)', null),
+          '<p><img alt="text" src="/image.png" /></p>\n');
+      expect(markdownToHtml('![text](/example/image.png)', baseUrl),
+          '<p><img alt="text" src="https://github.com/example/image.png" /></p>\n');
+      expect(markdownToHtml('![text](/example/image.png)', '$baseUrl/'),
+          '<p><img alt="text" src="https://github.com/example/image.png" /></p>\n');
     });
 
     test('email', () {


### PR DESCRIPTION
Fixes #850.

Unfortunately having more then one InlineSyntax in the inlineSyntaxes list didn't work out as expected: either the links or the images were updated, but never both. Instead, doing the transformation on the tree output of the parser.

I've also fixed the test with the root URLs (e.g. '/prefixed/with/slash' should be kept intact).