### PR TITLE
Introducing the deprecated flag on the backend.

### DIFF
--- a/app/bin/tools/deprecate.dart
+++ b/app/bin/tools/deprecate.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:appengine/appengine.dart';
+import 'package:gcloud/db.dart';
+
+import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/frontend/service_utils.dart';
+import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/package_memcache.dart';
+
+void _printUsage() {
+  print('Usage:');
+  print('    ${Platform.script} read  <package>');
+  print('    ${Platform.script} set   <package>');
+  print('    ${Platform.script} clear <package>');
+}
+
+Future main(List<String> arguments) async {
+  if (arguments.length != 2) {
+    _printUsage();
+    exit(1);
+  }
+
+  final String command = arguments[0];
+  final String package = arguments[1];
+
+  await withProdServices(() async {
+    if (command == 'read') {
+      await _read(package);
+    } else if (command == 'set') {
+      await _set(package, true);
+      await _clearCaches(package);
+    } else if (command == 'clear') {
+      await _set(package, false);
+      await _clearCaches(package);
+    } else {
+      _printUsage();
+      exit(1);
+    }
+    // TODO: figure out why the services do not exit.
+    exit(0);
+  });
+}
+
+Future _read(String packageName) async {
+  final Package p = (await dbService
+          .lookup([dbService.emptyKey.append(Package, id: packageName)]))
+      .single;
+  if (p == null) {
+    throw new Exception('Package $packageName does not exist.');
+  }
+  final isDeprecated = p.isDeprecated ?? false;
+  final label = isDeprecated ? 'deprecated' : '-';
+  print('Package $packageName: $label');
+}
+
+Future _set(String packageName, bool value) {
+  return dbService.withTransaction((Transaction tx) async {
+    final Package p =
+        (await tx.lookup([dbService.emptyKey.append(Package, id: packageName)]))
+            .single;
+    if (p == null) {
+      throw new Exception('Package $packageName does not exist.');
+    }
+    p.isDeprecated = value;
+    tx.queueMutations(inserts: [p]);
+    await tx.commit();
+    print('Package $packageName: isDeprecated=$value');
+    await new AnalyzerClient()
+        .triggerAnalysis(packageName, p.latestVersion, new Set());
+  });
+}
+
+Future _clearCaches(String packageName) async {
+  final pkgCache = new AppEnginePackageMemcache(memcacheService);
+  await pkgCache.invalidateUIPackagePage(packageName);
+  await pkgCache.invalidatePackageData(packageName);
+}

--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -347,6 +347,7 @@ class AnalysisBackend {
       exists: true,
       publishDate: pv.created,
       isLatestStable: p.latestVersion == version,
+      isDeprecated: p.isDeprecated ?? false,
     );
   }
 }
