### PR TITLE
Move frontend handler wrappers to shared.

### DIFF
--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -7,10 +7,20 @@ import 'dart:io';
 
 import 'package:appengine/appengine.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
-Future runHandler(Logger logger, shelf.Handler handler, {bool shared: false}) {
+import '../frontend/service_utils.dart';
+
+import 'utils.dart' show fileAnIssueContent;
+
+Future runHandler(Logger logger, shelf.Handler handler,
+    {bool sanitize: false, bool shared: false}) {
+  handler = _userAuthParsingWrapper(handler);
+  if (sanitize) {
+    handler = _sanitizeRequestWrapper(handler);
+  }
   handler = redirectToHttpsWrapper(handler);
   handler = _logRequestWrapper(logger, handler);
   return runAppEngine((HttpRequest request) => handleRequest(request, handler),
@@ -27,10 +37,38 @@ shelf.Handler _logRequestWrapper(Logger logger, shelf.Handler handler) {
       return await handler(request);
     } catch (error, st) {
       logger.severe('Request handler failed', error, st);
-      return new shelf.Response.internalServerError();
+
+      var body = '''Fatal package site error
+$fileAnIssueContent
+
+Add these details to help us fix the issue:
+Requested URL - ${request.requestedUri}''';
+
+      Map<String, String> debugHeaders;
+      if (context.traceId != null) {
+        debugHeaders = {'package-site-request-id': context.traceId};
+        body = '$body\n   Request ID - ${context.traceId}';
+      }
+
+      // TODO: user-friendly error page
+      return new shelf.Response.internalServerError(
+          body: body, headers: debugHeaders);
     } finally {
       logger.info('Request handler done.');
     }
+  };
+}
+
+shelf.Handler _sanitizeRequestWrapper(shelf.Handler handler) {
+  return (shelf.Request request) async {
+    return handler(_sanitizeRequestedUri(request));
+  };
+}
+
+shelf.Handler _userAuthParsingWrapper(shelf.Handler handler) {
+  return (shelf.Request request) async {
+    await registerLoggedInUserIfPossible(request);
+    return handler(request);
   };
 }
 
@@ -44,4 +82,33 @@ shelf.Handler redirectToHttpsWrapper(shelf.Handler handler) {
       return handler(request);
     }
   };
+}
+
+shelf.Request _sanitizeRequestedUri(shelf.Request request) {
+  final uri = request.requestedUri;
+  final resource = uri.path;
+  final normalizedResource = path.normalize(resource);
+
+  if (resource == normalizedResource) {
+    return request;
+  } else {
+    // With the new flex VMs we can get requests from the load balancer which
+    // can contain [Uri]s with e.g. double slashes
+    //
+    //    -> e.g. https://pub.dartlang.org//api/packages/foo
+    //
+    // Setting PUB_HOSTED_URL to a URL with a slash at the end can cause this.
+    // (The pub client will not remove it and instead directly try to request
+    //  "GET //api/..." :-/ )
+    final changedUri = uri.replace(path: normalizedResource);
+    return new shelf.Request(
+      request.method,
+      changedUri,
+      protocolVersion: request.protocolVersion,
+      headers: request.headers,
+      body: request.read(),
+      encoding: request.encoding,
+      context: request.context,
+    );
+  }
 }


### PR DESCRIPTION
- URL sanitizer is only for frontend, because documentation handles it differently
- removed the extra `try {} catch (e, st) {}` block around the logger wrapping
- user auth parsing seems to be something we don't use for dartdoc or other services, but won't hurt either
