### PR TITLE
Making it explicit that we render the dartdocs URLs.

### DIFF
--- a/app/lib/frontend/model_properties.dart
+++ b/app/lib/frontend/model_properties.dart
@@ -73,6 +73,11 @@ class Pubspec {
     return const <String>[];
   }
 
+  String get documentation {
+    _load();
+    return _asString(_json['documentation']);
+  }
+
   String get homepage {
     _load();
     return _asString(_json['homepage']);

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -199,8 +199,7 @@ class PackageVersion extends db.ExpandoModel {
       urls.pkgDocUrl(package, version: version, includeHost: true);
 
   String get documentation {
-    // TODO: Look first into pubspecYaml['documentation'] otherwise do this:
-    return dartdocsUrl;
+    return pubspec.documentation;
   }
 
   String get homepage {

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -105,7 +105,7 @@ class TemplateService {
       'version': version.version,
       'version_url': urls.pkgPageUrl(version.package, version: version.version),
       'short_created': version.shortCreated,
-      'documentation_url': _attr(version.documentation),
+      'dartdocs_url': _attr(version.dartdocsUrl),
       'dartdoc_ok': dartdocOk,
       'dartdoc_failed': dartdocFailed,
       'download_url': _attr(downloadUrl),
@@ -394,7 +394,7 @@ class TemplateService {
         'authors_html':
             _getAuthorsHtml(selectedVersion.pubspec.getAllAuthors()),
         'homepage': selectedVersion.homepage,
-        'documentation': selectedVersion.documentation,
+        'dartdocs_url': selectedVersion.dartdocsUrl,
         // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
         'uploaders_title': 'Uploader',
         'uploaders_html': _getAuthorsHtml(package.uploaderEmails),

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -91,7 +91,7 @@ import 'package:{{package}}/{{library}}';
       <p>{{package.description}}</p>
       <p>
           {{#package.homepage}}<a class="link" href="{{& package.homepage}}">Homepage</a>,{{/package.homepage}}
-          <a class="link" href="{{& package.documentation}}">API Docs</a>
+          <a class="link" href="{{& package.dartdocs_url}}">API Docs</a>
       </p>
     {{/package.description}}
 

--- a/app/views/pkg/versions/version_row.mustache
+++ b/app/views/pkg/versions/version_row.mustache
@@ -7,13 +7,13 @@
   <td>{{short_created}}</td>
   <td class="documentation">
     {{#dartdoc_ok}}
-    <a href="{{& documentation_url}}"
+    <a href="{{& dartdocs_url}}"
        title="Go to the documentation of {{package}} {{version}}">
       <img src="{{& icons.documentation}}" alt="Go to the documentation of {{package}} {{version}}" />
     </a>
     {{/dartdoc_ok}}
     {{#dartdoc_failed}}
-    <a href="{{& documentation_url}}log.txt">failed</a>
+    <a href="{{& dartdocs_url}}log.txt">failed</a>
     {{/dartdoc_failed}}
   </td>
   <td class="archive">


### PR DESCRIPTION
(and not the pubspec-provided documentation url)

#1214