@@ -355,8 +356,14 @@ class PackageStatus {
   final bool exists;
   final DateTime publishDate;
   final bool isLatestStable;
+  final bool isDeprecated;
 
-  PackageStatus({this.exists, this.publishDate, this.isLatestStable: false});
+  PackageStatus({
+    this.exists,
+    this.publishDate,
+    this.isLatestStable: false,
+    this.isDeprecated: false,
+  });
 }
 
 class BackendAnalysisStatus {

--- a/app/lib/analyzer/model_properties.dart
+++ b/app/lib/analyzer/model_properties.dart
@@ -25,6 +25,8 @@ class AnalysisStatusProperty extends StringProperty {
           return 'failure';
         case AnalysisStatus.success:
           return 'success';
+        case AnalysisStatus.deprecated:
+          return 'deprecated';
         case AnalysisStatus.outdated:
           return 'outdated';
         default:
@@ -45,6 +47,8 @@ class AnalysisStatusProperty extends StringProperty {
           return AnalysisStatus.failure;
         case 'success':
           return AnalysisStatus.success;
+        case 'deprecated':
+          return AnalysisStatus.deprecated;
         case 'outdated':
           return AnalysisStatus.outdated;
         default:

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -53,6 +53,14 @@ class PanaRunner implements TaskRunner {
     final Analysis analysis =
         new Analysis.init(task.package, task.version, timestamp);
 
+    if (packageStatus.isDeprecated) {
+      _logger.info('Package is deprecated: $task.');
+      analysis.analysisStatus = AnalysisStatus.deprecated;
+      analysis.maintenanceScore = 0.0;
+      final backendStatus = await _analysisBackend.storeAnalysis(analysis);
+      return backendStatus.wasRace;
+    }
+
     final Duration age = timestamp.difference(packageStatus.publishDate).abs();
     if (age > twoYears && !packageStatus.isLatestStable) {
       _logger.info(

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -49,6 +49,9 @@ class Package extends db.ExpandoModel {
   @CompatibleStringListProperty()
   List<String> uploaderEmails;
 
+  @db.BoolProperty()
+  bool isDeprecated;
+
   // Convenience Fields:
 
   String get latestVersion => latestVersionKey.id;

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -91,6 +91,7 @@ class SearchBackend {
         created: p.created,
         updated: pv.created,
         readme: compactReadme(pv.readmeContent),
+        isDeprecated: p.isDeprecated ?? false,
         health: analysisView.health,
         popularity: popularity,
         maintenance: analysisView.maintenanceScore,

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -55,7 +55,9 @@ class BatchIndexUpdater implements TaskRunner {
         final int count = _snapshot.documents.length;
         _logger
             .info('Got $count packages from snapshot at ${_snapshot.updated}');
-        await packageIndex.addPackages(_snapshot.documents.values);
+        await packageIndex.addPackages(_snapshot.documents.values.where(
+          (pd) => pd.isDeprecated != true, // isDeprecated may be null
+        ));
         // Arbitrary sanity check that the snapshot is not entirely bogus.
         // Index merge will enable search.
         if (count > 10) {
@@ -118,8 +120,9 @@ class BatchIndexUpdater implements TaskRunner {
               .loadDocuments(tasks.map((t) => t.package).toList()))
           .where((doc) => doc != null)
           .toList();
+      // TODO: decide if deprecated packages should be removed from the snapshot
       _snapshot.addAll(docs);
-      await packageIndex.addPackages(docs);
+      await packageIndex.addPackages(docs.where((d) => d.isDeprecated != true));
       final bool doMerge =
           _firstScanCount != null && _taskCount >= _firstScanCount;
       if (doMerge) {

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -40,6 +40,9 @@ enum AnalysisStatus {
   /// One or more tools failed to produce the expected output.
   failure,
 
+  /// Analysis was not started, because package is considered deprecated.
+  deprecated,
+
   /// Analysis was not started, because package is considered old and has a
   /// newer stable release.
   outdated,
@@ -56,6 +59,7 @@ int analysisStatusLevel(AnalysisStatus status) {
       return 0;
     case AnalysisStatus.failure:
       return 1;
+    case AnalysisStatus.deprecated:
     case AnalysisStatus.outdated:
     case AnalysisStatus.success:
       return 2;

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -47,6 +47,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
   final DateTime created;
   final DateTime updated;
   final String readme;
+  final bool isDeprecated;
 
   final List<String> platforms;
 
@@ -68,6 +69,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
     this.created,
     this.updated,
     this.readme,
+    this.isDeprecated,
     this.platforms,
     this.health,
     this.popularity,

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -25,6 +25,7 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
             ? null
             : DateTime.parse(json['updated'] as String),
         readme: json['readme'] as String,
+        isDeprecated: json['isDeprecated'] as bool,
         platforms:
             (json['platforms'] as List)?.map((e) => e as String)?.toList(),
         health: (json['health'] as num)?.toDouble(),
@@ -46,6 +47,7 @@ abstract class _$PackageDocumentSerializerMixin {
   DateTime get created;
   DateTime get updated;
   String get readme;
+  bool get isDeprecated;
   List<String> get platforms;
   double get health;
   double get popularity;
@@ -61,6 +63,7 @@ abstract class _$PackageDocumentSerializerMixin {
         'created': created?.toIso8601String(),
         'updated': updated?.toIso8601String(),
         'readme': readme,
+        'isDeprecated': isDeprecated,
         'platforms': platforms,
         'health': health,
         'popularity': popularity,

--- a/app/test/frontend/golden/pkg_show_page_deprecated.html
+++ b/app/test/frontend/golden/pkg_show_page_deprecated.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@dart_lang" />
+  <meta property="og:site_name" content="Dart Packages" />
+  <title>foobar_pkg | Dart Package</title>
+  <meta property="og:title" content="foobar_pkg | Dart Package" />
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
+  <meta itemprop="image" content="/static/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/img/dart-logo-400x400.png" />
+  <link rel="shortcut icon" href="/static/favicon.ico" />
+  <meta name="description" content="foobar_pkg 0.1.1 Dart package - my package description" />
+  <meta property="og:description" content="foobar_pkg 0.1.1 Dart package - my package description" />
+  <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
+  <link href="/static/highlight/github.css" rel="stylesheet" />
+  <link href="/static/css/style.css?hash=e04t8j4c9t71h5ha7p4pdkgq33og2ucf" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=1mdhgmfm490300v0h9lp3d23q52dlicd" defer></script>
+  <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-26406144-13', 'auto');
+      ga('send', 'pageview');
+  </script>
+  <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
+</head>
+<body>
+<header class="site-header">
+  <h1 class="_visuallyhidden">Dart pub</h1>
+  <button class="hamburger"></button>
+  <div class="mask"></div>
+  <div class="nav-wrap">
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/img/dart-logo.svg" alt="dart pub logo"></a>
+      <div class="_flex-space"></div>
+      <button class="close"></button>
+    </div>
+    <nav class="site-nav">
+      <span>Getting Started:</span>
+      <div class="sub-wrap hoverable">
+        <button class="button">Flutter</button>
+        <div class="sub-nav">
+          <a class="link" target="_blank" href="https://flutter.io/using-packages/">Using Packages</a>
+          <a class="link" target="_blank" href="https://flutter.io/developing-packages/">Developing Packages and Plugins</a>
+        </div>
+      </div>
+      <div class="sub-wrap hoverable">
+        <button class="button">Web &amp; Server</button>
+        <div class="sub-nav">
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/get-started">Using Packages</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub/publishing">Publishing a Package</a>
+          <a class="link" target="_blank" href="https://www.dartlang.org/tools/pub">Overview</a>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>
+
+  <div class="_banner-bg">
+    <main class="package-banner">
+      <form class="search-bar" action="/packages">
+        <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus />
+        <button class="icon"></button>
+      </form>
+    </main>
+  </div>
+
+
+
+<main>
+  
+<div class="package-header">
+  <h2 class="title">foobar_pkg 0.1.1</h2>
+  <div class="metadata">
+    Published <span>Jan 1, 2014</span>
+    <!-- &bull; Downloads: X -->
+    <div class="tags">    <span class="package-tag unidentified" title="Package was deprecated.">[deprecated]</span>
+</div>
+  </div>
+</div>
+
+<div class="package-container">
+  <div class="main tabs-content">
+    <ul class="package-tabs js-tabs">
+        <li class="tab -active" data-name="-readme-tab-">README.md</li>
+        <li class="tab " data-name="-changelog-tab-">CHANGELOG.md</li>
+        <li class="tab " data-name="-example-tab-">Example</li>
+      <li class="tab " data-name="-installing-tab-">Installing</li>
+      <li class="tab" data-name="-versions-tab-">Versions</li>
+      <li class="tab" data-name="-analysis-tab-">
+        <div class="score-box"><span class="number -missing" title="No analysis for this version.">--</span></div>
+      </li>
+    </ul>
+      <section class="content -active js-content markdown-body" data-name="-readme-tab-">
+        <h1 id="test-package">Test Package</h1>
+<p>This is a readme file.</p>
+<pre><code class="language-dart">void main() {
+}
+</code></pre>
+
+      </section>
+      <section class="content  js-content markdown-body" data-name="-changelog-tab-">
+        <h1 id="changelog">Changelog</h1>
+<p>0.1.1 - test package</p>
+
+      </section>
+      <section class="content  js-content markdown-body" data-name="-example-tab-">
+        <p style="font-family: monospace"><b>example&#47;lib&#47;main.dart</b></p>
+<pre><code class="language-dart">main() {
+  print('Hello world!');
+}
+</code></pre>
+
+      </section>
+    <section class="content  js-content markdown-body" data-name="-installing-tab-">
+      <h3>1. Depend on it</h3>
+      <p>Add this to your package's pubspec.yaml file:</p>
+      <pre><code class="language-yaml">
+dependencies:
+  <strong>foobar_pkg: &quot;^0.1.1&quot;</strong>
+
+</code></pre>
+      <h3>2. Install it</h3>
+      <p>You can install packages from the command line:</p>
+        <p>with pub:</p>
+  <pre><code class="language-shell">
+$ <strong>pub get</strong>
+
+</code></pre>
+<p>Alternatively, your editor might support <code>pub get</code>.
+  Check the docs for your editor to learn more.</p>
+
+        <h3>3. Import it</h3>
+        <p>Now in your Dart code, you can use:
+        </p>
+        <pre><code class="language-dart">
+import 'package:foobar_pkg/foolib.dart';
+        </code></pre>
+    </section>
+    <section class="content js-content markdown-body" data-name="-versions-tab-">
+      <table class="version-table">
+        <thead>
+        <tr>
+          <th>Version</th>
+          <th>Uploaded</th>
+          <th class="documentation" width="60">Documentation</th>
+          <th class="archive" width="60">Archive</th>
+        </tr>
+        </thead>
+        
+<tr>
+  <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
+  <td>Jan 1, 2014</td>
+  <td class="documentation">
+    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
+       title="Go to the documentation of foobar_pkg 0.1.1">
+      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
+    </a>
+  </td>
+  <td class="archive">
+    <a href="http://dart-example.com/"
+       title="Download foobar_pkg 0.1.1 archive">
+      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1 archive" />
+    </a>
+  </td>
+</tr>
+
+      </table>
+    </section>
+    <section class="content js-content markdown-body" data-name="-analysis-tab-">
+      <h2>Analysis</h2>
+
+<div class="analysis-disclaimer">
+  This feature is new. <br/>
+  We welcome <a class='github_issue' data-bug-tag='analysis' href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">feedback</a>. <br/>
+  More details: <a href="/help#scoring">scoring</a>.
+</div>
+
+<p>This package is not analyzed, because it is deprecated.</p>
+
+    </section>
+  </div>
+
+  <aside class="sidebar sidebar-content">
+      <h3 class="title">About</h3>
+      <p>my package description</p>
+
+    <h3 class="title">Author</h3>
+    <div><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> Hans Juergen</span></div>
+
+      <h3 class="title">Homepage</h3>
+      <a class="link" href="http://hans.juergen.com">hans.juergen.com</a>
+
+      <h3 class="title">Documentation</h3>
+      <a class="link" href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+
+    <h3 class="title">Uploader</h3>
+    <p><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> hans@juergen.com</span></p>
+
+
+
+    <h3 class="title">More</h3>
+    <p><a href="/packages?q=dependency%3Afoobar_pkg" rel="nofollow">Packages that depend on foobar_pkg</a></p>
+  </aside>
+</div>
+
+<script type="application/ld+json">
+{"@context":"http://schema.org","@type":"SoftwareSourceCode","name":"foobar_pkg","version":"0.1.1","description":"foobar_pkg - my package description","url":"https://pub.dartlang.org/packages/foobar_pkg","dateCreated":"2014-01-01T00:00:00.000Z","dateModified":"2014-01-01T00:00:00.000Z","programmingLanguage":"Dart","image":"https://pub.dartlang.org/static/img/dart-logo-400x400.png"}
+</script>
+
+</main>
+
+<footer class="site-footer">
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+  <a class="link" href="/help">Help</a>
+  <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
+</footer>
+<script src="/static/highlight/highlight.pack.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+</body>
+</html>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -195,6 +195,25 @@ void main() {
       expectGoldenFile(html, 'pkg_show_page_outdated.html');
     });
 
+    test('package show page with deprecated version', () {
+      final String html = templates.renderPkgShowPage(
+          deprecatedPackage,
+          false,
+          [testPackageVersion],
+          [Uri.parse('http://dart-example.com/')],
+          testPackageVersion,
+          testPackageVersion,
+          testPackageVersion,
+          1,
+          new AnalysisExtract(analysisStatus: AnalysisStatus.deprecated),
+          new MockAnalysisView(
+            analysisStatus: AnalysisStatus.deprecated,
+            timestamp: new DateTime(2018, 02, 05),
+          ));
+
+      expectGoldenFile(html, 'pkg_show_page_deprecated.html');
+    });
+
     test('no content for analysis tab', () async {
       // no content
       expect(templates.renderAnalysisTab('pkg_foo', null, null, null), isNull);

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -33,7 +33,7 @@ final Key devPackageVersionKey =
 
 final Pubspec testPubspec = new Pubspec.fromYaml(TestPackagePubspec);
 
-final Package testPackage = new Package()
+Package _createPackage() => new Package()
   ..parentKey = testPackageKey.parent
   ..id = testPackageKey.id
   ..name = testPackageKey.id
@@ -42,6 +42,10 @@ final Package testPackage = new Package()
   ..uploaderEmails = ['hans@juergen.com']
   ..latestVersionKey = testPackageVersionKey
   ..latestDevVersionKey = testPackageVersionKey;
+
+final Package testPackage = _createPackage();
+
+final Package deprecatedPackage = _createPackage()..isDeprecated = true;
 
 final PackageVersion testPackageVersion = new PackageVersion()
   ..parentKey = testPackageVersionKey.parent

--- a/app/views/pkg/analysis_tab.mustache
+++ b/app/views/pkg/analysis_tab.mustache
@@ -9,13 +9,16 @@
   More details: <a href="/help#scoring">scoring</a>.
 </div>
 
+{{#show_deprecated}}
+<p>This package is not analyzed, because it is deprecated.</p>
+{{/show_deprecated}}
 {{#show_outdated}}
 <p>
   This package version is not analyzed, because it is more than two years old.
   Check the <a href="/packages/{{{package}}}#-analysis-tab-">latest stable version</a> for its analysis.
 </p>
 {{/show_outdated}}
-{{^show_outdated}}
+{{#show_analysis}}
 <p>
   We analyzed this package on {{date_completed}}, and provided a score, details, and suggestions below.
   Analysis was completed with status <i>{{analysis_status}}</i> using:
@@ -141,4 +144,4 @@
 </table>
 </div>
 {{/has_dependency}}
-{{/show_outdated}}
+{{/show_analysis}}


### PR DESCRIPTION
#289.

- tool to get/set/clear the flag in the DataStore
- `search` skips adding it to the index when the flag is set
- `analyzer` skips analysis if the flag is set
- package tag and score is updated to handle the status

Disclaimer: I haven't tested it on staging yet.