### PR TITLE
Match dartdoc style in monospace fonts.

### DIFF
--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
 </head>
 <body>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
 </head>
 <body>

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="foobar_pkg Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="foobar_pkg Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="foobar_pkg Flutter and Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -26,7 +26,7 @@
   <meta property="og:description" content="foobar_pkg 0.1.1 Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -26,7 +26,7 @@
   <meta property="og:description" content="foobar_pkg 0.1.1 Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -26,7 +26,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=m0768jjq1tbl9kd7a0pm5b7cpt6kf6lf" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=uda17h8hkah47s3bdscb1sqoai2i751f" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=dpnjl27j3qcb445c0v5519t0j84ob0km" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -47,7 +47,7 @@ main, .site-header {
 code {
   background: #f8f8f8;
   border: 1px solid #eee;
-  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: 'Source Code Pro', Menlo, monospace;
   font-size: 85%;
   padding: 2px;
 }


### PR DESCRIPTION
- Previous change #1147 was matching GitHub's font settings.
- https://github.com/dart-lang/dartdoc/pull/1647 just landed in `package:dartdoc`, and I think it is better to match that (as long as it fixes the issue)
- Closes #1125
