### PR TITLE
Fix history model, appengine library requires to have an empty default constructor.

### DIFF
--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -39,7 +39,7 @@ class HistoryBackend {
     @required String source,
     @required HistoryEvent event,
   }) async {
-    final history = new History(
+    final history = new History.init(
       id: _uuid.v4(),
       packageName: package,
       packageVersion: version,

--- a/app/lib/history/models.dart
+++ b/app/lib/history/models.dart
@@ -11,7 +11,9 @@ part 'models.g.dart';
 
 @db.Kind(name: 'History', idType: db.IdType.String)
 class History extends db.ExpandoModel implements HistoryData {
-  History({
+  History();
+
+  History.init({
     String id,
     this.packageName,
     this.packageVersion,


### PR DESCRIPTION
Otherwise the services fail to start.