### PR TITLE
Track runtimeVersion in analyzer.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -110,6 +110,7 @@ class AnalysisBackend {
         packageVersion: entry.packageVersion,
         analysis: entry.analysis,
         timestamp: entry.timestamp,
+        runtimeVersion: entry.runtimeVersion,
         panaVersion: entry.panaVersion,
         flutterVersion: entry.flutterVersion,
         analysisStatus: entry.analysisStatus,
@@ -138,8 +139,7 @@ class AnalysisBackend {
       PackageVersionAnalysis version = parents[1];
       final isNewVersion = version == null;
       final isRegression = version != null &&
-          version.panaVersion == panaVersion &&
-          version.flutterVersion == flutterVersion &&
+          version.runtimeVersion == runtimeVersion &&
           (analysisStatusLevel(version.analysisStatus) >
               analysisStatusLevel(analysis.analysisStatus));
       final hasIdenticalHash = version != null &&
@@ -241,16 +241,15 @@ class AnalysisBackend {
     }
 
     // Is current analysis version newer?
-    if (isNewer(versionAnalysis.semanticPanaVersion, semanticPanaVersion) ||
-        isNewer(
-            versionAnalysis.semanticFlutterVersion, semanticFlutterVersion)) {
+    if (isNewer(
+        versionAnalysis.semanticRuntimeVersion, semanticRuntimeVersion)) {
+      // TODO: skip re-analysis of non-Flutter packages if only the flutterVersion changed
       return new TaskTargetStatus.ok();
     }
 
     // Is current analysis version obsolete?
-    if (isNewer(semanticPanaVersion, versionAnalysis.semanticPanaVersion) ||
-        isNewer(
-            semanticFlutterVersion, versionAnalysis.semanticFlutterVersion)) {
+    if (isNewer(
+        semanticRuntimeVersion, versionAnalysis.semanticRuntimeVersion)) {
       // existing analysis version is newer, current analyzer is obsolete?
       // TODO: turn off task polling on this instance
       _logger.warning(

--- a/app/lib/analyzer/models.dart
+++ b/app/lib/analyzer/models.dart
@@ -64,13 +64,16 @@ class PackageVersionAnalysis extends db.ExpandoModel {
   DateTime analysisTimestamp;
 
   @db.StringProperty()
+  String runtimeVersion;
+
+  @db.StringProperty()
   String panaVersion;
 
   @db.StringProperty()
   String flutterVersion;
 
-  Version get semanticPanaVersion => new Version.parse(panaVersion);
-  Version get semanticFlutterVersion => new Version.parse(flutterVersion);
+  Version get semanticRuntimeVersion =>
+      new Version.parse(runtimeVersion ?? versions.analyzerRuntimeEpoch);
 
   @AnalysisStatusProperty()
   AnalysisStatus analysisStatus;
@@ -85,6 +88,7 @@ class PackageVersionAnalysis extends db.ExpandoModel {
     id = analysis.packageVersion;
     latestAnalysisKey = analysis.key;
     analysisTimestamp = analysis.timestamp;
+    runtimeVersion = analysis.runtimeVersion;
     panaVersion = analysis.panaVersion;
     flutterVersion = analysis.flutterVersion;
     analysisStatus = analysis.analysisStatus;
@@ -93,13 +97,13 @@ class PackageVersionAnalysis extends db.ExpandoModel {
 
   /// Returns true if there was a change that warrants an update in Datastore.
   bool updateWithLatest(Analysis analysis) {
-    if (isNewer(analysis.semanticPanaVersion, semanticPanaVersion) ||
-        isNewer(analysis.semanticFlutterVersion, semanticFlutterVersion)) {
+    if (isNewer(analysis.semanticRuntimeVersion, semanticRuntimeVersion)) {
       // the new analysis' version is older, result probably obsolete
       return false;
     }
     latestAnalysisKey = analysis.key;
     analysisTimestamp = analysis.timestamp;
+    runtimeVersion = analysis.runtimeVersion;
     panaVersion = analysis.panaVersion;
     flutterVersion = analysis.flutterVersion;
     analysisStatus = analysis.analysisStatus;
@@ -129,13 +133,16 @@ class Analysis extends db.ExpandoModel {
   // how its execution went, and the raw output.
 
   @db.StringProperty()
+  String runtimeVersion;
+
+  @db.StringProperty()
   String panaVersion;
 
   @db.StringProperty()
   String flutterVersion;
 
-  Version get semanticPanaVersion => new Version.parse(panaVersion);
-  Version get semanticFlutterVersion => new Version.parse(flutterVersion);
+  Version get semanticRuntimeVersion =>
+      new Version.parse(runtimeVersion ?? versions.analyzerRuntimeEpoch);
 
   @AnalysisStatusProperty()
   AnalysisStatus analysisStatus;
@@ -158,6 +165,7 @@ class Analysis extends db.ExpandoModel {
         .append(PackageAnalysis, id: packageName)
         .append(PackageVersionAnalysis, id: packageVersion);
     timestamp = new DateTime.now().toUtc();
+    runtimeVersion = versions.runtimeVersion;
     panaVersion = versions.panaVersion;
     flutterVersion = versions.flutterVersion;
   }

--- a/app/lib/analyzer/task_sources.dart
+++ b/app/lib/analyzer/task_sources.dart
@@ -9,6 +9,7 @@ import 'package:gcloud/db.dart';
 import '../shared/analyzer_service.dart' show AnalysisStatus;
 import '../shared/task_scheduler.dart';
 import '../shared/task_sources.dart';
+import '../shared/utils.dart';
 import '../shared/versions.dart';
 
 import 'backend.dart' show reanalyzeThreshold;
@@ -53,8 +54,7 @@ class AnalyzerDatastoreHistoryTaskSource extends DatastoreHistoryTaskSource {
     final PackageVersionAnalysis version = list.first;
     if (version == null) return true;
 
-    if (version.panaVersion != panaVersion ||
-        version.flutterVersion != flutterVersion) {
+    if (isNewer(version.semanticRuntimeVersion, semanticRuntimeVersion)) {
       return true;
     }
 

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: annotate_overrides
 
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 import 'package:pub_dartlang_org/search/scoring.dart'
     show calculateOverallScore;
 
@@ -74,6 +75,7 @@ class AnalysisData extends Object with _$AnalysisDataSerializerMixin {
   final String packageVersion;
   final int analysis;
   final DateTime timestamp;
+  final String runtimeVersion;
   final String panaVersion;
   final String flutterVersion;
   final AnalysisStatus analysisStatus;
@@ -81,15 +83,16 @@ class AnalysisData extends Object with _$AnalysisDataSerializerMixin {
   final Map analysisContent;
 
   AnalysisData({
-    this.packageName,
-    this.packageVersion,
-    this.analysis,
-    this.timestamp,
-    this.panaVersion,
-    this.flutterVersion,
-    this.analysisStatus,
-    this.analysisContent,
-    this.maintenanceScore,
+    @required this.packageName,
+    @required this.packageVersion,
+    @required this.analysis,
+    @required this.timestamp,
+    @required this.runtimeVersion,
+    @required this.panaVersion,
+    @required this.flutterVersion,
+    @required this.analysisStatus,
+    @required this.analysisContent,
+    @required this.maintenanceScore,
   });
 
   factory AnalysisData.fromJson(Map json) => _$AnalysisDataFromJson(json);

--- a/app/lib/shared/analyzer_service.g.dart
+++ b/app/lib/shared/analyzer_service.g.dart
@@ -20,6 +20,7 @@ AnalysisData _$AnalysisDataFromJson(Map<String, dynamic> json) =>
         timestamp: json['timestamp'] == null
             ? null
             : DateTime.parse(json['timestamp'] as String),
+        runtimeVersion: json['runtimeVersion'] as String,
         panaVersion: json['panaVersion'] as String,
         flutterVersion: json['flutterVersion'] as String,
         analysisStatus: json['analysisStatus'] == null
@@ -34,6 +35,7 @@ abstract class _$AnalysisDataSerializerMixin {
   String get packageVersion;
   int get analysis;
   DateTime get timestamp;
+  String get runtimeVersion;
   String get panaVersion;
   String get flutterVersion;
   AnalysisStatus get analysisStatus;
@@ -44,6 +46,7 @@ abstract class _$AnalysisDataSerializerMixin {
         'packageVersion': packageVersion,
         'analysis': analysis,
         'timestamp': timestamp?.toIso8601String(),
+        'runtimeVersion': runtimeVersion,
         'panaVersion': panaVersion,
         'flutterVersion': flutterVersion,
         'analysisStatus': analysisStatus == null

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -35,6 +35,11 @@ final Version semanticCustomizationVersion =
 // Version that control the dartdoc serving.
 final _dartdocServingRuntime = new Version.parse('2018.3.8');
 
+// Version that marks the default runtime version for analyzer entries created
+// before the runtime version was tracked.
+// TODO: remove hardcoded runtime version after the deploy is solid
+final analyzerRuntimeEpoch = '2018.3.8';
+
 // Version that marks the default runtime version for dartdoc entries created
 // before the runtime version was tracked.
 // TODO: remove hardcoded runtime version after the deploy is solid

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -63,6 +63,7 @@ void main() {
           'packageVersion': '1.2.3',
           'analysis': 242345,
           'timestamp': '2017-06-26T12:48:00.000',
+          'runtimeVersion': '2018.3.8',
           'panaVersion': '0.2.0',
           'flutterVersion': '0.0.11',
           'analysisStatus': 'success',
@@ -79,6 +80,7 @@ void main() {
               'packageVersion': '1.2.3',
               'analysis': 242345,
               'timestamp': '2017-06-26T12:48:00.000',
+              'runtimeVersion': '2018.3.8',
               'panaVersion': '0.2.0',
               'flutterVersion': '0.0.11',
               'analysisStatus': 'success',
@@ -96,6 +98,7 @@ void main() {
               'packageVersion': '1.2.3',
               'analysis': 242345,
               'timestamp': '2017-06-26T12:48:00.000',
+              'runtimeVersion': '2018.3.8',
               'panaVersion': '0.2.0',
               'flutterVersion': '0.0.11',
               'analysisStatus': 'success',
@@ -152,6 +155,7 @@ class MockAnalysisBackend implements AnalysisBackend {
         packageVersion: analysis.packageVersion,
         analysis: analysis.analysis,
         timestamp: analysis.timestamp,
+        runtimeVersion: analysis.runtimeVersion,
         panaVersion: analysis.panaVersion,
         flutterVersion: analysis.flutterVersion,
         analysisStatus: analysis.analysisStatus,
@@ -182,6 +186,7 @@ final Analysis testAnalysis = new Analysis()
   ..packageVersion = '1.2.3'
   ..id = 242345
   ..analysisStatus = AnalysisStatus.success
+  ..runtimeVersion = '2018.3.8'
   ..panaVersion = '0.2.0'
   ..flutterVersion = '0.0.11'
   ..timestamp = new DateTime(2017, 06, 26, 12, 48, 00)

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -288,12 +288,16 @@ void main() {
           null,
           null,
           new AnalysisView(new AnalysisData(
+            analysis: 1,
             packageName: 'foo',
             packageVersion: '1.0.0',
+            runtimeVersion: '2018.3.8',
             panaVersion: '0.8.0',
             flutterVersion: '0.0.20',
             analysisStatus: AnalysisStatus.aborted,
             timestamp: new DateTime(2017, 12, 18, 14, 26, 00),
+            maintenanceScore: null,
+            analysisContent: null,
           )));
       expectGoldenFile(html, 'analysis_tab_aborted.html', isFragment: true);
     });
@@ -304,12 +308,16 @@ void main() {
           null,
           null,
           new AnalysisView(new AnalysisData(
+            analysis: 1,
             packageName: 'foo',
             packageVersion: '1.0.0',
+            runtimeVersion: '2018.3.8',
             panaVersion: '0.8.0',
             flutterVersion: '0.0.20',
             analysisStatus: AnalysisStatus.outdated,
             timestamp: new DateTime(2017, 12, 18, 14, 26, 00),
+            maintenanceScore: null,
+            analysisContent: null,
           )));
       expectGoldenFile(html, 'analysis_tab_outdated.html', isFragment: true);
     });


### PR DESCRIPTION
- #1079
- added a TODO for not running on non-Flutter packages when only `flutterVersion` changes, as I wanted to do `usesFlutter` tracking in a separate change.