### PR TITLE
Refactor dartdoc storage path utils, in preparation of deduplicating static assets.

### DIFF
--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -15,6 +15,8 @@ import '../shared/task_scheduler.dart' show TaskTargetStatus;
 import '../shared/utils.dart' show isNewer;
 import '../shared/versions.dart' as versions;
 
+import 'storage_path.dart' as storage_path;
+
 part 'models.g.dart';
 
 final Duration entryUpdateThreshold = const Duration(days: 90);
@@ -66,20 +68,26 @@ class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
 
   /// The path of the status while the upload is in progress
   String get inProgressPrefix =>
-      DartdocEntryPaths.inProgressPrefix(packageName, packageVersion);
+      storage_path.inProgressPrefix(packageName, packageVersion);
 
   /// The path of the particular JSON status while upload is in progress
-  String get inProgressPath => '$inProgressPrefix/$uuid.json';
+  String get inProgressObjectName =>
+      storage_path.inProgressObjectName(packageName, packageVersion, uuid);
 
   /// The path prefix where all of the entry JSON files are stored.
   String get entryPrefix =>
-      DartdocEntryPaths.entryPrefix(packageName, packageVersion);
+      storage_path.entryPrefix(packageName, packageVersion);
 
   /// The path of the particular JSON entry after the upload was completed.
-  String get entryPath => '$entryPrefix/$uuid.json';
+  String get entryObjectName =>
+      storage_path.entryObjectName(packageName, packageVersion, uuid);
 
   /// The path prefix where the content of this instance is stored.
-  String get contentPrefix => '$packageName/$packageVersion/content/$uuid';
+  String get contentPrefix =>
+      storage_path.contentPrefix(packageName, packageVersion, uuid);
+
+  String objectName(String relativePath) => storage_path.contentObjectName(
+      packageName, packageVersion, uuid, relativePath);
 
   List<int> asBytes() => UTF8.encode(JSON.encode(this.toJson()));
 
@@ -145,14 +153,6 @@ class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
     // Older entry seems to be better.
     return true;
   }
-}
-
-abstract class DartdocEntryPaths {
-  static String inProgressPrefix(String packageName, String packageVersion) =>
-      '$packageName/$packageVersion/in-progress';
-
-  static String entryPrefix(String packageName, String packageVersion) =>
-      '$packageName/$packageVersion/entry';
 }
 
 @JsonSerializable()

--- a/app/lib/dartdoc/storage_path.dart
+++ b/app/lib/dartdoc/storage_path.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+
+const _generatedStaticAssetPaths = const <String>['static-assets'];
+
+// Storage contains package data in a form of /package/version/...
+// This path contains '-' and is an invalid package name, safe of conflicts.
+const _storageSharedAssetPrefix = 'shared-assets';
+
+/// Whether the generated file can be moved to the shared assets.
+bool isSharedAsset(String relativePath) {
+  for (String parent in _generatedStaticAssetPaths) {
+    if (p.isWithin(parent, relativePath)) return true;
+  }
+  return false;
+}
+
+/// The storage path of a shared generated file.
+String sharedAssetObjectName(String dartdocVersion, String relativePath) =>
+    p.join(_storageSharedAssetPrefix, 'dartdoc', dartdocVersion, relativePath);
+
+/// Entry prefix for uploads in progress.
+String inProgressPrefix(String packageName, String packageVersion) =>
+    '$packageName/$packageVersion/in-progress';
+
+/// ObjectName of the DartdocEntry for uploads in progress.
+String inProgressObjectName(
+        String packageName, String packageVersion, String uuid) =>
+    '${inProgressPrefix(packageName, packageVersion)}/$uuid.json';
+
+/// Entry prefix for completed uploads.
+String entryPrefix(String packageName, String packageVersion) =>
+    '$packageName/$packageVersion/entry';
+
+/// ObjectName of the DartdocEntry for completed uploads.
+String entryObjectName(
+        String packageName, String packageVersion, String uuid) =>
+    '${entryPrefix(packageName, packageVersion)}/$uuid.json';
+
+/// Content path prefix.
+String contentPrefix(String packageName, String packageVersion, String uuid) =>
+    '$packageName/$packageVersion/content/$uuid';
+
+/// ObjectName of the generated content.
+String contentObjectName(String packageName, String packageVersion, String uuid,
+    String relativePath) {
+  return p.join(contentPrefix(packageName, packageVersion, uuid), relativePath);
+}

--- a/app/test/dartdoc/storage_path_test.dart
+++ b/app/test/dartdoc/storage_path_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/dartdoc/models.dart';
+import 'package:pub_dartlang_org/dartdoc/storage_path.dart';
+
+void main() {
+  test('shared assets', () {
+    expect(isSharedAsset('static-assets/css/style.css'), isTrue);
+    expect(isSharedAsset('static-assets/whatever.js'), isTrue);
+    expect(isSharedAsset('static-files/style.css'), isFalse);
+  });
+
+  test('shared asset ObjectName', () {
+    expect(sharedAssetObjectName('0.16.0', 'static-assets/style.css'),
+        'shared-assets/dartdoc/0.16.0/static-assets/style.css');
+  });
+
+  test('entry paths', () {
+    final entry = new DartdocEntry(
+      uuid: '12345678-abcdef10',
+      packageName: 'pkg_foo',
+      packageVersion: '1.2.3',
+      usesFlutter: false,
+      dartdocVersion: '0.16.0',
+      flutterVersion: '0.1.6',
+      customizationVersion: '0.0.1',
+      timestamp: new DateTime(2018, 03, 08),
+      depsResolved: true,
+      hasContent: true,
+    );
+    expect(entry.inProgressPrefix, 'pkg_foo/1.2.3/in-progress');
+    expect(entry.inProgressObjectName,
+        'pkg_foo/1.2.3/in-progress/12345678-abcdef10.json');
+    expect(entry.entryPrefix, 'pkg_foo/1.2.3/entry');
+    expect(entry.entryObjectName, 'pkg_foo/1.2.3/entry/12345678-abcdef10.json');
+    expect(entry.contentPrefix, 'pkg_foo/1.2.3/content/12345678-abcdef10');
+    expect(entry.objectName('static-assets/css/style.css'),
+        'pkg_foo/1.2.3/content/12345678-abcdef10/static-assets/css/style.css');
+    expect(entry.objectName('index.html'),
+        'pkg_foo/1.2.3/content/12345678-abcdef10/index.html');
+    expect(entry.objectName('library/index.html'),
+        'pkg_foo/1.2.3/content/12345678-abcdef10/library/index.html');
+  });
+}


### PR DESCRIPTION
Also added the proposed object name prefix for static assets:
`shared-assets/dartdoc/0.16.0/static-assets/style.css`

#1071 