### PR TITLE
Cleanup error page template.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -610,7 +610,7 @@ shelf.Response _redirectToFlutterPackages(shelf.Request request) =>
 shelf.Response _formattedNotFoundHandler(shelf.Request request) {
   final message = 'The path \'${request.requestedUri.path}\' was not found.';
   return htmlResponse(
-    templateService.renderErrorPage(default404NotFound, message, null),
+    templateService.renderErrorPage(default404NotFound, message),
     status: 404,
   );
 }

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -548,15 +548,14 @@ class TemplateService {
   }
 
   /// Renders the `views/index.mustache` template.
-  String renderErrorPage(String status, String message, String traceback) {
+  String renderErrorPage(String title, String message) {
     final values = {
-      'status': status,
+      'title': title,
       'message': message,
-      'traceback': traceback
     };
     final String content = _renderTemplate('error', values);
     return renderLayoutPage(PageType.package, content,
-        title: 'Error $status', includeSurvey: false);
+        title: title, includeSurvey: false);
   }
 
   /// Renders the `views/help.mustache` template.

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -14,8 +14,8 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@dart_lang" />
   <meta property="og:site_name" content="Dart Packages" />
-  <title>Error error_status</title>
-  <meta property="og:title" content="Error error_status" />
+  <title>error_title</title>
+  <meta property="og:title" content="error_title" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="/static/img/dart-logo-400x400.png" />
   <meta property="og:image" content="/static/img/dart-logo-400x400.png" />
@@ -71,9 +71,8 @@
 
 <main>
   
-<h1>Error error_status</h1>
-<p class="error-message">error_message</p>
-<pre class="traceback">error_traceback</pre>
+<h1>error_title</h1>
+<p>error_message</p>
 
 </main>
 

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -156,7 +156,7 @@ class TemplateMock implements TemplateService {
   }
 
   @override
-  String renderErrorPage(String status, String message, String traceback) {
+  String renderErrorPage(String title, String message) {
     return _response;
   }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -411,8 +411,8 @@ void main() {
     });
 
     test('error page', () {
-      final String html = templates.renderErrorPage(
-          'error_status', 'error_message', 'error_traceback');
+      final String html =
+          templates.renderErrorPage('error_title', 'error_message');
       expectGoldenFile(html, 'error_page.html');
     });
 

--- a/app/views/error.mustache
+++ b/app/views/error.mustache
@@ -2,8 +2,5 @@
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
 
-<h1>Error {{status}}</h1>
-<p class="error-message">{{message}}</p>
-{{#traceback}}
-<pre class="traceback">{{traceback}}</pre>
-{{/traceback}}
+<h1>{{title}}</h1>
+<p>{{message}}</p>


### PR DESCRIPTION
I wanted to separate this change from the "better 404" pages and the "graceful service outage handling" issues.

- `traceback` is not used anymore
- using `title` for better consistency
