### PR TITLE
Redirect /latest URL to the latest version.

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -154,7 +154,7 @@ DocFilePath parseRequestUri(Uri uri) {
   }
 
   final String version = uri.pathSegments[2];
-  if (version.isEmpty) {
+  if (version.isEmpty || version == 'latest') {
     return new DocFilePath(package, null, null);
   }
   if (segmentCount == 3) {


### PR DESCRIPTION
I've found that e.g. `aqueduct` references such url: https://www.dartdocs.org/documentation/aqueduct/latest