### PR TITLE
Display dartdoc status on the versions page.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -14,6 +14,7 @@ import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/analyzer_client.dart';
+import '../shared/dartdoc_client.dart';
 import '../shared/handlers.dart';
 import '../shared/platform.dart';
 import '../shared/search_service.dart';
@@ -426,8 +427,11 @@ Future<shelf.Response> _packageVersionsHandler(
     return backend.downloadUrl(packageName, version.version);
   }).toList());
 
+  final dartdocEntries = await dartdocClient.getEntries(
+      packageName, versions.map((pv) => pv.version).toList());
+
   return htmlResponse(templateService.renderPkgVersionsPage(
-      packageName, versions, versionDownloadUrls));
+      packageName, versions, dartdocEntries, versionDownloadUrls));
 }
 
 Future<shelf.Response> _packageVersionHandlerHtmlCore(
@@ -437,6 +441,7 @@ Future<shelf.Response> _packageVersionHandlerHtmlCore(
         Package package,
         bool isVersionPage,
         List<PackageVersion> first10Versions,
+        List<DartdocEntry> dartdocEntries,
         List<Uri> versionDownloadUrls,
         PackageVersion selectedVersion,
         PackageVersion latestStableVersion,
@@ -465,6 +470,8 @@ Future<shelf.Response> _packageVersionHandlerHtmlCore(
     sortPackageVersionsDesc(versions, decreasing: true, pubSorting: true);
     final latestStable = versions[0];
     final first10Versions = versions.take(10).toList();
+    final dartdocEntries = await dartdocClient.getEntries(
+        packageName, first10Versions.map((pv) => pv.version).toList());
 
     sortPackageVersionsDesc(versions, decreasing: true, pubSorting: false);
     final latestDev = versions[0];
@@ -501,6 +508,7 @@ Future<shelf.Response> _packageVersionHandlerHtmlCore(
         package,
         versionName != null,
         first10Versions,
+        dartdocEntries,
         versionDownloadUrls,
         selectedVersion,
         latestStable,

--- a/app/lib/shared/dartdoc_client.dart
+++ b/app/lib/shared/dartdoc_client.dart
@@ -6,9 +6,18 @@ import 'dart:async';
 
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:pool/pool.dart';
+
+import '../dartdoc/dartdoc_runner.dart' show statusFilePath;
+import '../dartdoc/models.dart' show DartdocEntry;
 
 import 'configuration.dart';
 import 'notification.dart' show notifyService;
+
+export '../dartdoc/models.dart' show DartdocEntry;
+
+final Logger _logger = new Logger('dartdoc.client');
 
 /// Sets the dartdoc client.
 void registerDartdocClient(DartdocClient client) =>
@@ -23,6 +32,17 @@ class DartdocClient {
   String get _dartdocServiceHttpHostPort =>
       activeConfiguration.dartdocServicePrefix;
 
+  Future<List<DartdocEntry>> getEntries(
+      String package, List<String> versions) async {
+    final resultFutures = <Future<DartdocEntry>>[];
+    final pool = new Pool(4); // concurrent requests
+    for (String version in versions) {
+      final future = pool.withResource(() => _getEntry(package, version));
+      resultFutures.add(future);
+    }
+    return await Future.wait(resultFutures);
+  }
+
   Future triggerDartdoc(
       String package, String version, Set<String> dependentPackages) async {
     await notifyService(_client, _dartdocServiceHttpHostPort, package, version);
@@ -34,5 +54,18 @@ class DartdocClient {
 
   Future close() async {
     _client.close();
+  }
+
+  Future<DartdocEntry> _getEntry(String package, String version) async {
+    final url =
+        '$_dartdocServiceHttpHostPort/documentation/$package/$version/$statusFilePath';
+    try {
+      final rs = await _client.get(url);
+      if (rs.statusCode != 200) return null;
+      return new DartdocEntry.fromBytes(rs.bodyBytes);
+    } catch (e) {
+      _logger.info('Error requesting entry for: $package $version');
+    }
+    return null;
   }
 }

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -157,10 +157,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
-       title="Go to the documentation of foobar_pkg 0.1.1">
-      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
-    </a>
+    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/log.txt">failed</a>
   </td>
   <td class="archive">
     <a href="http://dart-example.com/"

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -156,10 +156,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
-       title="Go to the documentation of foobar_pkg 0.1.1">
-      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
-    </a>
+    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/log.txt">failed</a>
   </td>
   <td class="archive">
     <a href="http://dart-example.com/"

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -123,10 +123,7 @@
   <td><strong><a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.2.0-dev/"
-       title="Go to the documentation of foobar_pkg 0.2.0-dev">
-      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.2.0-dev" />
-    </a>
+    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.2.0-dev/log.txt">failed</a>
   </td>
   <td class="archive">
     <a href="https://pub.dartlang.org/mock-download-uri.tar.gz"

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -15,6 +15,7 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
 import '../shared/handlers_test_utils.dart';
@@ -166,6 +167,7 @@ void main() {
         });
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
+        registerDartdocClient(new DartdocClientMock());
         await expectHtmlResponse(await issueGet('/packages/foobar_pkg'));
       });
 
@@ -187,6 +189,7 @@ void main() {
           return Uri.parse('http://blobstore/$package/$version');
         });
         registerBackend(backend);
+        registerDartdocClient(new DartdocClientMock());
         await expectHtmlResponse(
             await issueGet('/packages/foobar_pkg/versions'));
       });
