### PR TITLE
Connecting dartdoc components

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -11,6 +11,9 @@ import '../shared/handlers.dart';
 import '../shared/notification.dart';
 import '../shared/scheduler_stats.dart';
 import '../shared/task_client.dart';
+import '../shared/utils.dart' show contentType;
+
+import 'backend.dart';
 
 /// Handlers for the dartdoc service.
 Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
@@ -77,12 +80,14 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
   }
   final String requestMethod = request.method?.toUpperCase();
   if (requestMethod == 'GET') {
-    // placeholder response until proper implementation is done
-    return jsonResponse({
-      'package': docFilePath.package,
-      'version': docFilePath.version,
-      'path': docFilePath.path,
-    });
+    final entry = await dartdocBackend.getLatestEntry(
+        docFilePath.package, docFilePath.version);
+    final stream = dartdocBackend.readContent(entry, docFilePath.path);
+    return new shelf.Response(
+      HttpStatus.OK,
+      body: stream,
+      headers: {HttpHeaders.CONTENT_TYPE: contentType(docFilePath.path)},
+    );
   }
   return notFoundHandler(request);
 }
@@ -96,7 +101,7 @@ class DocFilePath {
 }
 
 DocFilePath parseRequestUri(Uri uri) {
-  final pathSegments = uri.pathSegments;
+  final pathSegments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
   if (pathSegments.length < 3) {
     return null;
   }
@@ -108,9 +113,12 @@ DocFilePath parseRequestUri(Uri uri) {
   if (package.isEmpty || version.isEmpty) {
     return null;
   }
-  String path = '/${pathSegments.skip(3).join('/')}';
-  if (path.endsWith('/')) {
-    path = '${path}index.html';
+  final relativeSegments = pathSegments.skip(3).toList();
+  String path = relativeSegments.join('/');
+  if (path.isEmpty) {
+    path = 'index.html';
+  } else if (path.isNotEmpty && !relativeSegments.last.contains('.')) {
+    path = '$path/index.html';
   }
   return new DocFilePath(package, version, path);
 }

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -56,15 +56,16 @@ class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
   String get entryPath => '$entryPrefix/$uuid.json';
 
   /// The path prefix where the content of this instance is stored.
-  String get contentPrefix => '/$packageName/$packageVersion/content/$uuid';
+  String get contentPrefix => '$packageName/$packageVersion/content/$uuid';
 
   List<int> asBytes() => UTF8.encode(JSON.encode(this.toJson()));
 }
 
+// TODO: use dartdocVersion in the prefix paths
 abstract class DartdocEntryPaths {
   static String inProgressPrefix(String packageName, String packageVersion) =>
-      '/$packageName/$packageVersion/in-progress';
+      '$packageName/$packageVersion/in-progress';
 
   static String entryPrefix(String packageName, String packageVersion) =>
-      '/$packageName/$packageVersion/entry';
+      '$packageName/$packageVersion/entry';
 }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -15,6 +15,8 @@ import 'package:gcloud/storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
+import 'package:mime/src/default_extension_map.dart' as mime;
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart' as semver;
 import 'package:stream_transform/stream_transform.dart';
 
@@ -349,4 +351,10 @@ class StringInternPool {
       _values.clear();
     }
   }
+}
+
+/// Returns the MIME content type based on the name of the file.
+String contentType(String name) {
+  final ext = p.extension(name).replaceAll('.', '');
+  return mime.defaultExtensionMap[ext] ?? 'application/octet-stream';
 }

--- a/app/test/dartdoc/handlers_test.dart
+++ b/app/test/dartdoc/handlers_test.dart
@@ -36,23 +36,23 @@ void main() {
     });
     test('/documentation/angular/4.0.0%2B2', () {
       testUri('/documentation/angular/4.0.0%2B2', 'angular', '4.0.0+2',
-          '/index.html');
+          'index.html');
     });
     test('/documentation/angular/4.0.0%2B2/', () {
       testUri('/documentation/angular/4.0.0%2B2/', 'angular', '4.0.0+2',
-          '/index.html');
+          'index.html');
     });
     test('/documentation/angular/4.0.0%2B2/subdir/', () {
       testUri('/documentation/angular/4.0.0%2B2/subdir/', 'angular', '4.0.0+2',
-          '/subdir/index.html');
+          'subdir/index.html');
     });
     test('/documentation/angular/4.0.0%2B2/file.html', () {
       testUri('/documentation/angular/4.0.0%2B2/file.html', 'angular',
-          '4.0.0+2', '/file.html');
+          '4.0.0+2', 'file.html');
     });
     test('/documentation/angular/4.0.0+2/file.html', () {
       testUri('/documentation/angular/4.0.0%2B2/file.html', 'angular',
-          '4.0.0+2', '/file.html');
+          '4.0.0+2', 'file.html');
     });
   });
 }


### PR DESCRIPTION
Main changes:
- task sources to generate tasks based on the metadata in the bucket
- fixed path issue: bucket objectpath shouldn't start with `/`
- fixed requestUri parsing that started some relative paths with `/`
- added content-type for both the stored entry and on serving the file

Tested this locally, and seems to work, but I'm not satisfied with it:
- even with the concurrent uploads, uploading large packages takes long time
- with a large API surface, we'll generate an upload request per method, which will possibly ramp up storage costs.

In an upcoming PR I'll rewrite the backend to store a .tar.gz of the generated directory and serve content from a local filesystem cache, but I wanted to submit this as this is a working version.