### PR TITLE
robots.txt handler for dartdoc

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -21,8 +21,6 @@ Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
   final handler = {
     '/': indexHandler,
     '/debug': _debugHandler,
-    // TODO: have a proper robots.txt after we are serving content
-    '/robots.txt': rejectRobotsHandler,
   }[path];
 
   if (handler != null) {
@@ -31,6 +29,10 @@ Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
     return documentationHandler(request);
   } else if (path.startsWith('/packages/')) {
     return packageHandler(request);
+  } else if (path == '/robots.txt' && !isProductionHost(request)) {
+    return rejectRobotsHandler(request);
+  } else if (path == '/robots.txt') {
+    return robotsTxtHandler(request);
   } else {
     return notFoundHandler(request);
   }
@@ -42,6 +44,11 @@ shelf.Response _debugHandler(shelf.Request request) => debugResponse();
 /// Handles / requests
 Future<shelf.Response> indexHandler(shelf.Request request) async {
   return htmlResponse(indexHtmlContent);
+}
+
+/// Handles /robots.txt requests
+Future<shelf.Response> robotsTxtHandler(shelf.Request request) async {
+  return htmlResponse(robotsTxtContent);
 }
 
 /// Handles requests for:
@@ -164,6 +171,11 @@ DocFilePath parseRequestUri(Uri uri) {
   }
   return new DocFilePath(package, version, path);
 }
+
+const robotsTxtContent = '''
+User-agent: *
+Disallow:
+''';
 
 const indexHtmlContent = '''
 <!DOCTYPE html>

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -80,7 +80,7 @@ Future<shelf.Response> appHandler(
     return _packageHandler(request);
   } else if (path.startsWith('/doc')) {
     return _docHandler(request);
-  } else if (path == '/robots.txt' && !_isProd(request)) {
+  } else if (path == '/robots.txt' && !isProductionHost(request)) {
     return rejectRobotsHandler(request);
   } else if (path.startsWith(staticUrls.staticPath)) {
     return _staticsHandler(request);
@@ -159,7 +159,7 @@ Future<shelf.Response> _indexHandler(
     return redirectResponse(
         request.requestedUri.replace(path: newPath).toString());
   }
-  final isProd = _isProd(request);
+  final isProd = isProductionHost(request);
   String pageContent =
       isProd ? await backend.uiPackageCache?.getUIIndexPage(platform) : null;
   if (pageContent == null) {
@@ -455,7 +455,7 @@ Future<shelf.Response> _packageVersionHandlerHtmlCore(
   }
   final Stopwatch sw = new Stopwatch()..start();
   String cachedPage;
-  final bool isProd = _isProd(request);
+  final bool isProd = isProductionHost(request);
   if (isProd && backend.uiPackageCache != null) {
     cachedPage =
         await backend.uiPackageCache.getUIPackagePage(packageName, versionName);
@@ -639,9 +639,4 @@ int _pageFromUrl(Uri url) {
     } catch (_, __) {}
   }
   return pageAsInt;
-}
-
-bool _isProd(shelf.Request request) {
-  final String host = request.requestedUri.host;
-  return host == hostedDomain;
 }

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'package:shelf/shelf.dart' as shelf;
 
 import 'scheduler_stats.dart';
+import 'utils.dart';
 import 'versions.dart';
 
 const String default404NotFound = '404 Not Found';
@@ -94,4 +95,9 @@ bool isNotModified(shelf.Request request, DateTime lastModified, String etag) {
   }
 
   return false;
+}
+
+bool isProductionHost(shelf.Request request) {
+  final String host = request.requestedUri.host;
+  return host == pubHostedDomain || host == dartdocsHostedDomain;
 }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -24,9 +24,10 @@ export 'package:pana/src/maintenance.dart' show exampleFileCandidates;
 
 final Duration twoYears = const Duration(days: 2 * 365);
 
-const hostedDomain = 'pub.dartlang.org';
+const pubHostedDomain = 'pub.dartlang.org';
+const dartdocsHostedDomain = 'www.dartdocs.org';
 
-const siteRoot = 'https://$hostedDomain';
+const siteRoot = 'https://$pubHostedDomain';
 
 /// The value `X-Cloud-Trace-Context`.
 ///


### PR DESCRIPTION
I've opted for a single `isProductionHost` method for all services, but splitting them is just as good.