### PR TITLE
Prepare dartdoc task sources.

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -48,8 +48,8 @@ void _runScheduler(List<SendPort> sendPorts) {
     final PanaRunner runner = new PanaRunner(analysisBackend);
     final scheduler = new TaskScheduler(runner, [
       new ManualTriggerTaskSource(taskReceivePort),
-      new DatastoreHeadTaskSource(db.dbService),
-      new DatastoreHistoryTaskSource(db.dbService),
+      new AnalyzerDatastoreHeadTaskSource(db.dbService),
+      new AnalyzerDatastoreHistoryTaskSource(db.dbService),
     ]);
     new Timer.periodic(const Duration(minutes: 1), (_) {
       statsSendPort.send(scheduler.stats());

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -6,17 +6,19 @@ import 'dart:async';
 import 'dart:isolate';
 
 import 'package:appengine/appengine.dart';
+import 'package:gcloud/db.dart';
 import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 
 import 'package:pub_dartlang_org/shared/configuration.dart';
+import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
 import 'package:pub_dartlang_org/shared/task_scheduler.dart';
-import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/dartdoc/dartdoc_runner.dart';
 import 'package:pub_dartlang_org/dartdoc/handlers.dart';
+import 'package:pub_dartlang_org/dartdoc/task_sources.dart';
 
 final Logger logger = new Logger('pub.dartdoc');
 
@@ -47,9 +49,8 @@ void _runScheduler(List<SendPort> sendPorts) {
     final runner = new DartdocRunner();
     final scheduler = new TaskScheduler(runner, [
       new ManualTriggerTaskSource(taskReceivePort),
-      // TODO: decide how frequently we want to poll the datastore
-      // new DatastoreHeadTaskSource(db.dbService),
-      // new DatastoreHistoryTaskSource(db.dbService),
+      new DartdocDatastoreHeadTaskSource(dbService),
+      new DartdocDatastoreHistoryTaskSource(dbService),
     ]);
     new Timer.periodic(const Duration(minutes: 1), (_) {
       statsSendPort.send(scheduler.stats());

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -81,7 +81,7 @@ void _main(int isolateId) {
       [
         new ManualTriggerTaskSource(taskReceivePort),
         new IndexUpdateTaskSource(db.dbService, batchIndexUpdater),
-        new DatastoreVersionsHeadTaskSource(
+        new DatastoreHeadTaskSource(
           db.dbService,
           TaskSourceModel.analysis,
           sleep: const Duration(minutes: 10),

--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -5,24 +5,19 @@
 import 'dart:async';
 
 import 'package:gcloud/db.dart';
-import 'package:logging/logging.dart';
 
-import '../frontend/models.dart';
 import '../shared/analyzer_service.dart' show AnalysisStatus;
 import '../shared/task_scheduler.dart';
 import '../shared/task_sources.dart';
-import '../shared/utils.dart';
 
 import 'models.dart';
 import 'versions.dart';
 
-final Logger _logger = new Logger('pub.analyzer.source');
-
 /// Creates a task when a version uploaded in the past 10 minutes has no
 /// analysis yet.
-class DatastoreHeadTaskSource extends DatastoreVersionsHeadTaskSource {
+class AnalyzerDatastoreHeadTaskSource extends DatastoreHeadTaskSource {
   final DatastoreDB _db;
-  DatastoreHeadTaskSource(DatastoreDB db)
+  AnalyzerDatastoreHeadTaskSource(DatastoreDB db)
       : _db = db,
         super(db, TaskSourceModel.version, skipHistory: true);
 
@@ -37,55 +32,16 @@ class DatastoreHeadTaskSource extends DatastoreVersionsHeadTaskSource {
   }
 }
 
-/// Creates a task when the most recent analysis is older than [afterDays] days.
-///
-/// When [analysisVersion] is set, it also checks whether the current one is
-/// newer and creates a task if needed.
-class DatastoreHistoryTaskSource implements TaskSource {
+/// Creates a task when the most recent analysis is older than 30 days.
+class AnalyzerDatastoreHistoryTaskSource extends DatastoreHistoryTaskSource {
   final DatastoreDB _db;
-  final int afterDays;
 
-  DatastoreHistoryTaskSource(
-    this._db, {
-    this.afterDays: 30,
-  });
+  AnalyzerDatastoreHistoryTaskSource(DatastoreDB db)
+      : _db = db,
+        super(db, afterDays: 30);
 
   @override
-  Stream<Task> startStreaming() => randomizeStream(_startStreaming());
-
-  Stream<Task> _startStreaming() async* {
-    for (;;) {
-      try {
-        // Check and schedule the latest stable version of each package.
-        final Query packageQuery = _db.query(Package)..order('-updated');
-        await for (Package p in packageQuery.run()) {
-          if (await _requiresUpdate(p.name, p.latestVersion,
-              retryFailed: true)) {
-            yield new Task(p.name, p.latestVersion, p.updated);
-          }
-
-          if (p.latestVersion != p.latestDevVersion &&
-              await _requiresUpdate(p.name, p.latestDevVersion)) {
-            yield new Task(p.name, p.latestDevVersion, p.updated);
-          }
-        }
-
-        // After we are done with the most important versions, let's check all
-        // of the older versions too.
-        final Query versionQuery = _db.query(PackageVersion)..order('-created');
-        await for (PackageVersion pv in versionQuery.run()) {
-          if (await _requiresUpdate(pv.package, pv.version)) {
-            yield new Task(pv.package, pv.version, pv.created);
-          }
-        }
-      } catch (e, st) {
-        _logger.severe('Error polling history.', e, st);
-      }
-      await new Future.delayed(const Duration(days: 1));
-    }
-  }
-
-  Future<bool> _requiresUpdate(String packageName, String packageVersion,
+  Future<bool> requiresUpdate(String packageName, String packageVersion,
       {bool retryFailed: false}) async {
     final List<PackageVersionAnalysis> list = await _db.lookup([
       _db.emptyKey

--- a/app/lib/dartdoc/task_sources.dart
+++ b/app/lib/dartdoc/task_sources.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcloud/db.dart';
+
+import '../shared/task_scheduler.dart';
+import '../shared/task_sources.dart';
+
+/// Creates a task when a version uploaded in the past 10 minutes has no
+/// dartdoc yet.
+class DartdocDatastoreHeadTaskSource extends DatastoreHeadTaskSource {
+  DartdocDatastoreHeadTaskSource(DatastoreDB db)
+      : super(db, TaskSourceModel.version, skipHistory: true);
+
+  @override
+  Future<bool> shouldYieldTask(Task task) async {
+    // TODO: implement using the bucket-based backend.
+    return false;
+  }
+}
+
+/// Creates a task when the most recent dartdoc run is older than 30 days.
+class DartdocDatastoreHistoryTaskSource extends DatastoreHistoryTaskSource {
+  DartdocDatastoreHistoryTaskSource(DatastoreDB db) : super(db, afterDays: 30);
+
+  @override
+  Future<bool> requiresUpdate(String packageName, String packageVersion,
+      {bool retryFailed: false}) async {
+    // TODO: implement using the bucket-based backend.
+    return false;
+  }
+}

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -16,7 +16,7 @@ import 'index_simple.dart';
 
 final Logger _logger = new Logger('pub.search.updater');
 
-class IndexUpdateTaskSource extends DatastoreVersionsHeadTaskSource {
+class IndexUpdateTaskSource extends DatastoreHeadTaskSource {
   final BatchIndexUpdater _batchIndexUpdater;
   IndexUpdateTaskSource(DatastoreDB db, this._batchIndexUpdater)
       : super(db, TaskSourceModel.package, sleep: const Duration(minutes: 30));


### PR DESCRIPTION
- Moved some common code to `shared`.
- The selection of the tasks depends on the backend (blocked on https://github.com/dart-lang/pub-dartlang-dart/pull/980)