### PR TITLE
don't remove non-serving dartdoc entries if they are the only ones left

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -123,7 +123,9 @@ class DartdocBackend {
     }
     final List<DartdocEntry> completedList =
         await _listEntries(storage_path.entryPrefix(package, version));
-    if (serving) {
+    final hasServing = completedList.any((entry) => entry.isServing);
+    // don't remove non-serving entries if they are the only ones left
+    if (serving && hasServing) {
       completedList.removeWhere((entry) => !entry.isServing);
     }
     if (completedList.isEmpty) return null;


### PR DESCRIPTION
#1183

I think this should be patch-deployed on the current live version, as this will prevent the same "meltdown" we've experienced yesterday.