### PR TITLE
On failed dartdoc output, redirect html pages to the log.

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -100,6 +100,10 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
     if (entry == null) {
       return notFoundHandler(request);
     }
+    if (!entry.hasContent && docFilePath.path.endsWith('.html')) {
+      return redirectResponse(
+          '/documentation/${docFilePath.package}/${docFilePath.version}/log.txt');
+    }
     final info = await dartdocBackend.getFileInfo(entry, docFilePath.path);
     if (info == null) {
       return notFoundHandler(request);


### PR DESCRIPTION
Not the best/final thing to do, but at least we don't just put a 404 out there.