### PR TITLE
Minimal hostname validation on package uploads.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -16,6 +16,7 @@ import 'package:uuid/uuid.dart';
 
 import '../shared/name_tracker.dart';
 import '../shared/package_memcache.dart';
+import '../shared/urls.dart' as urls;
 import '../shared/utils.dart';
 
 import 'model_properties.dart';
@@ -675,6 +676,7 @@ Future<models.PackageVersion> parseAndValidateUpload(
   if (!nameTracker.accept(pubspec.name)) {
     throw new Exception('Package name is too similar to another package.');
   }
+  urls.syntaxCheckHomepageUrl(pubspec.homepage);
 
   String exampleFilename;
   for (String candidate in exampleFileCandidates(pubspec.name)) {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -58,6 +58,37 @@ String analysisTabUrl(String package) {
       : pkgPageUrl(package, fragment: fragment);
 }
 
+final _invalidHostNames = const <String>[
+  '..',
+  '...',
+  'example.com',
+  'example.org',
+  'example.net',
+  'www.example.com',
+  'www.example.org',
+  'www.example.net',
+  'none',
+];
+
+void syntaxCheckHomepageUrl(String url) {
+  Uri uri;
+  try {
+    uri = Uri.parse(url);
+  } catch (_) {
+    throw new Exception('Unable to parse homepage URL: $url');
+  }
+  if (!uri.hasScheme || !uri.scheme.startsWith('http')) {
+    throw new Exception(
+        'Use http:// or https:// URL schemes for homepage URL: $url');
+  }
+  if (uri.host == null ||
+      uri.host.isEmpty ||
+      !uri.host.contains('.') ||
+      _invalidHostNames.contains(uri.host)) {
+    throw new Exception('Homepage URL has no valid host: $url');
+  }
+}
+
 // TODO: lib/shared/analyzer_client.dart
 
 // TODO: lib/shared/configuration.dart

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -36,4 +36,31 @@ void main() {
           'https://pub.dartlang.org/documentation/foo_bar/1.0.0/');
     });
   });
+
+  group('homepage syntax check', () {
+    test('no url is not accepted', () {
+      expect(() => syntaxCheckHomepageUrl(null), throwsException);
+    });
+
+    test('example urls that are accepted', () {
+      syntaxCheckHomepageUrl('http://github.com/user/repo/');
+      syntaxCheckHomepageUrl('https://github.com/user/repo/');
+      syntaxCheckHomepageUrl('http://some.domain.com');
+    });
+
+    test('urls without valid scheme are not accepted', () {
+      expect(() => syntaxCheckHomepageUrl('github.com/x/y'), throwsException);
+      expect(() => syntaxCheckHomepageUrl('ftp://github.com/x/y'),
+          throwsException);
+    });
+
+    test('urls without valid host are not accepted', () {
+      expect(() => syntaxCheckHomepageUrl('http://none/x/'), throwsException);
+      expect(() => syntaxCheckHomepageUrl('http://example.com/x/'),
+          throwsException);
+      expect(
+          () => syntaxCheckHomepageUrl('http://localhost/x/'), throwsException);
+      expect(() => syntaxCheckHomepageUrl('http://.../x/'), throwsException);
+    });
+  });
 }


### PR DESCRIPTION
Closes #1081

Manual testing revealed that `pub` client already validates against missing values and values without http(s) prefixes. However it accepted eg. `http://`, and now we are filtering those too.

I think that manually accessing the web page is not a strict requirement at upload time, because it may be that it has a temporary access issue, and I wouldn't block uploads on that. However, it is reasonable to make it part of the package analysis, and give some penalty if the homepage is 404. We have already an open issue for it here: https://github.com/dart-lang/pana/issues/287