### PR TITLE
Serve documentation on pub.dartlang.org

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -25,7 +25,7 @@ Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
 
   if (handler != null) {
     return handler(request);
-  } else if (path.startsWith('/documentation/')) {
+  } else if (path.startsWith('/documentation')) {
     return documentationHandler(request);
   } else if (path.startsWith('/packages/')) {
     return packageHandler(request);
@@ -83,7 +83,7 @@ Future<shelf.Response> packageHandler(shelf.Request request) async {
 Future<shelf.Response> documentationHandler(shelf.Request request) async {
   final docFilePath = parseRequestUri(request.requestedUri);
   if (docFilePath == null) {
-    return notFoundHandler(request);
+    return indexHandler(request);
   }
   if (redirectDartdocPages.containsKey(docFilePath.package)) {
     return redirectResponse(redirectDartdocPages[docFilePath.package]);

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -197,7 +197,7 @@ class PackageVersion extends db.ExpandoModel {
   String get dartdocsUrl {
     final name = Uri.encodeComponent(packageKey.id);
     final version = Uri.encodeComponent(id);
-    return 'http://www.dartdocs.org/documentation/$name/$version/';
+    return 'https://pub.dartlang.org/documentation/$name/$version/';
   }
 
   String get documentation {

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -155,7 +155,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/"
        title="Go to the documentation of foobar_pkg 0.1.1">
       <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
     </a>
@@ -294,7 +294,7 @@ Learn more about <a href="/help#scoring">scoring</a>.
       <a class="link" href="http://hans.juergen.com">hans.juergen.com</a>
 
       <h3 class="title">Documentation</h3>
-      <a class="link" href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+      <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/">pub.dartlang.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
     <p><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> hans@juergen.com</span></p>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -156,7 +156,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/log.txt">failed</a>
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/log.txt">failed</a>
   </td>
   <td class="archive">
     <a href="http://dart-example.com/"
@@ -187,7 +187,7 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="http://hans.juergen.com">hans.juergen.com</a>
 
       <h3 class="title">Documentation</h3>
-      <a class="link" href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+      <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/">pub.dartlang.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
     <p><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> hans@juergen.com</span></p>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -146,7 +146,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2015</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/"
        title="Go to the documentation of foobar_pkg 0.1.1">
       <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
     </a>
@@ -256,7 +256,7 @@ Learn more about <a href="/help#scoring">scoring</a>.
       <a class="link" href="http://hans.juergen.com">hans.juergen.com</a>
 
       <h3 class="title">Documentation</h3>
-      <a class="link" href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+      <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/">pub.dartlang.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
     <p><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> hans@juergen.com</span></p>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -155,7 +155,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/log.txt">failed</a>
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/log.txt">failed</a>
   </td>
   <td class="archive">
     <a href="http://dart-example.com/"
@@ -189,7 +189,7 @@ import 'package:foobar_pkg/foolib.dart';
       <a class="link" href="http://hans.juergen.com">hans.juergen.com</a>
 
       <h3 class="title">Documentation</h3>
-      <a class="link" href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+      <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/">pub.dartlang.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
     <p><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> hans@juergen.com</span></p>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -157,7 +157,7 @@ import 'package:foobar_pkg/foolib.dart';
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/"
        title="Go to the documentation of foobar_pkg 0.1.1">
       <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
     </a>
@@ -296,7 +296,7 @@ Learn more about <a href="/help#scoring">scoring</a>.
       <a class="link" href="http://hans.juergen.com">hans.juergen.com</a>
 
       <h3 class="title">Documentation</h3>
-      <a class="link" href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/">www.dartdocs.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
+      <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/">pub.dartlang.org&#x2F;documentation&#x2F;foobar_pkg&#x2F;0.1.1&#x2F;</a>
 
     <h3 class="title">Uploader</h3>
     <p><span class="author"><a href="mailto:hans@juergen.com" title="Email hans@juergen.com"><i class="email-icon"></i></a> <a href="/packages?q=email%3Ahans%40juergen.com" title="Search packages with hans@juergen.com" rel="nofollow"><i class="search-icon"></i></a> hans@juergen.com</span></p>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -90,7 +90,7 @@
   <td><strong><a href="/packages/foobar_pkg/versions/0.1.1">0.1.1</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.1.1/"
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1/"
        title="Go to the documentation of foobar_pkg 0.1.1">
       <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1" />
     </a>
@@ -122,7 +122,7 @@
   <td><strong><a href="/packages/foobar_pkg/versions/0.2.0-dev">0.2.0-dev</a></strong></td>
   <td>Jan 1, 2014</td>
   <td class="documentation">
-    <a href="http://www.dartdocs.org/documentation/foobar_pkg/0.2.0-dev/log.txt">failed</a>
+    <a href="https://pub.dartlang.org/documentation/foobar_pkg/0.2.0-dev/log.txt">failed</a>
   </td>
   <td class="archive">
     <a href="https://pub.dartlang.org/mock-download-uri.tar.gz"

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,0 +1,8 @@
+dispatch:
+  - url: "*.dartdocs.org/*"
+    service: dartdoc
+  - url: "pub.dartlang.org/documentation"
+    service: dartdoc
+  - url: "pub.dartlang.org/documentation/*"
+    service: dartdoc
+


### PR DESCRIPTION
Related to #227. In addition to (eventually) switching dartdocs.org over
to be hosted on pub, we would also like to serve the generated docs on
the pub.dartlang.org domain.

This change:

 * Adds dispatch mapping for dartdocs.org and
 pub.dartlang.org/documentation, mapping to the dartdoc service.
 * Makes pub.dartlang.org/documentation serve the dartdoc index page.
 * Switches the documentation link on the package pages to
 pub.dartlang.org.