### PR TITLE
First go with history/audit log

### DIFF
--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -1,0 +1,51 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcloud/db.dart';
+import 'package:gcloud/service_scope.dart' as ss;
+import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
+
+import 'models.dart';
+
+const String _latest = 'latest';
+
+/// Sets the history backend.
+void registerHistoryBackend(HistoryBackend backend) =>
+    ss.register(#_historyBackend, backend);
+
+/// The active history backend.
+HistoryBackend get historyBackend => ss.lookup(#_historyBackend);
+
+final _uuid = new Uuid();
+
+class HistoryBackend {
+  final DatastoreDB _db;
+  HistoryBackend(this._db);
+
+  Future store({
+    @required String package,
+    String version: _latest,
+    DateTime timestamp,
+    @required String source,
+    @required String type,
+    Map<String, dynamic> paramsMap,
+  }) async {
+    final history = new History(
+      id: _uuid.v4(),
+      packageName: package,
+      packageVersion: version,
+      timestamp: timestamp,
+      source: source,
+      type: type,
+      paramsMap: paramsMap,
+    );
+    await _db.withTransaction((tx) async {
+      tx.queueMutations(inserts: [history]);
+      await tx.commit();
+    });
+  }
+}

--- a/app/lib/history/models.dart
+++ b/app/lib/history/models.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:gcloud/db.dart' as db;
+
+@db.Kind(name: 'History', idType: db.IdType.String)
+class History extends db.ExpandoModel {
+  History({
+    String id,
+    this.packageName,
+    this.packageVersion,
+    this.timestamp,
+    this.source,
+    this.type,
+    Map<String, dynamic> paramsMap,
+  }) {
+    this.id = id;
+    timestamp ??= new DateTime.now().toUtc();
+    this.paramsMap = paramsMap;
+  }
+
+  @db.StringProperty(required: true)
+  String packageName;
+
+  /// exact version or the 'latest' string
+  @db.StringProperty(required: true)
+  String packageVersion;
+
+  /// The timestamp of the entry.
+  @db.DateTimeProperty()
+  DateTime timestamp;
+
+  @db.StringProperty(required: true)
+  String source;
+
+  @db.StringProperty(required: true)
+  String type;
+
+  @db.StringProperty()
+  String paramsJson;
+
+  Map<String, dynamic> get paramsMap => json.decode(paramsJson);
+  set paramsMap(Map<String, dynamic> value) {
+    paramsJson = json.encode(value);
+  }
+}


### PR DESCRIPTION
This is my first take on #1018:

- Using `History` as entity name, `AuditLog` looks weird, especially if there would be some aggregation at the database level.

- My current idea is to store the related low-level data in the datastore, and format the human-readable description/message on the UI (vs. storing the formatted message directly in the datastore). This would allow us to re-phrase the formatting if/when needed, without overriding the old entries (or getting stuck with the non-desired phrasing).

- Using only a single entity for it, hierarchy is being handled by the special version notation 'latest'. When the version is 'latest', the entry would be displayed at the package-level, otherwise at the packageversion-level. An alternative could be a separate flag, which would indicate whether to include it on the package-level messages. (I'm 50-50% on this, decisive input is more than welcome.)