@@ -214,6 +217,7 @@ void main() {
         });
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
+        registerDartdocClient(new DartdocClientMock());
         await expectHtmlResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.1'));
       });
@@ -230,6 +234,7 @@ void main() {
         });
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
+        registerDartdocClient(new DartdocClientMock());
         await expectHtmlResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.2'),
             status: 404);

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -7,16 +7,18 @@ library pub_dartlang_org.handlers_test;
 import 'dart:async';
 
 import 'package:meta/meta.dart';
-import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/dartdoc/models.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
+import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
 Future<shelf.Response> issueGet(String path) async {
@@ -205,6 +207,7 @@ class TemplateMock implements TemplateService {
       Package package,
       bool isVersionPage,
       List<PackageVersion> versions,
+      List<DartdocEntry> dartdocEntries,
       List<Uri> versionDownloadUrls,
       PackageVersion selectedVersion,
       PackageVersion latestStableVersion,
@@ -217,7 +220,7 @@ class TemplateMock implements TemplateService {
 
   @override
   String renderPkgVersionsPage(String package, List<PackageVersion> versions,
-      List<Uri> versionDownloadUrls) {
+      List<DartdocEntry> dartdocEntries, List<Uri> versionDownloadUrls) {
     return _response;
   }
 
@@ -299,4 +302,19 @@ class AnalyzerClientMock implements AnalyzerClient {
   @override
   Future triggerAnalysis(
       String package, String version, Set<String> dependentPackages) async {}
+}
+
+class DartdocClientMock implements DartdocClient {
+  @override
+  Future<List<DartdocEntry>> getEntries(
+      String package, List<String> versions) async {
+    return versions.map((s) => null).toList();
+  }
+
+  @override
+  Future triggerDartdoc(
+      String package, String version, Set<String> dependentPackages) async {}
+
+  @override
+  Future close() async {}
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -86,6 +86,7 @@ void main() {
           testPackage,
           false,
           [testPackageVersion],
+          [okDartdocEntry],
           [Uri.parse('http://dart-example.com/')],
           testPackageVersion,
           testPackageVersion,
@@ -122,6 +123,7 @@ void main() {
           testPackage,
           true,
           [testPackageVersion],
+          [okDartdocEntry],
           [Uri.parse('http://dart-example.com/')],
           testPackageVersion,
           testPackageVersion,
@@ -158,6 +160,7 @@ void main() {
           testPackage,
           false,
           [flutterPackageVersion],
+          [okDartdocEntry],
           [Uri.parse('http://dart-example.com/')],
           flutterPackageVersion,
           flutterPackageVersion,
@@ -181,6 +184,7 @@ void main() {
           testPackage,
           false,
           [testPackageVersion],
+          [failedDartdocEntry],
           [Uri.parse('http://dart-example.com/')],
           testPackageVersion,
           testPackageVersion,
@@ -200,6 +204,7 @@ void main() {
           discontinuedPackage,
           false,
           [testPackageVersion],
+          [failedDartdocEntry],
           [Uri.parse('http://dart-example.com/')],
           testPackageVersion,
           testPackageVersion,
@@ -374,13 +379,21 @@ void main() {
     });
 
     test('package versions page', () {
-      final String html = templates.renderPkgVersionsPage('foobar', [
-        testPackageVersion,
-        devPackageVersion,
-      ], [
-        Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
-        Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
-      ]);
+      final String html = templates.renderPkgVersionsPage(
+        'foobar',
+        [
+          testPackageVersion,
+          devPackageVersion,
+        ],
+        [
+          okDartdocEntry,
+          failedDartdocEntry,
+        ],
+        [
+          Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
+          Uri.parse('https://pub.dartlang.org/mock-download-uri.tar.gz'),
+        ],
+      );
       expectGoldenFile(html, 'pkg_versions_page.html');
     });
 

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -7,8 +7,10 @@ library pub_dartlang_org.utils;
 import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/dartdoc/models.dart';
 import 'package:pub_dartlang_org/frontend/model_properties.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/shared/versions.dart' as v;
 
 class TestDelayCompletion {
   final int count;
@@ -128,3 +130,29 @@ description: 'my package description'
 dependencies:
   gcloud: any
 ''';
+
+final okDartdocEntry = new DartdocEntry(
+  uuid: 'uuid-value-ok',
+  packageName: testPackage.name,
+  packageVersion: testPackageVersion.version,
+  dartdocVersion: v.dartdocVersion,
+  flutterVersion: v.flutterVersion,
+  customizationVersion: v.customizationVersion,
+  usesFlutter: false,
+  depsResolved: true,
+  hasContent: true,
+  timestamp: new DateTime.now(),
+);
+
+final failedDartdocEntry = new DartdocEntry(
+  uuid: 'uuid-value-failed',
+  packageName: testPackage.name,
+  packageVersion: testPackageVersion.version,
+  dartdocVersion: v.dartdocVersion,
+  flutterVersion: v.flutterVersion,
+  customizationVersion: v.customizationVersion,
+  usesFlutter: false,
+  depsResolved: false,
+  hasContent: false,
+  timestamp: new DateTime.now(),
+);

--- a/app/views/pkg/versions/version_row.mustache
+++ b/app/views/pkg/versions/version_row.mustache
@@ -6,10 +6,15 @@
   <td><strong><a href="/packages/{{package}}/versions/{{version}}">{{version}}</a></strong></td>
   <td>{{short_created}}</td>
   <td class="documentation">
+    {{#dartdoc_ok}}
     <a href="{{& documentation_url}}"
        title="Go to the documentation of {{package}} {{version}}">
       <img src="{{& icons.documentation}}" alt="Go to the documentation of {{package}} {{version}}" />
     </a>
+    {{/dartdoc_ok}}
+    {{#dartdoc_failed}}
+    <a href="{{& documentation_url}}log.txt">failed</a>
+    {{/dartdoc_failed}}
   </td>
   <td class="archive">
     <a href="{{& download_url}}"


### PR DESCRIPTION
Closes #993 

https://dartlang-pub-dev.appspot.com/packages/url_launcher#-versions-tab-
https://dartlang-pub-dev.appspot.com/packages/url_launcher/versions

Unfortunately the failed ones are not yet exposed due to a bug in dartdoc_runner:
https://dartlang-pub-dev.appspot.com/packages/audio_recorder/versions
