### PR TITLE
Exclude dart:* libraries which are generated for Flutter packages.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -26,6 +26,19 @@ final Uuid _uuid = new Uuid();
 const statusFilePath = 'status.json';
 const buildLogFilePath = 'log.txt';
 
+const _excludedLibraries = const <String>[
+  'dart:async',
+  'dart:collection',
+  'dart:convert',
+  'dart:core',
+  'dart:developer',
+  'dart:io',
+  'dart:isolate',
+  'dart:math',
+  'dart:typed_data',
+  'dart:ui',
+];
+
 class DartdocRunner implements TaskRunner {
   @override
   Future<TaskTargetStatus> checkTargetStatus(Task task) {
@@ -137,6 +150,8 @@ class DartdocRunner implements TaskRunner {
         _hostedUrl,
         '--rel-canonical-prefix',
         p.join(_hostedUrl, 'documentation', task.package, task.version),
+        '--exclude',
+        _excludedLibraries.join(','),
       ],
       workingDirectory: pkgPath,
       environment: environment,


### PR DESCRIPTION
It takes up more resources to upload and store these, without much benefit, e.g.:
https://dartdoc-dot-dartlang-pub-dev.appspot.com/documentation/url_launcher/2.0.1/
