### PR TITLE
Don't link path, git and sdk dependencies in analysis tab.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -11,6 +11,7 @@ import 'dart:math';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:meta/meta.dart';
 import 'package:mustache/mustache.dart' as mustache;
+import 'package:pana/pana.dart' show ConstraintTypes;
 
 import '../shared/analyzer_client.dart';
 import '../shared/markdown.dart';
@@ -170,6 +171,20 @@ class TemplateService {
     );
   }
 
+  String _renderAnalysisDepRow(PkgDependency pd) {
+    final isHosted = pd.constraintType != ConstraintTypes.sdk &&
+        pd.constraintType != ConstraintTypes.git &&
+        pd.constraintType != ConstraintTypes.path &&
+        pd.constraintType != ConstraintTypes.unknown;
+    return _renderTemplate('pkg/analysis_dep_row', {
+      'is_hosted': isHosted,
+      'package': pd.package,
+      'constraint': pd.constraint?.toString(),
+      'resolved': pd.resolved?.toString(),
+      'available': pd.available?.toString(),
+    });
+  }
+
   /// Renders the `views/pkg/analysis_tab.mustache` template.
   String renderAnalysisTab(String package, String sdkConstraint,
       AnalysisExtract extract, AnalysisView analysis) {
@@ -200,14 +215,7 @@ class TemplateService {
 
     List<Map> prepareDependencies(List<PkgDependency> list) {
       if (list == null || list.isEmpty) return const [];
-      return list
-          .map((pd) => {
-                'package': pd.package,
-                'constraint': pd.constraint?.toString(),
-                'resolved': pd.resolved?.toString(),
-                'available': pd.available?.toString(),
-              })
-          .toList();
+      return list.map((pd) => {'row_html': _renderAnalysisDepRow(pd)}).toList();
     }
 
     final hasSdkConstraint = sdkConstraint != null && sdkConstraint.isNotEmpty;

--- a/app/test/frontend/golden/analysis_tab_http.html
+++ b/app/test/frontend/golden/analysis_tab_http.html
@@ -157,41 +157,44 @@
     <td>1.9.1</td>
     <td></td>
   </tr>
+
   <tr>
     <th colspan="4" class="sub-header">Transitive dependencies</th>
   </tr>
-    <tr>
-      <td><a href="/packages/charcode">charcode</a></td>
-      <td></td>
-      <td>1.1.1</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/packages/source_span">source_span</a></td>
-      <td></td>
-      <td>1.4.0</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/packages/string_scanner">string_scanner</a></td>
-      <td></td>
-      <td>1.0.2</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><a href="/packages/typed_data">typed_data</a></td>
-      <td></td>
-      <td>1.1.5</td>
-      <td></td>
-    </tr>
+  <tr>
+    <td><a href="/packages/charcode">charcode</a></td>
+    <td></td>
+    <td>1.1.1</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a href="/packages/source_span">source_span</a></td>
+    <td></td>
+    <td>1.4.0</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a href="/packages/string_scanner">string_scanner</a></td>
+    <td></td>
+    <td>1.0.2</td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><a href="/packages/typed_data">typed_data</a></td>
+    <td></td>
+    <td>1.1.5</td>
+    <td></td>
+  </tr>
+
   <tr>
     <th colspan="4" class="sub-header">Dev dependencies</th>
   </tr>
-    <tr>
-      <td><a href="/packages/unittest">unittest</a></td>
-      <td>&gt;=0.9.0 &lt;0.12.0</td>
-      <td></td>
-      <td></td>
-    </tr>
+  <tr>
+    <td><a href="/packages/unittest">unittest</a></td>
+    <td>&gt;=0.9.0 &lt;0.12.0</td>
+    <td></td>
+    <td></td>
+  </tr>
+
 </table>
 </div>

--- a/app/test/frontend/golden/analysis_tab_mock.html
+++ b/app/test/frontend/golden/analysis_tab_mock.html
@@ -115,14 +115,17 @@
     <td>1.0.0</td>
     <td>1.1.0</td>
   </tr>
+
   <tr>
     <th colspan="4" class="sub-header">Transitive dependencies</th>
   </tr>
-    <tr>
-      <td><a href="/packages/async">async</a></td>
-      <td>&gt;=0.3.0 &lt;1.0.0</td>
-      <td>0.5.1</td>
-      <td>1.0.2</td>
-    </tr>
+  <tr>
+    <td><a href="/packages/async">async</a></td>
+    <td>&gt;=0.3.0 &lt;1.0.0</td>
+    <td>0.5.1</td>
+    <td>1.0.2</td>
+  </tr>
+
+
 </table>
 </div>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -280,6 +280,9 @@ import 'package:foobar_pkg/foolib.dart';
     <td>1.2.0</td>
     <td>1.3.0</td>
   </tr>
+
+
+
 </table>
 </div>
 

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -282,6 +282,9 @@ import 'package:foobar_pkg/foolib.dart';
     <td>1.2.0</td>
     <td>1.3.0</td>
   </tr>
+
+
+
 </table>
 </div>
 

--- a/app/views/pkg/analysis_dep_row.mustache
+++ b/app/views/pkg/analysis_dep_row.mustache
@@ -1,0 +1,9 @@
+{{! Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+  <tr>
+    <td>{{#is_hosted}}<a href="/packages/{{package}}">{{/is_hosted}}{{package}}{{#is_hosted}}</a>{{/is_hosted}}</td>
+    <td>{{constraint}}</td>
+    <td>{{resolved}}</td>
+    <td>{{available}}</td>
+  </tr>

--- a/app/views/pkg/analysis_tab.mustache
+++ b/app/views/pkg/analysis_tab.mustache
@@ -1,3 +1,6 @@
+{{! Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
 <h2>Analysis</h2>
 
 <div class="analysis-disclaimer">
@@ -122,40 +125,19 @@
     <td></td>
   </tr>
   {{/dependencies.has_sdk}}
-  {{#dependencies.direct}}
-  <tr>
-    <td><a href="/packages/{{package}}">{{package}}</a></td>
-    <td>{{constraint}}</td>
-    <td>{{resolved}}</td>
-    <td>{{available}}</td>
-  </tr>
-  {{/dependencies.direct}}
+{{#dependencies.direct}}{{& row_html}}{{/dependencies.direct}}
   {{#dependencies.has_transitive}}
   <tr>
     <th colspan="4" class="sub-header">Transitive dependencies</th>
   </tr>
   {{/dependencies.has_transitive}}
-  {{#dependencies.transitive}}
-    <tr>
-      <td><a href="/packages/{{package}}">{{package}}</a></td>
-      <td>{{constraint}}</td>
-      <td>{{resolved}}</td>
-      <td>{{available}}</td>
-    </tr>
-  {{/dependencies.transitive}}
+{{#dependencies.transitive}}{{& row_html}}{{/dependencies.transitive}}
   {{#dependencies.has_dev}}
   <tr>
     <th colspan="4" class="sub-header">Dev dependencies</th>
   </tr>
   {{/dependencies.has_dev}}
-  {{#dependencies.dev}}
-    <tr>
-      <td><a href="/packages/{{package}}">{{package}}</a></td>
-      <td>{{constraint}}</td>
-      <td>{{resolved}}</td>
-      <td>{{available}}</td>
-    </tr>
-  {{/dependencies.dev}}
+{{#dependencies.dev}}{{& row_html}}{{/dependencies.dev}}
 </table>
 </div>
 {{/has_dependency}}


### PR DESCRIPTION
- reduces duplicated template code
- somewhat fixes the output HTML indent (but still lacks a few items)
- fixes #933
