### PR TITLE
Fix global dartdoc's pub cache environment

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -91,9 +91,8 @@ class DartdocRunner implements TaskRunner {
 
       bool hasContent = false;
       if (depsResolved) {
-        final dartdocEnv = {'PUB_CACHE': pubCacheDir};
-        hasContent = await _generateDocs(
-            task, pkgPath, outputDir, dartdocEnv, logFileOutput);
+        hasContent =
+            await _generateDocs(task, pkgPath, outputDir, logFileOutput);
       }
 
       if (hasContent) {
@@ -153,7 +152,6 @@ class DartdocRunner implements TaskRunner {
     Task task,
     String pkgPath,
     String outputDir,
-    Map<String, String> environment,
     StringBuffer logFileOutput,
   ) async {
     logFileOutput.write('Running dartdoc:\n');
@@ -173,7 +171,6 @@ class DartdocRunner implements TaskRunner {
         _excludedLibraries.join(','),
       ],
       workingDirectory: pkgPath,
-      environment: environment,
     );
     _appendLog(logFileOutput, pr);
 


### PR DESCRIPTION
If `PUB_CACHE` is set for a non-default value, `pub` won't find the activated global dartdoc, and running the `pub global run dartdoc` will fail. Without the explicit `PUB_CACHE` override, it finds it correctly.

As we are after the `pub upgrade`, it is safe to ignore `PUB_CACHE` for dartdoc, it won't use it anyway.
