### PR TITLE
Platform + classification reason override in AnalyzerClient

### DIFF
--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -170,7 +170,13 @@ class AnalysisView {
       if (data != null &&
           data.analysisStatus != AnalysisStatus.aborted &&
           data.analysisContent != null) {
-        summary = new Summary.fromJson(data.analysisContent);
+        Map jsonSource = data.analysisContent;
+        if (packagePlatformOverrides.containsKey(data.packageName)) {
+          jsonSource = new Map.from(data.analysisContent);
+          jsonSource['platform'] =
+              packagePlatformOverrides[data.packageName].toJson();
+        }
+        summary = new Summary.fromJson(jsonSource);
       }
     } catch (e, st) {
       // don't block on faulty serialization

--- a/app/lib/shared/platform.dart
+++ b/app/lib/shared/platform.dart
@@ -13,6 +13,16 @@ abstract class KnownPlatforms {
   static bool isKnownPlatform(String platform) => all.contains(platform);
 }
 
+final _whitelistedOverride = 'Whitelisted platform override.';
+
+final packagePlatformOverrides = <String, DartPlatform>{
+  // categorized as "flutter, other", override to "web"
+  'dart_to_js_script_rewriter': new DartPlatform.fromComponents(
+    [ComponentNames.html],
+    reason: _whitelistedOverride,
+  ),
+};
+
 List<String> indexDartPlatform(DartPlatform platform) {
   if (platform == null || platform.uses == null || platform.hasConflict) {
     return null;


### PR DESCRIPTION
Closes #598.

An alternative would be to override the platform in either `pana`, at the time we are storing the results, or at the time the `analyzer` service serves it, but neither of that feels right.

Because we display the classification reason on the analysis tab, overriding it in the `List<String> get platform` field is not enough, hence the override in the JSON, just before parsing it to `Summary`.