### PR TITLE
Additional context versions for dartdoc entry.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -83,12 +83,12 @@ class DartdocBackend {
     await _storage.delete(entry.inProgressPath);
   }
 
-  Future<bool> shouldRunTask(Task task, String dartdocVersion) async {
+  Future<bool> shouldRunTask(Task task) async {
     final entry = await getLatestEntry(task.package, task.version);
     if (entry == null) {
       return true;
     }
-    if (entry.dartdocVersion != dartdocVersion) {
+    if (entry.requiresNewRun()) {
       return true;
     }
     if (task.updated != null && task.updated.isAfter(entry.timestamp)) {

--- a/app/lib/dartdoc/models.g.dart
+++ b/app/lib/dartdoc/models.g.dart
@@ -17,7 +17,10 @@ DartdocEntry _$DartdocEntryFromJson(Map<String, dynamic> json) =>
         uuid: json['uuid'] as String,
         packageName: json['packageName'] as String,
         packageVersion: json['packageVersion'] as String,
+        usesFlutter: json['usesFlutter'] as bool,
         dartdocVersion: json['dartdocVersion'] as String,
+        flutterVersion: json['flutterVersion'] as String,
+        customizationVersion: json['customizationVersion'] as String,
         timestamp: json['timestamp'] == null
             ? null
             : DateTime.parse(json['timestamp'] as String),
@@ -27,14 +30,20 @@ abstract class _$DartdocEntrySerializerMixin {
   String get uuid;
   String get packageName;
   String get packageVersion;
+  bool get usesFlutter;
   String get dartdocVersion;
+  String get flutterVersion;
+  String get customizationVersion;
   DateTime get timestamp;
   bool get hasContent;
   Map<String, dynamic> toJson() => <String, dynamic>{
         'uuid': uuid,
         'packageName': packageName,
         'packageVersion': packageVersion,
+        'usesFlutter': usesFlutter,
         'dartdocVersion': dartdocVersion,
+        'flutterVersion': flutterVersion,
+        'customizationVersion': customizationVersion,
         'timestamp': timestamp?.toIso8601String(),
         'hasContent': hasContent
       };

--- a/app/lib/dartdoc/task_sources.dart
+++ b/app/lib/dartdoc/task_sources.dart
@@ -39,7 +39,7 @@ class DartdocDatastoreHistoryTaskSource extends DatastoreHistoryTaskSource {
       return true;
     }
 
-    // TODO: trigger task if current dartdoc version is newer
+    if (entry.requiresNewRun()) return true;
 
     final now = new DateTime.now().toUtc();
     final age = now.difference(entry.timestamp).abs();

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -15,3 +15,9 @@ final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 // keep in-sync with SDK version in .travis.yml and Dockerfile
 final String dartdocVersion = '0.16.0';
 final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
+
+/// The version of our customization going into the output of the dartdoc static
+/// HTML files.
+final String customizationVersion = '0.0.1';
+final Version semanticCustomizationVersion =
+    new Version.parse(customizationVersion);


### PR DESCRIPTION
- Consolidated "should we update it" logic in `DartdocEntry.requiresNewRun()`
- Added `usesFlutter` and `flutterVersion` to trigger the re-run of packages when there is a flutter version upgrade (applies only on packages with flutter).
- Added `customizationVersion` to trigger the re-run of the packages when there is an update in our customization code.
