### PR TITLE
Update memcache dependency.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -336,7 +336,7 @@ packages:
       name: memcache
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+2"
+    version: "0.2.2"
   meta:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   json_annotation: '^0.2.0'
   logging: '>=0.9.3 <1.0.0'
   markdown: '>=1.1.0 <1.2.0'
-  memcache: '^0.2.1+1'
+  memcache: '^0.2.2'
   meta: ^1.1.2
   mime: '>=0.9.3 <0.10.0'
   mustache: ^1.0.0


### PR DESCRIPTION
This fixes a crash issue when an instance loses its memcache
connection.

Fixes #1098