### PR TITLE
Add an extra documentation label in the customized breadcrumbs.

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -69,6 +69,13 @@ class DartdocCustomizer {
       final firstLink = breadcrumbs.querySelector('a');
       firstLink.attributes['href'] = pubPackageLink;
       firstLink.text = pubPackageText;
+
+      final docitem = new Element.tag('li')
+        ..className = 'self-crumb'
+        ..text = 'documentation';
+      breadcrumbs.append(new Text('  '));
+      breadcrumbs.append(docitem);
+      breadcrumbs.append(new Text('\n  '));
     } else if (breadcrumbs.children.isNotEmpty) {
       // we are inside
       final firstLink = breadcrumbs.querySelector('a');

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -22,6 +22,7 @@
   <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2">pana package</a></li>
+    <li class="self-crumb">documentation</li>
   </ol>
   <div class="self-name">pana</div>
   <form class="search navbar-right" role="search">


### PR DESCRIPTION
The difference is the following: [earlier version](https://dartdoc-dot-dartlang-pub-dev.appspot.com/documentation/sqflite/0.6.2+2/) has no "documentation" on the landing page after the package name, while the [current one](https://dartdoc-dot-dartlang-pub-dev.appspot.com/documentation/sqflite/0.4.0/) has it.