### PR TITLE
Fix deprecated handling: do not remove entirely from the index.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -195,13 +195,16 @@ class SimplePackageIndex implements PackageIndex {
         results = _rankWithComparator(packages, _compareUpdated);
         break;
       case SearchOrder.popularity:
-        results = _rankWithValues(getPopularityScore(packages));
+        results = _rankWithValues(getPopularityScore(packages),
+            deprecatedRank: _DeprecatedRank.keep);
         break;
       case SearchOrder.health:
-        results = _rankWithValues(getHealthScore(packages));
+        results = _rankWithValues(getHealthScore(packages),
+            deprecatedRank: _DeprecatedRank.remove);
         break;
       case SearchOrder.maintenance:
-        results = _rankWithValues(getMaintenanceScore(packages));
+        results = _rankWithValues(getMaintenanceScore(packages),
+            deprecatedRank: _DeprecatedRank.remove);
         break;
     }
 
@@ -321,12 +324,28 @@ class SimplePackageIndex implements PackageIndex {
     return null;
   }
 
-  List<PackageScore> _rankWithValues(Map<String, double> values) {
+  List<PackageScore> _rankWithValues(Map<String, double> values,
+      {_DeprecatedRank deprecatedRank: _DeprecatedRank.back}) {
     final List<PackageScore> list = values.keys
-        .map((package) => new PackageScore(
-              package: _packages[package].package,
-              score: values[package],
-            ))
+        .map((package) {
+          final doc = _packages[package];
+          double score = values[package];
+          // isDeprecated may be null
+          if (doc.isDeprecated == true) {
+            switch (deprecatedRank) {
+              case _DeprecatedRank.keep:
+                // keeps score
+                break;
+              case _DeprecatedRank.back:
+                score -= 100.0;
+                break;
+              case _DeprecatedRank.remove:
+                return null;
+            }
+          }
+          return new PackageScore(package: package, score: score);
+        })
+        .where((ps) => ps != null)
         .toList();
     list.sort((a, b) {
       final int scoreCompare = -a.score.compareTo(b.score);
@@ -617,3 +636,14 @@ Set<String> _tokenize(String originalText, int minLength) {
 }
 
 bool _isLower(String c) => c.toLowerCase() == c;
+
+enum _DeprecatedRank {
+  /// Keep original score.
+  keep,
+
+  /// Remove deprecated package from the results.
+  remove,
+
+  /// Move deprecated package to the back.
+  back,
+}

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -55,9 +55,7 @@ class BatchIndexUpdater implements TaskRunner {
         final int count = _snapshot.documents.length;
         _logger
             .info('Got $count packages from snapshot at ${_snapshot.updated}');
-        await packageIndex.addPackages(_snapshot.documents.values.where(
-          (pd) => pd.isDeprecated != true, // isDeprecated may be null
-        ));
+        await packageIndex.addPackages(_snapshot.documents.values);
         // Arbitrary sanity check that the snapshot is not entirely bogus.
         // Index merge will enable search.
         if (count > 10) {
@@ -120,9 +118,8 @@ class BatchIndexUpdater implements TaskRunner {
               .loadDocuments(tasks.map((t) => t.package).toList()))
           .where((doc) => doc != null)
           .toList();
-      // TODO: decide if deprecated packages should be removed from the snapshot
       _snapshot.addAll(docs);
-      await packageIndex.addPackages(docs.where((d) => d.isDeprecated != true));
+      await packageIndex.addPackages(docs);
       final bool doMerge =
           _firstScanCount != null && _taskCount >= _firstScanCount;
       if (doMerge) {

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -91,6 +91,7 @@ class PackageDocument extends Object with _$PackageDocumentSerializerMixin {
       created: created,
       updated: updated,
       readme: readme,
+      isDeprecated: isDeprecated,
       platforms: platforms?.map(internFn)?.toList(),
       health: health,
       popularity: popularity,


### PR DESCRIPTION
I believe removing the package from the index was confusing, especially when the package name is rare, and I know it exists. Introducing three different handling inside the index:

- default ranking (displayed on landing page and platform listings) and text-based ranking will keep the deprecated package, but will list it at the end.
- popularity ranking will keep the package's original popularity and list it along other packages (total score will be a gray `--` though)
- updated and created ranking will keep the package as it was
- health and maintenance ranking will remove it from the results (as both the health and maintenance is considered too bad for displaying it there).

#289