### PR TITLE
Dartdoc backend implementation on Bucket and files.

### DIFF
--- a/app/build.yaml
+++ b/app/build.yaml
@@ -3,6 +3,7 @@
 targets:
   pub_dartlang_org:
     sources:
+      - 'lib/dartdoc/models.dart'
       - 'lib/shared/*.dart'
       - 'lib/search/backend*.dart'
     builders:

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -10,7 +10,14 @@ import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:pub_dartlang_org/shared/task_scheduler.dart' show Task;
+
+import 'models.dart';
+
 final Logger _logger = new Logger('pub.dartdoc.backend');
+
+final Duration _entryUpdateThreshold = const Duration(days: 30);
+final Duration _contentDeleteThreshold = const Duration(days: 1);
 
 /// Sets the dartdoc backend.
 void registerDartdocBackend(DartdocBackend backend) =>
@@ -25,7 +32,12 @@ class DartdocBackend {
   DartdocBackend(this._storage);
 
   /// Uploads a directory to the storage bucket.
-  Future uploadDir(String dirPath, String objectPrefix) async {
+  Future uploadDir(DartdocEntry entry, String dirPath) async {
+    // upload is in progress
+    await _storage.writeBytes(entry.inProgressPath, entry.asBytes());
+
+    // upload all files
+    final objectPrefix = entry.contentPrefix;
     final dir = new Directory(dirPath);
     final Stream<File> fileStream = dir
         .list(recursive: true)
@@ -44,8 +56,106 @@ class DartdocBackend {
         rethrow;
       }
     }
+
+    // upload was completed
+    await _storage.writeBytes(entry.entryPath, entry.asBytes());
+
+    // there is a small chance that the process is interrupted before this gets
+    // deleted, but the [removeObsolete] should be able to validate it.
+    await _storage.delete(entry.inProgressPath);
+  }
+
+  Future<bool> shouldRunTask(Task task, String dartdocVersion) async {
+    final entry = await getLatestEntry(task.package, task.version);
+    if (entry == null) {
+      return true;
+    }
+    if (entry.dartdocVersion != dartdocVersion) {
+      return true;
+    }
+    if (task.updated != null && task.updated.isAfter(entry.timestamp)) {
+      return true;
+    }
+    final age = new DateTime.now().difference(entry.timestamp).abs();
+    if (age > _entryUpdateThreshold) {
+      return true;
+    }
+    return false;
+  }
+
+  /// Return the latest entry that should be used to serve the content.
+  Future<DartdocEntry> getLatestEntry(String package, String version) async {
+    final List<DartdocEntry> completedList =
+        await _listEntries(DartdocEntryPaths.entryPrefix(package, version));
+    if (completedList.isEmpty) return null;
+    completedList.sort((a, b) => -a.timestamp.compareTo(b.timestamp));
+    return completedList.first;
   }
 
   /// Returns a file's content from the storage bucket.
-  Stream<List<int>> read(String objectName) => _storage.read(objectName);
+  Stream<List<int>> readContent(DartdocEntry entry, String relativePath) {
+    final objectName = p.join(entry.contentPrefix, relativePath);
+    return _storage.read(objectName);
+  }
+
+  /// Removes incomplete uploads and old outputs from the bucket.
+  Future removeObsolete(String package, String version) async {
+    final List<DartdocEntry> completedList =
+        await _listEntries(DartdocEntryPaths.entryPrefix(package, version));
+    final List<DartdocEntry> inProgressList = await _listEntries(
+        DartdocEntryPaths.inProgressPrefix(package, version));
+
+    for (var entry in inProgressList) {
+      if (completedList.any((e) => e.uuid == entry.uuid)) {
+        // upload was interrupted between setting the final entry and removing
+        // the in-progress indicator. Doing the later now.
+        await _storage.delete(entry.inProgressPath);
+      } else {
+        final age = new DateTime.now().difference(entry.timestamp).abs();
+        if (age > _contentDeleteThreshold) {
+          await _deleteAll(entry);
+          await _storage.delete(entry.inProgressPath);
+        }
+      }
+    }
+
+    // delete everything except the latest
+    completedList.sort((a, b) => -a.timestamp.compareTo(b.timestamp));
+    for (var entry in completedList.skip(1)) {
+      final age = new DateTime.now().difference(entry.timestamp).abs();
+      if (age > _contentDeleteThreshold) {
+        await _deleteAll(entry);
+      }
+    }
+  }
+
+  Future<List<DartdocEntry>> _listEntries(String prefix) async {
+    final List<DartdocEntry> list = [];
+    await for (final entry in _storage.list(prefix: prefix)) {
+      if (entry.isDirectory) continue;
+      if (!entry.name.endsWith('.json')) continue;
+
+      try {
+        list.add(await DartdocEntry.fromStream(_storage.read(entry.name)));
+      } catch (e, st) {
+        _logger.warning('Unable to read entry: ${entry.name}.', st);
+      }
+    }
+    return list;
+  }
+
+  Future _deleteAll(DartdocEntry entry) async {
+    var page = await _storage.page(prefix: entry.contentPrefix);
+    for (;;) {
+      for (var item in page.items) {
+        await _storage.delete(item.name);
+      }
+      if (page.isLast) {
+        break;
+      } else {
+        page = await page.next();
+      }
+    }
+    await _storage.delete(entry.entryPath);
+  }
 }

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// ignore_for_file: annotate_overrides
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'models.g.dart';
+
+@JsonSerializable()
+class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
+  final String uuid;
+  final String packageName;
+  final String packageVersion;
+  final String dartdocVersion;
+  final DateTime timestamp;
+  final bool hasContent;
+
+  DartdocEntry({
+    @required this.uuid,
+    @required this.packageName,
+    @required this.packageVersion,
+    @required this.dartdocVersion,
+    @required this.timestamp,
+    @required this.hasContent,
+  });
+
+  factory DartdocEntry.fromJson(Map<String, dynamic> json) =>
+      _$DartdocEntryFromJson(json);
+
+  factory DartdocEntry.fromBytes(List<int> bytes) =>
+      new DartdocEntry.fromJson(JSON.decode(UTF8.decode(bytes)));
+
+  static Future<DartdocEntry> fromStream(Stream<List<int>> stream) async {
+    final bytes = await stream.fold([], (sum, list) => sum..addAll(list));
+    return new DartdocEntry.fromBytes(bytes);
+  }
+
+  /// The path of the status while the upload is in progress
+  String get inProgressPrefix =>
+      DartdocEntryPaths.inProgressPrefix(packageName, packageVersion);
+
+  /// The path of the particular JSON status while upload is in progress
+  String get inProgressPath => '$inProgressPrefix/$uuid.json';
+
+  /// The path prefix where all of the entry JSON files are stored.
+  String get entryPrefix =>
+      DartdocEntryPaths.entryPrefix(packageName, packageVersion);
+
+  /// The path of the particular JSON entry after the upload was completed.
+  String get entryPath => '$entryPrefix/$uuid.json';
+
+  /// The path prefix where the content of this instance is stored.
+  String get contentPrefix => '/$packageName/$packageVersion/content/$uuid';
+
+  List<int> asBytes() => UTF8.encode(JSON.encode(this.toJson()));
+}
+
+abstract class DartdocEntryPaths {
+  static String inProgressPrefix(String packageName, String packageVersion) =>
+      '/$packageName/$packageVersion/in-progress';
+
+  static String entryPrefix(String packageName, String packageVersion) =>
+      '/$packageName/$packageVersion/entry';
+}

