### PR TITLE
Placeholder for all the URL- and domain name related methods.

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// TODO: lib/dartdoc/customization.dart
+
+// TODO: lib/dartdoc/dartdoc_runner.dart
+
+// TODO: lib/dartdoc/handlers.dart
+
+// TODO: lib/frontend/backend.dart
+
+// TODO: lib/frontend/handlers.dart
+
+// TODO: lib/frontend/models.dart
+
+// TODO: lib/frontend/service_utils.dart
+
+// TODO: lib/frontend/upload_signer_service.dart
+
+// TODO: lib/shared/analyzer_client.dart
+
+// TODO: lib/shared/configuration.dart
+
+// TODO: lib/shared/dartdoc_client.dart
+
+// TODO: lib/shared/notification.dart
+
+// TODO: lib/shared/search_client.dart
+
+// TODO: lib/shared/utils.dart
+
+// TODO: test/analyzer/handlers_test_utils.dart
+
+// TODO: test/dartdoc/handlers_test.dart
+
+// TODO: test/frontend/handlers_test.dart
+
+// TODO: test/frontend/tarball_storage_namer_test.dart
+
+// TODO: test/search/handlers_test_utils.dart


### PR DESCRIPTION
I find it hard to track where to go if I need to check a URL pattern or introduce a new one, hence the file. I've filled it with TODO placeholders, as there are many pending PRs that would cause merge conflicts, it will be easier to migrate to this util in a case-by-case basis.