### PR TITLE
Use frontend-isolate in analyzer and dartdoc services.

### DIFF
--- a/app/lib/shared/service_utils.dart
+++ b/app/lib/shared/service_utils.dart
@@ -54,6 +54,7 @@ class WorkerProtocolMessage {
 Future startIsolates({
   @required Logger logger,
   void frontendEntryPoint(FrontendEntryMessage message),
+  Future workerSetup(),
   void workerEntryPoint(WorkerEntryMessage message),
 }) async {
   int frontendStarted = 0;
@@ -155,6 +156,9 @@ Future startIsolates({
     }
   }
   if (workerEntryPoint != null) {
+    if (workerSetup != null) {
+      await workerSetup();
+    }
     for (int i = 0; i < envConfig.workerCount; i++) {
       await startWorkerIsolate();
     }


### PR DESCRIPTION
#1101 

Initializing Flutter and dartdoc come after the frontend isolates are started, making it non-blocking for appengine health checks.