--- a/app/lib/dartdoc/models.g.dart
+++ b/app/lib/dartdoc/models.g.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2017, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: prefer_final_locals
+
+part of 'models.dart';
+
+// **************************************************************************
+// Generator: JsonSerializableGenerator
+// **************************************************************************
+
+DartdocEntry _$DartdocEntryFromJson(Map<String, dynamic> json) =>
+    new DartdocEntry(
+        uuid: json['uuid'] as String,
+        packageName: json['packageName'] as String,
+        packageVersion: json['packageVersion'] as String,
+        dartdocVersion: json['dartdocVersion'] as String,
+        timestamp: json['timestamp'] == null
+            ? null
+            : DateTime.parse(json['timestamp'] as String),
+        hasContent: json['hasContent'] as bool);
+
+abstract class _$DartdocEntrySerializerMixin {
+  String get uuid;
+  String get packageName;
+  String get packageVersion;
+  String get dartdocVersion;
+  DateTime get timestamp;
+  bool get hasContent;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'uuid': uuid,
+        'packageName': packageName,
+        'packageVersion': packageVersion,
+        'dartdocVersion': dartdocVersion,
+        'timestamp': timestamp?.toIso8601String(),
+        'hasContent': hasContent
+      };
+}


### PR DESCRIPTION
The main idea here is that we can store and serve the generated files without going to Datastore, working only on files in a bucket.

- Each dartdoc run is associated with an uuid.
- `/$pkg/$version/content/$uuid/` will contain the generated files.
- `/$pkg/$version/in-progress/$uuid.json` indicates that an upload is in progress (or aborted)
- `/$pkg/$version/entry/$uuid.json` indicates a successful upload.
- The `../entry/` and the `.../in-progress/` are organized in a separate directories, in order to make their listing fast.

I'm planning to add memcache for the `entry/` listing, the uuids and the content serving too.

The alternative would be to introduce a similar hierarchy than we have in `PackageAnalysis`, `PackageVersionAnalysis` and `Analysis`, but thinking about it more, we could simplify that model using files like here. Both system could rely on the bucket to delete old entries automatically, sparing some worry about GC-ing orphaned entries.