### PR TITLE
Initialize dartdoc for analyzer service.

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -24,7 +24,8 @@ final Logger logger = new Logger('pub.analyzer');
 Future main() async {
   useLoggingPackageAdaptor();
 
-  withAppEngineServices(() async {
+  await initDartdoc(logger);
+  await withAppEngineServices(() async {
     initFlutterSdk(logger)
         .then((_) => startIsolates(logger, _runSchedulerWrapper));
     _registerServices();


### PR DESCRIPTION
`pana` will eventually try to run dartdoc for checking if there is documentation on the API methods, this will make sure the analyzer service has in installed.