### PR TITLE
Help page: add short lead to pub publish command.

### DIFF
--- a/app/views/help.mustache
+++ b/app/views/help.mustache
@@ -2,6 +2,14 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 <div style="max-width: 600px">
+  <h2>Publishing a Package</h2>
+  <p>
+      <a href="https://www.dartlang.org/tools/pub">Pub</a> isn't just for using
+      other people's packages. It also allows you to share your packages with the world.
+      If you have a useful project and you want others to be able to use it, use the
+      <a href="https://www.dartlang.org/tools/pub/publishing">pub publish</a> command.
+  </p>
+
   <h2 id="search">Search</h2>
   <p>We support the following search expressions:</p>
   <ul>


### PR DESCRIPTION
Closes #1056.

Lead text is the same as the first paragraph on https://www.dartlang.org/tools/pub/publishing

/cc @mit-mit 