### PR TITLE
Control dartdoc serving (and cleanup) with maximum versions.

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -90,7 +90,10 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
   final String requestMethod = request.method?.toUpperCase();
   if (requestMethod == 'GET') {
     final entry = await dartdocBackend.getLatestEntry(
-        docFilePath.package, docFilePath.version);
+        docFilePath.package, docFilePath.version, true);
+    if (entry == null) {
+      return notFoundHandler(request);
+    }
     final stream = dartdocBackend.readContent(entry, docFilePath.path);
     return new shelf.Response(
       HttpStatus.OK,

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -56,6 +56,9 @@ class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
   Version get _semanticCustomizationVersion =>
       new Version.parse(customizationVersion);
 
+  bool get isServing => versions.shouldServeDartdoc(
+      dartdocVersion, flutterVersion, customizationVersion);
+
   /// The path of the status while the upload is in progress
   String get inProgressPrefix =>
       DartdocEntryPaths.inProgressPrefix(packageName, packageVersion);

--- a/app/lib/dartdoc/task_sources.dart
+++ b/app/lib/dartdoc/task_sources.dart
@@ -20,7 +20,7 @@ class DartdocDatastoreHeadTaskSource extends DatastoreHeadTaskSource {
   @override
   Future<bool> shouldYieldTask(Task task) async {
     final entry =
-        await dartdocBackend.getLatestEntry(task.package, task.version);
+        await dartdocBackend.getLatestEntry(task.package, task.version, false);
     return entry == null;
   }
 }
@@ -34,7 +34,7 @@ class DartdocDatastoreHistoryTaskSource extends DatastoreHistoryTaskSource {
   Future<bool> requiresUpdate(String packageName, String packageVersion,
       {bool retryFailed: false}) async {
     final entry =
-        await dartdocBackend.getLatestEntry(packageName, packageVersion);
+        await dartdocBackend.getLatestEntry(packageName, packageVersion, false);
     if (entry == null) {
       return true;
     }

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -4,6 +4,8 @@
 
 import 'package:pub_semver/pub_semver.dart';
 
+import 'utils.dart' show isNewer;
+
 // keep in-sync with app/pubspec.yaml
 final String panaVersion = '0.10.2';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
@@ -21,3 +23,15 @@ final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
 final String customizationVersion = '0.0.1';
 final Version semanticCustomizationVersion =
     new Version.parse(customizationVersion);
+
+// Versions that control the dartdoc serving.
+final _dartdocVersion = new Version.parse('0.16.0');
+final _dartdocFlutter = new Version.parse('0.0.22');
+final _dartdocCustomization = new Version.parse('0.0.1');
+
+/// Whether the given [dartdoc], [flutter] and [customization] versions should
+/// be displayed on the live site (or a coordinated upgrade is in progress).
+bool shouldServeDartdoc(String dartdoc, String flutter, String customization) =>
+    !isNewer(_dartdocVersion, new Version.parse(dartdoc)) &&
+    !isNewer(_dartdocFlutter, new Version.parse(flutter)) &&
+    !isNewer(_dartdocCustomization, new Version.parse(customization));

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -36,4 +36,44 @@ void main() {
     final version = match.group(1).trim();
     expect(version, dartdocVersion);
   });
+
+  group('dartdoc serving', () {
+    test('old versions are serving', () {
+      expect(shouldServeDartdoc('0.15.0', '0.0.21', '0.0.0'), isTrue);
+    });
+
+    test('max versions are serving', () {
+      expect(
+          shouldServeDartdoc(
+            dartdocVersion,
+            flutterVersion,
+            customizationVersion,
+          ),
+          isTrue);
+    });
+
+    test('next versions are not serving', () {
+      expect(
+          shouldServeDartdoc(
+            '0.16.1',
+            flutterVersion,
+            customizationVersion,
+          ),
+          isFalse);
+      expect(
+          shouldServeDartdoc(
+            dartdocVersion,
+            '0.0.23',
+            customizationVersion,
+          ),
+          isFalse);
+      expect(
+          shouldServeDartdoc(
+            dartdocVersion,
+            flutterVersion,
+            '0.0.2',
+          ),
+          isFalse);
+    });
+  });
 }


### PR DESCRIPTION
- making sure we don't serve newer versions then the set maximums
- making sure we don't delete older versions and run out of serving ones 