### PR TITLE
Restructure notification URLs

### DIFF
--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -4,22 +4,19 @@
 
 import 'dart:async';
 
-import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/analyzer_service.dart';
 import '../shared/handlers.dart';
 import '../shared/notification.dart';
-import '../shared/task_client.dart';
 
 import 'backend.dart';
-
-final Logger _logger = new Logger('analyzer.handler');
 
 /// Handlers for the analyzer service.
 Future<shelf.Response> analyzerServiceHandler(shelf.Request request) async {
   final path = request.requestedUri.path;
   final handler = {
+    apiNotificationEndpoint: notificationHandler,
     '/debug': _debugHandler,
     '/robots.txt': rejectRobotsHandler,
   }[path];
@@ -64,18 +61,6 @@ Future<shelf.Response> packageHandler(shelf.Request request) async {
       return notFoundHandler(request);
     }
     return jsonResponse(data.toJson());
-  } else if (requestMethod == 'POST') {
-    if (pathParts.length != 2) {
-      // trigger should have version and shouldn't contain analysis id
-      return notFoundHandler(request);
-    }
-    if (await validateNotificationSecret(request)) {
-      _logger.info('Received notification: $package $version');
-      triggerTask(package, version);
-      return jsonResponse({'success': true});
-    } else {
-      return jsonResponse({'success': false});
-    }
   }
 
   return notFoundHandler(request);

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -113,9 +113,11 @@ void main() {
         await expectNotFoundResponse(await issuePost('/packages/pkg'));
       });
 
-      scopedTest('/packages/pkg/1.0.1', () async {
+      scopedTest('/api/notification', () async {
         // TODO: mock notification secret and re-enable testing task receive
-        await expectJsonResponse(await issuePost('/packages/pkg/1.0.1'),
+        await expectJsonResponse(
+            await issuePost('/api/notification',
+                body: {'package': 'foo', 'version': '1.0.0'}),
             body: {'success': false});
       });
     });

--- a/app/test/analyzer/handlers_test_utils.dart
+++ b/app/test/analyzer/handlers_test_utils.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:shelf/shelf.dart' as shelf;
 
@@ -15,8 +16,9 @@ Future<shelf.Response> issueGet(String path) async {
   return analyzerServiceHandler(request);
 }
 
-Future<shelf.Response> issuePost(String path) async {
+Future<shelf.Response> issuePost(String path, {Map body}) async {
   final uri = '$siteRoot$path';
-  final request = new shelf.Request('POST', Uri.parse(uri));
+  final encodedBody = body == null ? null : json.encode(body);
+  final request = new shelf.Request('POST', Uri.parse(uri), body: encodedBody);
   return analyzerServiceHandler(request);
 }

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -34,9 +34,11 @@ void main() {
     });
 
     group('trigger analysis', () {
-      scopedTest('/packages/pkg_foo', () async {
+      scopedTest('/api/notification', () async {
         // TODO: mock notification secret and re-enable testing task receive
-        await expectJsonResponse(await issuePost('/packages/pkg_foo'),
+        await expectJsonResponse(
+            await issuePost('/api/notification',
+                body: {'package': 'foo', 'version': '1.0.0'}),
             body: {'success': false});
       });
     });

--- a/app/test/search/handlers_test_utils.dart
+++ b/app/test/search/handlers_test_utils.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:shelf/shelf.dart' as shelf;
 
@@ -14,8 +15,9 @@ Future<shelf.Response> issueGet(String path) async {
   return searchServiceHandler(request);
 }
 
-Future<shelf.Response> issuePost(String path) async {
+Future<shelf.Response> issuePost(String path, {Map body}) async {
   final uri = 'https://search-dot-dartlang-pub.appspot.com$path';
-  final request = new shelf.Request('POST', Uri.parse(uri));
+  final encodedBody = body == null ? null : json.encode(body);
+  final request = new shelf.Request('POST', Uri.parse(uri), body: encodedBody);
   return searchServiceHandler(request);
 }


### PR DESCRIPTION
This is auxiliary to the URL refactoring, and makes notification API separate from the usual package-data serving paths. `POST /packages/[pkg]/[version]` becomes: `POST /api/notification` with a JSON payload.

On deploy there is a short period while the old version wants to notify the new or the new version wants to notify the old API. We'll have some entries in the logs wrt. unsuccessful notification, but otherwise there is no break in functionality, as datasource polling should pick up the same task in 10-15 minutes at most.