### PR TITLE
Add og:image metadata (with the default dart logo).

### DIFF
--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Pub Authorized Successfully" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Error error_status" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Flutter Packages" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Dart Packages" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Top Dart packages" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="foobar_pkg | Dart Package" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="foobar_pkg 0.1.1 Dart package - my package description" />
   <meta property="og:description" content="foobar_pkg 0.1.1 Dart package - my package description" />

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="foobar_pkg | Flutter Package" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png" />
   <meta name="description" content="foobar_pkg 0.1.1 Flutter and Dart package - my package description" />
   <meta property="og:description" content="foobar_pkg 0.1.1 Flutter and Dart package - my package description" />

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="foobar_pkg | Dart Package" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="foobar_pkg 0.1.1 Dart package - my package description" />
   <meta property="og:description" content="foobar_pkg 0.1.1 Dart package - my package description" />

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="foobar_pkg 0.1.1 | Dart Package" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <link rel="canonical" href="https://pub.dartlang.org/packages/foobar_pkg"/>
   <meta property="og:url" content="https://pub.dartlang.org/packages/foobar_pkg" />

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="foobar package - All Versions" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <link rel="canonical" href="https://pub.dartlang.org/packages/foobar"/>
   <meta property="og:url" content="https://pub.dartlang.org/packages/foobar" />

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Search results for foobar." />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Search results for email:user@domain.com." />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Search results for foo:bar." />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="Dart Packages for Web" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/v2/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/v2/img/dart-logo-400x400.png" />
   <link rel="shortcut icon" href="/static/favicon.ico" />
   <meta name="description" content="Pub is a package manager for the Dart programming language." />
   <meta property="og:description" content="Pub is a package manager for the Dart programming language." />

--- a/app/views/layout.mustache
+++ b/app/views/layout.mustache
@@ -14,6 +14,7 @@
   <meta property="og:title" content="{{title}}" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="{{{static_assets_dir}}}/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="{{{static_assets_dir}}}/img/dart-logo-400x400.png" />
   {{#favicon}}
   <link rel="shortcut icon" href="{{{favicon}}}" />
   {{/favicon}}


### PR DESCRIPTION
Fixes #885 (as there is no current consensus on how to selected the package-specific image yet).