### PR TITLE
Redirect on not found package or version.

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -12,6 +12,8 @@
 
 // TODO: lib/frontend/handlers.dart
 
+String versionsTabUrl(String package) => '/packages/$package#-versions-tab-';
+
 // TODO: lib/frontend/models.dart
 
 // TODO: lib/frontend/service_utils.dart

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -177,8 +177,8 @@ void main() {
           return null;
         });
         registerBackend(backend);
-        await expectHtmlResponse(await issueGet('/packages/foobar_pkg'),
-            status: 404);
+        await expectRedirectResponse(
+            await issueGet('/packages/foobar_pkg'), '/packages?q=foobar_pkg');
       });
 
       tScopedTest('/packages/foobar_pkg/versions - found', () async {
@@ -200,9 +200,9 @@ void main() {
           return [];
         });
         registerBackend(backend);
-        await expectHtmlResponse(
+        await expectRedirectResponse(
             await issueGet('/packages/foobar_pkg/versions'),
-            status: 404);
+            '/packages?q=foobar_pkg');
       });
 
       tScopedTest('/packages/foobar_pkg/versions/0.1.1 - found', () async {
@@ -235,9 +235,9 @@ void main() {
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
         registerDartdocClient(new DartdocClientMock());
-        await expectHtmlResponse(
+        await expectRedirectResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.2'),
-            status: 404);
+            '/packages/foobar_pkg#-versions-tab-');
       });
 
       tScopedTest('/packages/flutter - redirect', () async {


### PR DESCRIPTION
#1115 

- not found package gets redirected to the search page with the `packageName` as query text
- not found version gets redirected to the package's latest stable page, to the versions tab
