### PR TITLE
Setup flutter in dartdoc service too.

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:isolate';
 
 import 'package:appengine/appengine.dart';
@@ -11,7 +10,6 @@ import 'package:gcloud/db.dart' as db;
 import 'package:logging/logging.dart';
 
 import 'package:pub_dartlang_org/shared/analyzer_memcache.dart';
-import 'package:pub_dartlang_org/shared/configuration.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
 import 'package:pub_dartlang_org/shared/task_scheduler.dart';
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
@@ -27,9 +25,8 @@ Future main() async {
   useLoggingPackageAdaptor();
 
   withAppEngineServices(() async {
-    _initFlutterSdk().then((_) async {
-      startIsolates(logger, _runSchedulerWrapper);
-    });
+    initFlutterSdk(logger)
+        .then((_) => startIsolates(logger, _runSchedulerWrapper));
     _registerServices();
     await runHandler(logger, analyzerServiceHandler);
   });
@@ -59,29 +56,6 @@ void _runScheduler(List<SendPort> sendPorts) {
     });
     await scheduler.run();
   });
-}
-
-Future _initFlutterSdk() async {
-  if (envConfig.flutterSdkDir == null) {
-    logger.warning('FLUTTER_SDK is not set, assuming flutter is in PATH.');
-  } else {
-    // If the script exists, it is very likely that we are inside the appengine.
-    // In local development environment the setup should happen only once, and
-    // running the setup script multiple times should be safe (no-op if
-    // FLUTTER_SDK directory exists).
-    if (FileSystemEntity.isFileSync('/project/app/script/setup-flutter.sh')) {
-      logger.warning('Setting up flutter checkout. This may take some time.');
-      final ProcessResult result =
-          await Process.run('/project/app/script/setup-flutter.sh', []);
-      if (result.exitCode != 0) {
-        logger.shout(
-            'Failed to checkout flutter (exited with ${result.exitCode})\n'
-            'stdout: ${result.stdout}\nstderr: ${result.stderr}');
-      } else {
-        logger.info('Flutter checkout completed.');
-      }
-    }
-  }
 }
 
 void _registerServices() {

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -21,7 +21,8 @@ Future main() async {
   useLoggingPackageAdaptor();
 
   withAppEngineServices(() async {
-    await startIsolates(logger, _runSchedulerWrapper);
+    initFlutterSdk(logger)
+        .then((_) => startIsolates(logger, _runSchedulerWrapper));
     _registerServices();
     await runHandler(logger, dartdocServiceHandler);
   });

--- a/dartdoc.yaml
+++ b/dartdoc.yaml
@@ -5,6 +5,9 @@
 runtime: custom
 env: flex
 service: dartdoc
+env_variables:
+  # Needs to be in sync with app/script/setup-flutter.sh and with lib/shared/configuration.dart
+  FLUTTER_SDK: '/flutter'
 
 resources:
   cpu: 1
@@ -14,8 +17,8 @@ resources:
 #  instances: 1
 
 automatic_scaling:
-  min_num_instances: 1
-  max_num_instances: 2
+  min_num_instances: 2
+  max_num_instances: 4
 
 skip_files:
 - ^\.git/.*$


### PR DESCRIPTION
AFAICT flutter is not needed for running dartdoc, but it seems to help if it is present (or at least it seems it would if/when https://github.com/dart-lang/dartdoc/issues/1431 gets closed).