### PR TITLE
Cleanup of isolate code: typed entry point, explicit worker/frontend separation.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -29,18 +29,16 @@ import 'package:pub_dartlang_org/search/updater.dart';
 final Logger _logger = new Logger('pub.search');
 
 Future main() async {
-  await startIsolates(_logger, _mainWrapper);
+  // TODO: use a "frontend" isolate
+  await startIsolates(logger: _logger, workerEntryPoint: _main);
 }
 
-// Remove after https://github.com/dart-lang/sdk/issues/30755 lands.
-void _mainWrapper(message) => _main(message);
-
-void _main(List<SendPort> sendPorts) {
+void _main(WorkerEntryMessage message) {
   useLoggingPackageAdaptor();
 
-  final SendPort mainSendPort = sendPorts[0];
   final ReceivePort taskReceivePort = new ReceivePort();
-  mainSendPort.send(taskReceivePort.sendPort);
+  message.protocolSendPort
+      .send(new WorkerProtocolMessage(taskSendPort: taskReceivePort.sendPort));
 
   withAppEngineServices(() async {
     final Bucket popularityBucket = await getOrCreateBucket(

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:io';
-import 'dart:math' show max;
 
 import 'package:googleapis_auth/auth.dart' as auth;
 
@@ -93,14 +92,16 @@ class EnvConfig {
   final String gcloudKey;
   final String gcloudProject;
   final String flutterSdkDir;
-  final int isolateCount;
+  final int frontendCount;
+  final int workerCount;
 
   EnvConfig._(
     this.gaeService,
     this.gcloudProject,
     this.gcloudKey,
     this.flutterSdkDir,
-    this.isolateCount,
+    this.frontendCount,
+    this.workerCount,
   ) {
     if (this.gcloudProject == null) {
       throw new Exception('GCLOUD_PROJECT needs to be set!');
@@ -108,15 +109,21 @@ class EnvConfig {
   }
 
   factory EnvConfig._detect() {
-    final String isolateCountStr = Platform.environment['ISOLATE_COUNT'] ?? '1';
-    int isolateCount = int.parse(isolateCountStr, onError: (_) => 1);
-    isolateCount = max(1, isolateCount);
+    final frontendCount = int.parse(
+      Platform.environment['FRONTEND_COUNT'] ?? '1',
+      onError: (_) => Platform.numberOfProcessors,
+    );
+    final workerCount = int.parse(
+      Platform.environment['WORKER_COUNT'] ?? '1',
+      onError: (_) => 1,
+    );
     return new EnvConfig._(
       Platform.environment['GAE_SERVICE'],
       Platform.environment['GCLOUD_PROJECT'],
       Platform.environment['GCLOUD_KEY'],
       Platform.environment['FLUTTER_SDK'],
-      isolateCount,
+      frontendCount,
+      workerCount,
     );
   }
 


### PR DESCRIPTION
#1101

- introducing the concept of `frontend-isolate`, which would be the http-serving part of the service
- now everything is treated as worker isolate, but `search` should use `frontend-isolate`s, will be done in a subsequent PR
- env config will now have two env variables for controlling the number of isolates