### PR TITLE
Dartdoc customization

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -29,9 +29,22 @@ class DartdocCustomizer {
     final doc = html_parser.parse(html);
     final breadcrumbs = doc.body.querySelector('.breadcrumbs');
     if (breadcrumbs != null) {
+      _addPubSiteLogo(breadcrumbs);
       _addPubPackageLink(breadcrumbs);
     }
     return doc.outerHtml;
+  }
+
+  void _addPubSiteLogo(Element breadcrumbs) {
+    final parent = breadcrumbs.parent;
+    final logoLink = new Element.tag('a');
+    logoLink.attributes['href'] = 'https://pub.dartlang.org/';
+    final imgRef = new Element.tag('img');
+    imgRef.attributes['src'] = 'https://pub.dartlang.org/static/img/dart-logo.svg';
+    imgRef.attributes['style'] = 'height: 30px; margin-right: 1em;';
+    logoLink.append(imgRef);
+    parent.insertBefore(logoLink, breadcrumbs);
+    parent.insertBefore(new Text('\n  '), breadcrumbs);
   }
 
   void _addPubPackageLink(Element breadcrumbs) {

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -5,6 +5,9 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:html/dom.dart';
+import 'package:html/parser.dart' as html_parser;
+
 class DartdocCustomizer {
   final String packageName;
   final String packageVersion;
@@ -23,7 +26,8 @@ class DartdocCustomizer {
   }
 
   String customizeHtml(String html) {
-    return null;
+    final doc = html_parser.parse(html);
+    return doc.outerHtml;
   }
 }
 

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -1,0 +1,29 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+class DartdocCustomizer {
+  final String packageName;
+  final String packageVersion;
+
+  DartdocCustomizer(this.packageName, this.packageVersion);
+
+  Future<bool> customizeFile(File file) async {
+    final String oldContent = await file.readAsString();
+    final String newContent = customizeHtml(oldContent);
+    if (newContent != null && oldContent != newContent) {
+      await file.writeAsString(newContent);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  String customizeHtml(String html) {
+    return null;
+  }
+}
+

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -27,7 +27,35 @@ class DartdocCustomizer {
 
   String customizeHtml(String html) {
     final doc = html_parser.parse(html);
+    final breadcrumbs = doc.body.querySelector('.breadcrumbs');
+    if (breadcrumbs != null) {
+      _addPubPackageLink(breadcrumbs);
+    }
     return doc.outerHtml;
   }
-}
 
+  void _addPubPackageLink(Element breadcrumbs) {
+    final pubPackageLink =
+        'https://pub.dartlang.org/packages/$packageName/versions/$packageVersion';
+    final pubPackageText = '$packageName package';
+    if (breadcrumbs.children.length == 1) {
+      // we are on the index page
+      final firstLink = breadcrumbs.querySelector('a');
+      firstLink.attributes['href'] = pubPackageLink;
+      firstLink.text = pubPackageText;
+    } else if (breadcrumbs.children.isNotEmpty) {
+      // we are inside
+      final firstLink = breadcrumbs.querySelector('a');
+      firstLink.text = 'documentation';
+
+      final lead = new Element.tag('li');
+      final leadLink = new Element.tag('a');
+      leadLink.attributes['href'] = pubPackageLink;
+      leadLink.text = pubPackageText;
+      lead.append(leadLink);
+
+      breadcrumbs.insertBefore(lead, breadcrumbs.firstChild);
+      breadcrumbs.insertBefore(new Text('\n    '), breadcrumbs.firstChild);
+    }
+  }
+}

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -14,6 +14,18 @@ class DartdocCustomizer {
 
   DartdocCustomizer(this.packageName, this.packageVersion);
 
+  Future<bool> customizeDir(String path) async {
+    bool changed = false;
+    final dir = new Directory(path);
+    await for (var fse in dir.list(recursive: true)) {
+      if (fse is File && fse.path.endsWith('.html')) {
+        final c = await customizeFile(fse);
+        changed = changed || c;
+      }
+    }
+    return changed;
+  }
+
   Future<bool> customizeFile(File file) async {
     final String oldContent = await file.readAsString();
     final String newContent = customizeHtml(oldContent);
@@ -40,7 +52,8 @@ class DartdocCustomizer {
     final logoLink = new Element.tag('a');
     logoLink.attributes['href'] = 'https://pub.dartlang.org/';
     final imgRef = new Element.tag('img');
-    imgRef.attributes['src'] = 'https://pub.dartlang.org/static/img/dart-logo.svg';
+    imgRef.attributes['src'] =
+        'https://pub.dartlang.org/static/img/dart-logo.svg';
     imgRef.attributes['style'] = 'height: 30px; margin-right: 1em;';
     logoLink.append(imgRef);
     parent.insertBefore(logoLink, breadcrumbs);

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -17,6 +17,7 @@ import '../shared/utils.dart' show redirectDartdocPages;
 import '../shared/versions.dart';
 
 import 'backend.dart';
+import 'customization.dart';
 import 'models.dart';
 
 final Logger _logger = new Logger('pub.dartdoc.runner');
@@ -65,6 +66,9 @@ class DartdocRunner implements TaskRunner {
 
       final dartdocEnv = {'PUB_CACHE': pubCacheDir};
       final entry = await _generateDocs(task, pkgPath, outputDir, dartdocEnv);
+
+      await new DartdocCustomizer(task.package, task.version)
+          .customizeDir(outputDir);
 
       if (entry.hasContent) {
         await dartdocBackend.uploadDir(entry, outputDir);

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:html/parser.dart';
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/dartdoc/customization.dart';
+
+const String goldenDir = 'test/dartdoc/golden';
+
+final _regenerateGoldens = false;
+
+void main() {
+  void expectGoldenFile(String content, String fileName) {
+    // Making sure it is valid HTML
+    final htmlParser = new HtmlParser(content, strict: true);
+    htmlParser.parse();
+
+    if (_regenerateGoldens) {
+      new File('$goldenDir/$fileName').writeAsStringSync(content);
+      fail('Set `_regenerateGoldens` to `false` to run tests.');
+    }
+    final golden = new File('$goldenDir/$fileName').readAsStringSync();
+    expect(content.split('\n'), golden.split('\n'));
+  }
+
+  group('pana 0.10.2', () {
+    final customization = new DartdocCustomizer('pana', '0.10.2');
+
+    void expectMatch(String name) {
+      test(name, () {
+        final inputName = 'pana_0.10.2_$name.html';
+        final outputName = 'pana_0.10.2_$name.out.html';
+        final html = new File('$goldenDir/$inputName').readAsStringSync();
+        final result = customization.customizeHtml(html) ?? html;
+        expectGoldenFile(result, outputName);
+      });
+    }
+
+    expectMatch('index');
+    expectMatch('license_file_class');
+    expectMatch('license_file_constructor');
+    expectMatch('license_file_name_field');
+    expectMatch('pretty_json');
+  });
+}

--- a/app/test/dartdoc/golden/pana_0.10.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="generator" content="made with love by dartdoc 0.16.0">
+  <meta name="description" content="pana API docs, for the Dart programming language.">
+  <title>pana - Dart API docs</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/index.html">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="https://github.com/dart-lang/pana">pana package</a></li>
+  </ol>
+  <div class="self-name">pana</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>pana package</h5>
+
+
+    <ol>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
+      <li><a href="pana/pana-library.html">pana</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <section class="desc markdown">
+        <p><a href="https://travis-ci.org/dart-lang/pana"><img alt="Build Status" src="https://travis-ci.org/dart-lang/pana.svg?branch=master"></a></p>
+<p>A library for analyzing Dart packages.</p><ul><li>Validates the code using <a href="https://www.dartlang.org/tools/analyzer">Dart Analyzer</a>.</li><li>Checks code formatting.</li><li>Checks for outdated dependencies.</li><li>Infers supported platforms: Flutter, web, and/or server.</li></ul>
+<p>Used by the <a href="https://pub.dartlang.org/">Dart Package site</a>.</p>
+<h2>Use as an executable</h2>
+<h3>Installation</h3>
+<pre class="language-console"><code class="language-console">&gt; pub global activate pana
+</code></pre>
+<h3>Usage</h3>
+<p>You can specify either a package (+ version) or a local directory to analyze:</p>
+<pre class="language-dart"><code>Usage: pana [&lt;options&gt;] &lt;package&gt; [&lt;version&gt;]
+       pana [&lt;options&gt;] --source path &lt;directory&gt;
+
+Options:
+  -j, --json            Output log items as JSON.
+  -s, --source          The source used to find the package.
+                        [hosted (default), path]
+  
+      --hosted-url      The server that hosts &lt;package&gt;.
+                        (defaults to "https://pub.dartlang.org")
+  
+      --[no-]warning    Shows the warning message before potentially destructive operation.
+                        (defaults to on)
+</code></pre>
+      </section>
+      
+
+      <section class="summary" id="libraries">
+        <h2>Libraries</h2>
+        <dl>
+            <dt id="pana">
+              <span class="name"><a href="pana/pana-library.html">pana</a></span>
+            </dt>
+            <dd>
+              
+            </dd>
+        </dl>
+      </section>
+
+  </div> <!-- /.main-content -->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -19,6 +19,7 @@
 <div id="overlay-under-drawer"></div>
 
 <header id="title">
+  <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
   </ol>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!DOCTYPE html><html lang="en"><head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -26,7 +24,7 @@
   </ol>
   <div class="self-name">pana</div>
   <form class="search navbar-right" role="search">
-    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+    <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search...">
   </form>
 </header>
 
@@ -100,6 +98,7 @@ Options:
 <script src="static-assets/script.js"></script>
 
 
-</body>
 
-</html>
+
+
+</body></html>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -20,7 +20,7 @@
 
 <header id="title">
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    <li><a href="https://github.com/dart-lang/pana">pana package</a></li>
+    <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
   </ol>
   <div class="self-name">pana</div>
   <form class="search navbar-right" role="search">

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="generator" content="made with love by dartdoc 0.16.0">
+  <meta name="description" content="pana API docs, for the Dart programming language.">
+  <title>pana - Dart API docs</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/index.html">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="https://github.com/dart-lang/pana">pana package</a></li>
+  </ol>
+  <div class="self-name">pana</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>pana package</h5>
+
+
+    <ol>
+      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
+      <li><a href="pana/pana-library.html">pana</a></li>
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+      <section class="desc markdown">
+        <p><a href="https://travis-ci.org/dart-lang/pana"><img alt="Build Status" src="https://travis-ci.org/dart-lang/pana.svg?branch=master"></a></p>
+<p>A library for analyzing Dart packages.</p><ul><li>Validates the code using <a href="https://www.dartlang.org/tools/analyzer">Dart Analyzer</a>.</li><li>Checks code formatting.</li><li>Checks for outdated dependencies.</li><li>Infers supported platforms: Flutter, web, and/or server.</li></ul>
+<p>Used by the <a href="https://pub.dartlang.org/">Dart Package site</a>.</p>
+<h2>Use as an executable</h2>
+<h3>Installation</h3>
+<pre class="language-console"><code class="language-console">&gt; pub global activate pana
+</code></pre>
+<h3>Usage</h3>
+<p>You can specify either a package (+ version) or a local directory to analyze:</p>
+<pre class="language-dart"><code>Usage: pana [&lt;options&gt;] &lt;package&gt; [&lt;version&gt;]
+       pana [&lt;options&gt;] --source path &lt;directory&gt;
+
+Options:
+  -j, --json            Output log items as JSON.
+  -s, --source          The source used to find the package.
+                        [hosted (default), path]
+  
+      --hosted-url      The server that hosts &lt;package&gt;.
+                        (defaults to "https://pub.dartlang.org")
+  
+      --[no-]warning    Shows the warning message before potentially destructive operation.
+                        (defaults to on)
+</code></pre>
+      </section>
+      
+
+      <section class="summary" id="libraries">
+        <h2>Libraries</h2>
+        <dl>
+            <dt id="pana">
+              <span class="name"><a href="pana/pana-library.html">pana</a></span>
+            </dt>
+            <dd>
+              
+            </dd>
+        </dl>
+      </section>
+
+  </div> <!-- /.main-content -->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the LicenseFile class from the pana library, for the Dart programming language.">
+  <title>LicenseFile class - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/LicenseFile-class.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li class="self-crumb">LicenseFile class</li>
+  </ol>
+  <div class="self-name">LicenseFile</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>pana library</h5>
+    <ol>
+      <li class="section-title"><a href="pana/pana-library.html#classes">Classes</a></li>
+      <li><a href="pana/CodeProblem-class.html">CodeProblem</a></li>
+      <li><a href="pana/ComponentDef-class.html">ComponentDef</a></li>
+      <li><a href="pana/ComponentNames-class.html">ComponentNames</a></li>
+      <li><a href="pana/ConstraintTypes-class.html">ConstraintTypes</a></li>
+      <li><a href="pana/DartFileSummary-class.html">DartFileSummary</a></li>
+      <li><a href="pana/DartPlatform-class.html">DartPlatform</a></li>
+      <li><a href="pana/DartSdk-class.html">DartSdk</a></li>
+      <li><a href="pana/DependencyTypes-class.html">DependencyTypes</a></li>
+      <li><a href="pana/Fitness-class.html">Fitness</a></li>
+      <li><a href="pana/FlutterSdk-class.html">FlutterSdk</a></li>
+      <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseNames-class.html">LicenseNames</a></li>
+      <li><a href="pana/PackageAnalyzer-class.html">PackageAnalyzer</a></li>
+      <li><a href="pana/PackageLocation-class.html">PackageLocation</a></li>
+      <li><a href="pana/Penalty-class.html">Penalty</a></li>
+      <li><a href="pana/PkgDependency-class.html">PkgDependency</a></li>
+      <li><a href="pana/PkgResolution-class.html">PkgResolution</a></li>
+      <li><a href="pana/PlatformDef-class.html">PlatformDef</a></li>
+      <li><a href="pana/PlatformNames-class.html">PlatformNames</a></li>
+      <li><a href="pana/PubEntry-class.html">PubEntry</a></li>
+      <li><a href="pana/PubEnvironment-class.html">PubEnvironment</a></li>
+      <li><a href="pana/Pubspec-class.html">Pubspec</a></li>
+      <li><a href="pana/Suggestion-class.html">Suggestion</a></li>
+      <li><a href="pana/SuggestionLevel-class.html">SuggestionLevel</a></li>
+      <li><a href="pana/Summary-class.html">Summary</a></li>
+    
+    
+    
+      <li class="section-title"><a href="pana/pana-library.html#functions">Functions</a></li>
+      <li><a href="pana/applyPenalties.html">applyPenalties</a></li>
+      <li><a href="pana/byteStreamSplit.html">byteStreamSplit</a></li>
+      <li><a href="pana/calcFitness.html">calcFitness</a></li>
+      <li><a href="pana/calcPkgFitness.html">calcPkgFitness</a></li>
+      <li><a href="pana/classifyLibPlatform.html">classifyLibPlatform</a></li>
+      <li><a href="pana/classifyPkgPlatform.html">classifyPkgPlatform</a></li>
+      <li><a href="pana/detectLicenseInContent.html">detectLicenseInContent</a></li>
+      <li><a href="pana/detectLicenseInFile.html">detectLicenseInFile</a></li>
+      <li><a href="pana/detectLicensesInDir.html">detectLicensesInDir</a></li>
+      <li><a href="pana/fileSize.html">fileSize</a></li>
+      <li><a href="pana/getPubspecContent.html">getPubspecContent</a></li>
+      <li><a href="pana/getSignals.html">getSignals</a></li>
+      <li><a href="pana/handleProcessErrors.html">handleProcessErrors</a></li>
+      <li><a href="pana/listFiles.html">listFiles</a></li>
+      <li><a href="pana/listFocusDirs.html">listFocusDirs</a></li>
+      <li><a href="pana/prettyJson.html">prettyJson</a></li>
+      <li><a href="pana/runProc.html">runProc</a></li>
+      <li><a href="pana/runProcSync.html">runProcSync</a></li>
+      <li><a href="pana/sortedJson.html">sortedJson</a></li>
+      <li><a href="pana/toPackageUri.html">toPackageUri</a></li>
+      <li><a href="pana/toRelativePath.html">toRelativePath</a></li>
+      <li><a href="pana/updateLicenseUrls.html">updateLicenseUrls</a></li>
+      <li><a href="pana/yamlToJson.html">yamlToJson</a></li>
+    
+      <li class="section-title"><a href="pana/pana-library.html#enums">Enums</a></li>
+      <li><a href="pana/PlatformUse-class.html">PlatformUse</a></li>
+      <li><a href="pana/VersionResolutionType-class.html">VersionResolutionType</a></li>
+    
+    
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>LicenseFile class</h1>
+
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+
+        <dt>Annotations</dt>
+        <dd><ul class="annotation-list clazz-relationships">
+          <li>@JsonSerializable()</li>
+        </ul></dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="LicenseFile" class="callable">
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })</span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="LicenseFile.fromJson" class="callable">
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
+        </dt>
+        <dd>
+          
+          <div class="constructor-modifier features">factory</div>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property">
+          <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd>
+          The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
+          <div class="features">read-only</div>
+</dd>
+        <dt id="name" class="property">
+          <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">final</div>
+</dd>
+        <dt id="path" class="property">
+          <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">final</div>
+</dd>
+        <dt id="shortFormatted" class="property">
+          <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">read-only</div>
+</dd>
+        <dt id="url" class="property">
+          <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">@JsonKey(includeIfNull: false), final</div>
+</dd>
+        <dt id="version" class="property">
+          <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">@JsonKey(includeIfNull: false), final</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          A representation of the runtime type of the object.
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="change" class="callable">
+          <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+            <span class="returntype parameter">&#8594; <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
+          </span>
+        </dt>
+        <dd>
+          
+          
+</dd>
+        <dt id="toString" class="callable">
+          <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd>
+          Returns a string representation of this object.
+          
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Invoked when a non-existent method or property is accessed. <a href="pana/LicenseFile/noSuchMethod.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toJson" class="callable inherited">
+          <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;String, dynamic&gt;</span></span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable">
+          <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd>
+          The equality operator. <a href="pana/LicenseFile/operator_equals.html">[...]</a>
+          
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="pana/LicenseFile-class.html#constructors">Constructors</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.fromJson.html">fromJson</a></li>
+    
+      <li class="section-title">
+        <a href="pana/LicenseFile-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="pana/LicenseFile/hashCode.html">hashCode</a></li>
+      <li><a href="pana/LicenseFile/name.html">name</a></li>
+      <li><a href="pana/LicenseFile/path.html">path</a></li>
+      <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
+      <li><a href="pana/LicenseFile/url.html">url</a></li>
+      <li><a href="pana/LicenseFile/version.html">version</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
+      <li><a href="pana/LicenseFile/change.html">change</a></li>
+      <li><a href="pana/LicenseFile/toString.html">toString</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
+      <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the LicenseFile class from the pana library, for the Dart programming language.">
+  <title>LicenseFile class - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/LicenseFile-class.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li class="self-crumb">LicenseFile class</li>
+  </ol>
+  <div class="self-name">LicenseFile</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>pana library</h5>
+    <ol>
+      <li class="section-title"><a href="pana/pana-library.html#classes">Classes</a></li>
+      <li><a href="pana/CodeProblem-class.html">CodeProblem</a></li>
+      <li><a href="pana/ComponentDef-class.html">ComponentDef</a></li>
+      <li><a href="pana/ComponentNames-class.html">ComponentNames</a></li>
+      <li><a href="pana/ConstraintTypes-class.html">ConstraintTypes</a></li>
+      <li><a href="pana/DartFileSummary-class.html">DartFileSummary</a></li>
+      <li><a href="pana/DartPlatform-class.html">DartPlatform</a></li>
+      <li><a href="pana/DartSdk-class.html">DartSdk</a></li>
+      <li><a href="pana/DependencyTypes-class.html">DependencyTypes</a></li>
+      <li><a href="pana/Fitness-class.html">Fitness</a></li>
+      <li><a href="pana/FlutterSdk-class.html">FlutterSdk</a></li>
+      <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseNames-class.html">LicenseNames</a></li>
+      <li><a href="pana/PackageAnalyzer-class.html">PackageAnalyzer</a></li>
+      <li><a href="pana/PackageLocation-class.html">PackageLocation</a></li>
+      <li><a href="pana/Penalty-class.html">Penalty</a></li>
+      <li><a href="pana/PkgDependency-class.html">PkgDependency</a></li>
+      <li><a href="pana/PkgResolution-class.html">PkgResolution</a></li>
+      <li><a href="pana/PlatformDef-class.html">PlatformDef</a></li>
+      <li><a href="pana/PlatformNames-class.html">PlatformNames</a></li>
+      <li><a href="pana/PubEntry-class.html">PubEntry</a></li>
+      <li><a href="pana/PubEnvironment-class.html">PubEnvironment</a></li>
+      <li><a href="pana/Pubspec-class.html">Pubspec</a></li>
+      <li><a href="pana/Suggestion-class.html">Suggestion</a></li>
+      <li><a href="pana/SuggestionLevel-class.html">SuggestionLevel</a></li>
+      <li><a href="pana/Summary-class.html">Summary</a></li>
+    
+    
+    
+      <li class="section-title"><a href="pana/pana-library.html#functions">Functions</a></li>
+      <li><a href="pana/applyPenalties.html">applyPenalties</a></li>
+      <li><a href="pana/byteStreamSplit.html">byteStreamSplit</a></li>
+      <li><a href="pana/calcFitness.html">calcFitness</a></li>
+      <li><a href="pana/calcPkgFitness.html">calcPkgFitness</a></li>
+      <li><a href="pana/classifyLibPlatform.html">classifyLibPlatform</a></li>
+      <li><a href="pana/classifyPkgPlatform.html">classifyPkgPlatform</a></li>
+      <li><a href="pana/detectLicenseInContent.html">detectLicenseInContent</a></li>
+      <li><a href="pana/detectLicenseInFile.html">detectLicenseInFile</a></li>
+      <li><a href="pana/detectLicensesInDir.html">detectLicensesInDir</a></li>
+      <li><a href="pana/fileSize.html">fileSize</a></li>
+      <li><a href="pana/getPubspecContent.html">getPubspecContent</a></li>
+      <li><a href="pana/getSignals.html">getSignals</a></li>
+      <li><a href="pana/handleProcessErrors.html">handleProcessErrors</a></li>
+      <li><a href="pana/listFiles.html">listFiles</a></li>
+      <li><a href="pana/listFocusDirs.html">listFocusDirs</a></li>
+      <li><a href="pana/prettyJson.html">prettyJson</a></li>
+      <li><a href="pana/runProc.html">runProc</a></li>
+      <li><a href="pana/runProcSync.html">runProcSync</a></li>
+      <li><a href="pana/sortedJson.html">sortedJson</a></li>
+      <li><a href="pana/toPackageUri.html">toPackageUri</a></li>
+      <li><a href="pana/toRelativePath.html">toRelativePath</a></li>
+      <li><a href="pana/updateLicenseUrls.html">updateLicenseUrls</a></li>
+      <li><a href="pana/yamlToJson.html">yamlToJson</a></li>
+    
+      <li class="section-title"><a href="pana/pana-library.html#enums">Enums</a></li>
+      <li><a href="pana/PlatformUse-class.html">PlatformUse</a></li>
+      <li><a href="pana/VersionResolutionType-class.html">VersionResolutionType</a></li>
+    
+    
+    </ol>
+  </div>
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>LicenseFile class</h1>
+
+    
+    <section>
+      <dl class="dl-horizontal">
+
+
+
+
+        <dt>Annotations</dt>
+        <dd><ul class="annotation-list clazz-relationships">
+          <li>@JsonSerializable()</li>
+        </ul></dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="constructors">
+      <h2>Constructors</h2>
+
+      <dl class="constructor-summary-list">
+        <dt id="LicenseFile" class="callable">
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })</span>
+        </dt>
+        <dd>
+          
+        </dd>
+        <dt id="LicenseFile.fromJson" class="callable">
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
+        </dt>
+        <dd>
+          
+          <div class="constructor-modifier features">factory</div>
+        </dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-properties">
+      <h2>Properties</h2>
+
+      <dl class="properties">
+        <dt id="hashCode" class="property">
+          <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
+          <span class="signature">&#8594; int</span>
+        </dt>
+        <dd>
+          The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
+          <div class="features">read-only</div>
+</dd>
+        <dt id="name" class="property">
+          <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">final</div>
+</dd>
+        <dt id="path" class="property">
+          <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">final</div>
+</dd>
+        <dt id="shortFormatted" class="property">
+          <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">read-only</div>
+</dd>
+        <dt id="url" class="property">
+          <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">@JsonKey(includeIfNull: false), final</div>
+</dd>
+        <dt id="version" class="property">
+          <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
+          <span class="signature">&#8594; String</span>
+        </dt>
+        <dd>
+          
+          <div class="features">@JsonKey(includeIfNull: false), final</div>
+</dd>
+        <dt id="runtimeType" class="property inherited">
+          <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; Type</span>
+        </dt>
+        <dd class="inherited">
+          A representation of the runtime type of the object.
+          <div class="features">read-only, inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="instance-methods">
+      <h2>Methods</h2>
+      <dl class="callables">
+        <dt id="change" class="callable">
+          <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+            <span class="returntype parameter">&#8594; <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
+          </span>
+        </dt>
+        <dd>
+          
+          
+</dd>
+        <dt id="toString" class="callable">
+          <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; String</span>
+          </span>
+        </dt>
+        <dd>
+          Returns a string representation of this object.
+          
+</dd>
+        <dt id="noSuchMethod" class="callable inherited">
+          <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+            <span class="returntype parameter">&#8594; dynamic</span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          Invoked when a non-existent method or property is accessed. <a href="pana/LicenseFile/noSuchMethod.html">[...]</a>
+          <div class="features">inherited</div>
+</dd>
+        <dt id="toJson" class="callable inherited">
+          <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;String, dynamic&gt;</span></span>
+          </span>
+        </dt>
+        <dd class="inherited">
+          
+          <div class="features">inherited</div>
+</dd>
+      </dl>
+    </section>
+
+    <section class="summary offset-anchor" id="operators">
+      <h2>Operators</h2>
+      <dl class="callables">
+        <dt id="operator ==" class="callable">
+          <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; bool</span>
+          </span>
+        </dt>
+        <dd>
+          The equality operator. <a href="pana/LicenseFile/operator_equals.html">[...]</a>
+          
+</dd>
+      </dl>
+    </section>
+
+
+
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+    <ol>
+      <li class="section-title"><a href="pana/LicenseFile-class.html#constructors">Constructors</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.fromJson.html">fromJson</a></li>
+    
+      <li class="section-title">
+        <a href="pana/LicenseFile-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="pana/LicenseFile/hashCode.html">hashCode</a></li>
+      <li><a href="pana/LicenseFile/name.html">name</a></li>
+      <li><a href="pana/LicenseFile/path.html">path</a></li>
+      <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
+      <li><a href="pana/LicenseFile/url.html">url</a></li>
+      <li><a href="pana/LicenseFile/version.html">version</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
+      <li><a href="pana/LicenseFile/change.html">change</a></li>
+      <li><a href="pana/LicenseFile/toString.html">toString</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
+      <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!DOCTYPE html><html lang="en"><head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -30,7 +28,7 @@
   </ol>
   <div class="self-name">LicenseFile</div>
   <form class="search navbar-right" role="search">
-    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+    <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search...">
   </form>
 </header>
 
@@ -144,7 +142,7 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
           <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
+          <span class="signature">→ int</span>
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
@@ -152,7 +150,7 @@
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">→ String</span>
         </dt>
         <dd>
           
@@ -160,7 +158,7 @@
 </dd>
         <dt id="path" class="property">
           <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">→ String</span>
         </dt>
         <dd>
           
@@ -168,7 +166,7 @@
 </dd>
         <dt id="shortFormatted" class="property">
           <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">→ String</span>
         </dt>
         <dd>
           
@@ -176,7 +174,7 @@
 </dd>
         <dt id="url" class="property">
           <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">→ String</span>
         </dt>
         <dd>
           
@@ -184,7 +182,7 @@
 </dd>
         <dt id="version" class="property">
           <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">→ String</span>
         </dt>
         <dd>
           
@@ -192,7 +190,7 @@
 </dd>
         <dt id="runtimeType" class="property inherited">
           <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
+          <span class="signature">→ Type</span>
         </dt>
         <dd class="inherited">
           A representation of the runtime type of the object.
@@ -206,7 +204,7 @@
       <dl class="callables">
         <dt id="change" class="callable">
           <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
-            <span class="returntype parameter">&#8594; <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
+            <span class="returntype parameter">→ <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
           </span>
         </dt>
         <dd>
@@ -215,7 +213,7 @@
 </dd>
         <dt id="toString" class="callable">
           <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
+            <span class="returntype parameter">→ String</span>
           </span>
         </dt>
         <dd>
@@ -224,7 +222,7 @@
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
-            <span class="returntype parameter">&#8594; dynamic</span>
+            <span class="returntype parameter">→ dynamic</span>
           </span>
         </dt>
         <dd class="inherited">
@@ -233,7 +231,7 @@
 </dd>
         <dt id="toJson" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;String, dynamic&gt;</span></span>
+            <span class="returntype parameter">→ Map<span class="signature">&lt;String, dynamic&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -248,7 +246,7 @@
       <dl class="callables">
         <dt id="operator ==" class="callable">
           <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
+            <span class="returntype parameter">→ bool</span>
           </span>
         </dt>
         <dd>
@@ -310,6 +308,7 @@
 <script src="static-assets/script.js"></script>
 
 
-</body>
 
-</html>
+
+
+</body></html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -22,7 +22,8 @@
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    <li><a href="index.html">pana</a></li>
+    <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
+    <li><a href="index.html">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li class="self-crumb">LicenseFile class</li>
   </ol>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -21,6 +21,7 @@
 
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
     <li><a href="index.html">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the LicenseFile constructor from the Class LicenseFile class from the pana library, for the Dart programming language.">
+  <title>LicenseFile constructor - LicenseFile class - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/LicenseFile/LicenseFile.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+    <li class="self-crumb">LicenseFile constructor</li>
+  </ol>
+  <div class="self-name">LicenseFile</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>LicenseFile class</h5>
+    <ol>
+      <li class="section-title"><a href="pana/LicenseFile-class.html#constructors">Constructors</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.fromJson.html">fromJson</a></li>
+    
+      <li class="section-title">
+        <a href="pana/LicenseFile-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="pana/LicenseFile/hashCode.html">hashCode</a></li>
+      <li><a href="pana/LicenseFile/name.html">name</a></li>
+      <li><a href="pana/LicenseFile/path.html">path</a></li>
+      <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
+      <li><a href="pana/LicenseFile/url.html">url</a></li>
+      <li><a href="pana/LicenseFile/version.html">version</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
+      <li><a href="pana/LicenseFile/change.html">change</a></li>
+      <li><a href="pana/LicenseFile/toString.html">toString</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
+      <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>LicenseFile constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">LicenseFile</span>(<wbr><span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+    </section>
+
+    
+    <section class="summary source-code" id="source">
+      <h2><span>Implementation</span> </h2>
+      <pre class="language-dart"><code class="language-dart">LicenseFile(this.path, this.name, {this.version, this.url});</code></pre>
+    </section>
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!DOCTYPE html><html lang="en"><head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -31,7 +29,7 @@
   </ol>
   <div class="self-name">LicenseFile</div>
   <form class="search navbar-right" role="search">
-    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+    <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search...">
   </form>
 </header>
 
@@ -104,6 +102,7 @@
 <script src="static-assets/script.js"></script>
 
 
-</body>
 
-</html>
+
+
+</body></html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -22,7 +22,8 @@
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    <li><a href="index.html">pana</a></li>
+    <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
+    <li><a href="index.html">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
     <li class="self-crumb">LicenseFile constructor</li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -21,6 +21,7 @@
 
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
     <li><a href="index.html">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the LicenseFile constructor from the Class LicenseFile class from the pana library, for the Dart programming language.">
+  <title>LicenseFile constructor - LicenseFile class - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/LicenseFile/LicenseFile.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+    <li class="self-crumb">LicenseFile constructor</li>
+  </ol>
+  <div class="self-name">LicenseFile</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>LicenseFile class</h5>
+    <ol>
+      <li class="section-title"><a href="pana/LicenseFile-class.html#constructors">Constructors</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.fromJson.html">fromJson</a></li>
+    
+      <li class="section-title">
+        <a href="pana/LicenseFile-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="pana/LicenseFile/hashCode.html">hashCode</a></li>
+      <li><a href="pana/LicenseFile/name.html">name</a></li>
+      <li><a href="pana/LicenseFile/path.html">path</a></li>
+      <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
+      <li><a href="pana/LicenseFile/url.html">url</a></li>
+      <li><a href="pana/LicenseFile/version.html">version</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
+      <li><a href="pana/LicenseFile/change.html">change</a></li>
+      <li><a href="pana/LicenseFile/toString.html">toString</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
+      <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>LicenseFile constructor</h1>
+
+    <section class="multi-line-signature">
+      
+      <span class="name ">LicenseFile</span>(<wbr><span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+    </section>
+
+    
+    <section class="summary source-code" id="source">
+      <h2><span>Implementation</span> </h2>
+      <pre class="language-dart"><code class="language-dart">LicenseFile(this.path, this.name, {this.version, this.url});</code></pre>
+    </section>
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the name property from the LicenseFile class, for the Dart programming language.">
+  <title>name property - LicenseFile class - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/LicenseFile/name.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+    <li class="self-crumb">name property</li>
+  </ol>
+  <div class="self-name">name</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>LicenseFile class</h5>
+    <ol>
+      <li class="section-title"><a href="pana/LicenseFile-class.html#constructors">Constructors</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.fromJson.html">fromJson</a></li>
+    
+      <li class="section-title">
+        <a href="pana/LicenseFile-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="pana/LicenseFile/hashCode.html">hashCode</a></li>
+      <li><a href="pana/LicenseFile/name.html">name</a></li>
+      <li><a href="pana/LicenseFile/path.html">path</a></li>
+      <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
+      <li><a href="pana/LicenseFile/url.html">url</a></li>
+      <li><a href="pana/LicenseFile/version.html">version</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
+      <li><a href="pana/LicenseFile/change.html">change</a></li>
+      <li><a href="pana/LicenseFile/toString.html">toString</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
+      <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>name property</h1>
+
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">name</span>
+          <div class="features">final</div>
+        </section>
+                <section class="summary source-code" id="source">
+          <h2><span>Implementation</span> </h2>
+          <pre class="language-dart"><code class="language-dart">final String name
+
+</code></pre>
+        </section>
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!DOCTYPE html><html lang="en"><head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -31,7 +29,7 @@
   </ol>
   <div class="self-name">name</div>
   <form class="search navbar-right" role="search">
-    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+    <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search...">
   </form>
 </header>
 
@@ -105,6 +103,7 @@
 <script src="static-assets/script.js"></script>
 
 
-</body>
 
-</html>
+
+
+</body></html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -22,7 +22,8 @@
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    <li><a href="index.html">pana</a></li>
+    <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
+    <li><a href="index.html">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
     <li class="self-crumb">name property</li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the name property from the LicenseFile class, for the Dart programming language.">
+  <title>name property - LicenseFile class - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/LicenseFile/name.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="../..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+    <li class="self-crumb">name property</li>
+  </ol>
+  <div class="self-name">name</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>LicenseFile class</h5>
+    <ol>
+      <li class="section-title"><a href="pana/LicenseFile-class.html#constructors">Constructors</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseFile/LicenseFile.fromJson.html">fromJson</a></li>
+    
+      <li class="section-title">
+        <a href="pana/LicenseFile-class.html#instance-properties">Properties</a>
+      </li>
+      <li><a href="pana/LicenseFile/hashCode.html">hashCode</a></li>
+      <li><a href="pana/LicenseFile/name.html">name</a></li>
+      <li><a href="pana/LicenseFile/path.html">path</a></li>
+      <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
+      <li><a href="pana/LicenseFile/url.html">url</a></li>
+      <li><a href="pana/LicenseFile/version.html">version</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
+      <li><a href="pana/LicenseFile/change.html">change</a></li>
+      <li><a href="pana/LicenseFile/toString.html">toString</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+    
+      <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
+      <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
+    
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>name property</h1>
+
+        <section class="multi-line-signature">
+          <span class="returntype">String</span>
+          <span class="name ">name</span>
+          <div class="features">final</div>
+        </section>
+                <section class="summary source-code" id="source">
+          <h2><span>Implementation</span> </h2>
+          <pre class="language-dart"><code class="language-dart">final String name
+
+</code></pre>
+        </section>
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -21,6 +21,7 @@
 
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
     <li><a href="index.html">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the prettyJson function from the pana library, for the Dart programming language.">
+  <title>prettyJson function - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/prettyJson.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li class="self-crumb">prettyJson function</li>
+  </ol>
+  <div class="self-name">prettyJson</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>pana library</h5>
+    <ol>
+      <li class="section-title"><a href="pana/pana-library.html#classes">Classes</a></li>
+      <li><a href="pana/CodeProblem-class.html">CodeProblem</a></li>
+      <li><a href="pana/ComponentDef-class.html">ComponentDef</a></li>
+      <li><a href="pana/ComponentNames-class.html">ComponentNames</a></li>
+      <li><a href="pana/ConstraintTypes-class.html">ConstraintTypes</a></li>
+      <li><a href="pana/DartFileSummary-class.html">DartFileSummary</a></li>
+      <li><a href="pana/DartPlatform-class.html">DartPlatform</a></li>
+      <li><a href="pana/DartSdk-class.html">DartSdk</a></li>
+      <li><a href="pana/DependencyTypes-class.html">DependencyTypes</a></li>
+      <li><a href="pana/Fitness-class.html">Fitness</a></li>
+      <li><a href="pana/FlutterSdk-class.html">FlutterSdk</a></li>
+      <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseNames-class.html">LicenseNames</a></li>
+      <li><a href="pana/PackageAnalyzer-class.html">PackageAnalyzer</a></li>
+      <li><a href="pana/PackageLocation-class.html">PackageLocation</a></li>
+      <li><a href="pana/Penalty-class.html">Penalty</a></li>
+      <li><a href="pana/PkgDependency-class.html">PkgDependency</a></li>
+      <li><a href="pana/PkgResolution-class.html">PkgResolution</a></li>
+      <li><a href="pana/PlatformDef-class.html">PlatformDef</a></li>
+      <li><a href="pana/PlatformNames-class.html">PlatformNames</a></li>
+      <li><a href="pana/PubEntry-class.html">PubEntry</a></li>
+      <li><a href="pana/PubEnvironment-class.html">PubEnvironment</a></li>
+      <li><a href="pana/Pubspec-class.html">Pubspec</a></li>
+      <li><a href="pana/Suggestion-class.html">Suggestion</a></li>
+      <li><a href="pana/SuggestionLevel-class.html">SuggestionLevel</a></li>
+      <li><a href="pana/Summary-class.html">Summary</a></li>
+    
+    
+    
+      <li class="section-title"><a href="pana/pana-library.html#functions">Functions</a></li>
+      <li><a href="pana/applyPenalties.html">applyPenalties</a></li>
+      <li><a href="pana/byteStreamSplit.html">byteStreamSplit</a></li>
+      <li><a href="pana/calcFitness.html">calcFitness</a></li>
+      <li><a href="pana/calcPkgFitness.html">calcPkgFitness</a></li>
+      <li><a href="pana/classifyLibPlatform.html">classifyLibPlatform</a></li>
+      <li><a href="pana/classifyPkgPlatform.html">classifyPkgPlatform</a></li>
+      <li><a href="pana/detectLicenseInContent.html">detectLicenseInContent</a></li>
+      <li><a href="pana/detectLicenseInFile.html">detectLicenseInFile</a></li>
+      <li><a href="pana/detectLicensesInDir.html">detectLicensesInDir</a></li>
+      <li><a href="pana/fileSize.html">fileSize</a></li>
+      <li><a href="pana/getPubspecContent.html">getPubspecContent</a></li>
+      <li><a href="pana/getSignals.html">getSignals</a></li>
+      <li><a href="pana/handleProcessErrors.html">handleProcessErrors</a></li>
+      <li><a href="pana/listFiles.html">listFiles</a></li>
+      <li><a href="pana/listFocusDirs.html">listFocusDirs</a></li>
+      <li><a href="pana/prettyJson.html">prettyJson</a></li>
+      <li><a href="pana/runProc.html">runProc</a></li>
+      <li><a href="pana/runProcSync.html">runProcSync</a></li>
+      <li><a href="pana/sortedJson.html">sortedJson</a></li>
+      <li><a href="pana/toPackageUri.html">toPackageUri</a></li>
+      <li><a href="pana/toRelativePath.html">toRelativePath</a></li>
+      <li><a href="pana/updateLicenseUrls.html">updateLicenseUrls</a></li>
+      <li><a href="pana/yamlToJson.html">yamlToJson</a></li>
+    
+      <li class="section-title"><a href="pana/pana-library.html#enums">Enums</a></li>
+      <li><a href="pana/PlatformUse-class.html">PlatformUse</a></li>
+      <li><a href="pana/VersionResolutionType-class.html">VersionResolutionType</a></li>
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>prettyJson function</h1>
+
+    <section class="multi-line-signature">
+        <span class="returntype">String</span>
+        <span class="name ">prettyJson</span>
+(<wbr><span class="parameter" id="prettyJson-param-obj"><span class="parameter-name">obj</span></span>)
+    </section>
+    
+    <section class="summary source-code" id="source">
+      <h2><span>Implementation</span> </h2>
+      <pre class="language-dart"><code class="language-dart">String prettyJson(obj) {
+  try {
+    return const JsonEncoder.withIndent(&#39; &#39;).convert(obj);
+  } on JsonUnsupportedObjectError catch (e) {
+    var error = e;
+
+    while (error is JsonUnsupportedObjectError) {
+      stderr.writeln([
+        error,
+        &quot;${error.unsupportedObject} - (${error.unsupportedObject.runtimeType})&quot;,
+        error.cause == null ? null : &quot;Nested cause: ${error.cause}&quot;,
+        error.stackTrace
+      ].where((i) =&gt; i != null).join(&#39;\n&#39;));
+
+      error = error.cause;
+    }
+    rethrow;
+  }
+}</code></pre>
+    </section>
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="API docs for the prettyJson function from the pana library, for the Dart programming language.">
+  <title>prettyJson function - pana library - Dart API</title>
+  <link rel="canonical" href="https://www.dartdocs.org/documentation/pana/0.10.2/pana/prettyJson.html">
+  <!-- required because all the links are pseudo-absolute -->
+  <base href="..">
+
+  <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">
+  <link rel="stylesheet" href="static-assets/github.css">
+  <link rel="stylesheet" href="static-assets/styles.css">
+  <link rel="icon" href="static-assets/favicon.png">
+
+</head>
+
+<body>
+
+<div id="overlay-under-drawer"></div>
+
+<header id="title">
+  <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <ol class="breadcrumbs gt-separated dark hidden-xs">
+    <li><a href="index.html">pana</a></li>
+    <li><a href="pana/pana-library.html">pana</a></li>
+    <li class="self-crumb">prettyJson function</li>
+  </ol>
+  <div class="self-name">prettyJson</div>
+  <form class="search navbar-right" role="search">
+    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+  </form>
+</header>
+
+<main>
+
+  <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
+    <h5>pana library</h5>
+    <ol>
+      <li class="section-title"><a href="pana/pana-library.html#classes">Classes</a></li>
+      <li><a href="pana/CodeProblem-class.html">CodeProblem</a></li>
+      <li><a href="pana/ComponentDef-class.html">ComponentDef</a></li>
+      <li><a href="pana/ComponentNames-class.html">ComponentNames</a></li>
+      <li><a href="pana/ConstraintTypes-class.html">ConstraintTypes</a></li>
+      <li><a href="pana/DartFileSummary-class.html">DartFileSummary</a></li>
+      <li><a href="pana/DartPlatform-class.html">DartPlatform</a></li>
+      <li><a href="pana/DartSdk-class.html">DartSdk</a></li>
+      <li><a href="pana/DependencyTypes-class.html">DependencyTypes</a></li>
+      <li><a href="pana/Fitness-class.html">Fitness</a></li>
+      <li><a href="pana/FlutterSdk-class.html">FlutterSdk</a></li>
+      <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
+      <li><a href="pana/LicenseNames-class.html">LicenseNames</a></li>
+      <li><a href="pana/PackageAnalyzer-class.html">PackageAnalyzer</a></li>
+      <li><a href="pana/PackageLocation-class.html">PackageLocation</a></li>
+      <li><a href="pana/Penalty-class.html">Penalty</a></li>
+      <li><a href="pana/PkgDependency-class.html">PkgDependency</a></li>
+      <li><a href="pana/PkgResolution-class.html">PkgResolution</a></li>
+      <li><a href="pana/PlatformDef-class.html">PlatformDef</a></li>
+      <li><a href="pana/PlatformNames-class.html">PlatformNames</a></li>
+      <li><a href="pana/PubEntry-class.html">PubEntry</a></li>
+      <li><a href="pana/PubEnvironment-class.html">PubEnvironment</a></li>
+      <li><a href="pana/Pubspec-class.html">Pubspec</a></li>
+      <li><a href="pana/Suggestion-class.html">Suggestion</a></li>
+      <li><a href="pana/SuggestionLevel-class.html">SuggestionLevel</a></li>
+      <li><a href="pana/Summary-class.html">Summary</a></li>
+    
+    
+    
+      <li class="section-title"><a href="pana/pana-library.html#functions">Functions</a></li>
+      <li><a href="pana/applyPenalties.html">applyPenalties</a></li>
+      <li><a href="pana/byteStreamSplit.html">byteStreamSplit</a></li>
+      <li><a href="pana/calcFitness.html">calcFitness</a></li>
+      <li><a href="pana/calcPkgFitness.html">calcPkgFitness</a></li>
+      <li><a href="pana/classifyLibPlatform.html">classifyLibPlatform</a></li>
+      <li><a href="pana/classifyPkgPlatform.html">classifyPkgPlatform</a></li>
+      <li><a href="pana/detectLicenseInContent.html">detectLicenseInContent</a></li>
+      <li><a href="pana/detectLicenseInFile.html">detectLicenseInFile</a></li>
+      <li><a href="pana/detectLicensesInDir.html">detectLicensesInDir</a></li>
+      <li><a href="pana/fileSize.html">fileSize</a></li>
+      <li><a href="pana/getPubspecContent.html">getPubspecContent</a></li>
+      <li><a href="pana/getSignals.html">getSignals</a></li>
+      <li><a href="pana/handleProcessErrors.html">handleProcessErrors</a></li>
+      <li><a href="pana/listFiles.html">listFiles</a></li>
+      <li><a href="pana/listFocusDirs.html">listFocusDirs</a></li>
+      <li><a href="pana/prettyJson.html">prettyJson</a></li>
+      <li><a href="pana/runProc.html">runProc</a></li>
+      <li><a href="pana/runProcSync.html">runProcSync</a></li>
+      <li><a href="pana/sortedJson.html">sortedJson</a></li>
+      <li><a href="pana/toPackageUri.html">toPackageUri</a></li>
+      <li><a href="pana/toRelativePath.html">toRelativePath</a></li>
+      <li><a href="pana/updateLicenseUrls.html">updateLicenseUrls</a></li>
+      <li><a href="pana/yamlToJson.html">yamlToJson</a></li>
+    
+      <li class="section-title"><a href="pana/pana-library.html#enums">Enums</a></li>
+      <li><a href="pana/PlatformUse-class.html">PlatformUse</a></li>
+      <li><a href="pana/VersionResolutionType-class.html">VersionResolutionType</a></li>
+    
+    
+    </ol>
+  </div><!--/.sidebar-offcanvas-left-->
+
+  <div class="col-xs-12 col-sm-9 col-md-8 main-content">
+    <h1>prettyJson function</h1>
+
+    <section class="multi-line-signature">
+        <span class="returntype">String</span>
+        <span class="name ">prettyJson</span>
+(<wbr><span class="parameter" id="prettyJson-param-obj"><span class="parameter-name">obj</span></span>)
+    </section>
+    
+    <section class="summary source-code" id="source">
+      <h2><span>Implementation</span> </h2>
+      <pre class="language-dart"><code class="language-dart">String prettyJson(obj) {
+  try {
+    return const JsonEncoder.withIndent(&#39; &#39;).convert(obj);
+  } on JsonUnsupportedObjectError catch (e) {
+    var error = e;
+
+    while (error is JsonUnsupportedObjectError) {
+      stderr.writeln([
+        error,
+        &quot;${error.unsupportedObject} - (${error.unsupportedObject.runtimeType})&quot;,
+        error.cause == null ? null : &quot;Nested cause: ${error.cause}&quot;,
+        error.stackTrace
+      ].where((i) =&gt; i != null).join(&#39;\n&#39;));
+
+      error = error.cause;
+    }
+    rethrow;
+  }
+}</code></pre>
+    </section>
+
+  </div> <!-- /.main-content -->
+
+  <div class="col-xs-6 col-sm-6 col-md-2 sidebar sidebar-offcanvas-right">
+  </div><!--/.sidebar-offcanvas-->
+
+</main>
+
+<footer>
+  <span class="no-break">
+    pana 0.10.2
+  </span>
+
+</footer>
+
+<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="static-assets/typeahead.bundle.min.js"></script>
+<script src="static-assets/highlight.pack.js"></script>
+<script src="static-assets/URI.js"></script>
+<script src="static-assets/script.js"></script>
+
+
+</body>
+
+</html>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -22,7 +22,8 @@
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
-    <li><a href="index.html">pana</a></li>
+    <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
+    <li><a href="index.html">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li class="self-crumb">prettyJson function</li>
   </ol>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -21,6 +21,7 @@
 
 <header id="title">
   <button id="sidenav-left-toggle" type="button">&nbsp;</button>
+  <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
     <li><a href="index.html">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -1,6 +1,4 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
+<!DOCTYPE html><html lang="en"><head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -30,7 +28,7 @@
   </ol>
   <div class="self-name">prettyJson</div>
   <form class="search navbar-right" role="search">
-    <input type="text" id="search-box" autocomplete="off" disabled class="form-control typeahead" placeholder="Loading search...">
+    <input type="text" id="search-box" autocomplete="off" disabled="" class="form-control typeahead" placeholder="Loading search...">
   </form>
 </header>
 
@@ -114,17 +112,17 @@
       <h2><span>Implementation</span> </h2>
       <pre class="language-dart"><code class="language-dart">String prettyJson(obj) {
   try {
-    return const JsonEncoder.withIndent(&#39; &#39;).convert(obj);
+    return const JsonEncoder.withIndent(' ').convert(obj);
   } on JsonUnsupportedObjectError catch (e) {
     var error = e;
 
     while (error is JsonUnsupportedObjectError) {
       stderr.writeln([
         error,
-        &quot;${error.unsupportedObject} - (${error.unsupportedObject.runtimeType})&quot;,
-        error.cause == null ? null : &quot;Nested cause: ${error.cause}&quot;,
+        "${error.unsupportedObject} - (${error.unsupportedObject.runtimeType})",
+        error.cause == null ? null : "Nested cause: ${error.cause}",
         error.stackTrace
-      ].where((i) =&gt; i != null).join(&#39;\n&#39;));
+      ].where((i) =&gt; i != null).join('\n'));
 
       error = error.cause;
     }
@@ -154,6 +152,7 @@
 <script src="static-assets/script.js"></script>
 
 
-</body>
 
-</html>
+
+
+</body></html>


### PR DESCRIPTION
The current customization focuses on the page header:
- The icon goes to pub.dartlang.org
- The "<pkg_name> pacakge" goes to the pub.dartlang.org/packages/<pkg>/versions/<version> page
- The documentation" goes to the generated output's root (index.html)

<img width="526" alt="screen shot 2018-02-21 at 11 03 56" src="https://user-images.githubusercontent.com/4778111/36474175-fe090a1a-16f6-11e8-9f3c-dd4586a23c10.png">

---

Submitted in separate commits for easier review.