### PR TITLE
Upload and server shared files from a shared directory path.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -62,6 +62,14 @@ class DartdocBackend {
     Future upload(File file) async {
       final relativePath = p.relative(file.path, from: dir.path);
       final objectName = entry.objectName(relativePath);
+      final isShared = storage_path.isSharedAsset(relativePath);
+      if (isShared) {
+        final info = await getFileInfo(entry, relativePath);
+        if (info != null) {
+          _logger.fine('$objectName has been already uploaded.');
+          return;
+        }
+      }
       _logger.fine('Uploading to $objectName...');
       try {
         final sink =

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -84,8 +84,15 @@ class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
   String get contentPrefix =>
       storage_path.contentPrefix(packageName, packageVersion, uuid);
 
-  String objectName(String relativePath) => storage_path.contentObjectName(
-      packageName, packageVersion, uuid, relativePath);
+  String objectName(String relativePath) {
+    final isShared = storage_path.isSharedAsset(relativePath);
+    if (isShared) {
+      return storage_path.sharedAssetObjectName(dartdocVersion, relativePath);
+    } else {
+      return storage_path.contentObjectName(
+          packageName, packageVersion, uuid, relativePath);
+    }
+  }
 
   List<int> asBytes() => utf8.encode(json.encode(this.toJson()));
 

--- a/app/test/dartdoc/storage_path_test.dart
+++ b/app/test/dartdoc/storage_path_test.dart
@@ -41,7 +41,7 @@ void main() {
     expect(entry.entryObjectName, 'pkg_foo/1.2.3/entry/12345678-abcdef10.json');
     expect(entry.contentPrefix, 'pkg_foo/1.2.3/content/12345678-abcdef10');
     expect(entry.objectName('static-assets/css/style.css'),
-        'pkg_foo/1.2.3/content/12345678-abcdef10/static-assets/css/style.css');
+        'shared-assets/dartdoc/0.16.0/static-assets/css/style.css');
     expect(entry.objectName('index.html'),
         'pkg_foo/1.2.3/content/12345678-abcdef10/index.html');
     expect(entry.objectName('library/index.html'),


### PR DESCRIPTION
Closes #1071.

All the related methods use the `DartdocEntry.objectName` to look up the stored path of a file, upload need to be tuned in order to prevent duplicate uploads.