### PR TITLE
Display user-provided documentation link.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -368,6 +368,14 @@ class TemplateService {
       tabs.first['active'] = '-active';
     }
     final analysisStatus = analysis?.analysisStatus ?? extract?.analysisStatus;
+    String documentationUrl = selectedVersion.documentation;
+    if (documentationUrl != null &&
+        (documentationUrl.startsWith('https://www.dartdocs.org/') ||
+            documentationUrl.startsWith('http://www.dartdocs.org/') ||
+            documentationUrl.startsWith('https://pub.dartlang.org/') ||
+            documentationUrl.startsWith('http://pub.dartlang.org/'))) {
+      documentationUrl = null;
+    }
 
     final values = {
       'package': {
@@ -394,6 +402,7 @@ class TemplateService {
         'authors_html':
             _getAuthorsHtml(selectedVersion.pubspec.getAllAuthors()),
         'homepage': selectedVersion.homepage,
+        'documentation': documentationUrl,
         'dartdocs_url': selectedVersion.dartdocsUrl,
         // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
         'uploaders_title': 'Uploader',

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -291,7 +291,8 @@ Learn more about <a href="/help#scoring">scoring</a>.
     <h3 class="title">About</h3>
       <p>my package description</p>
       <p>
-          <a class="link" href="http://hans.juergen.com">Homepage</a>,
+          <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
+          
           <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1+5/">API Docs</a>
       </p>
 

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -180,7 +180,8 @@ import 'package:foobar_pkg/foolib.dart';
     <h3 class="title">About</h3>
       <p>my package description</p>
       <p>
-          <a class="link" href="http://hans.juergen.com">Homepage</a>,
+          <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
+          
           <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1+5/">API Docs</a>
       </p>
 

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -249,7 +249,8 @@ Learn more about <a href="/help#scoring">scoring</a>.
     <h3 class="title">About</h3>
       <p>my package description</p>
       <p>
-          <a class="link" href="http://hans.juergen.com">Homepage</a>,
+          <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
+          
           <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1+5/">API Docs</a>
       </p>
 

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -184,7 +184,8 @@ import 'package:foobar_pkg/foolib.dart';
     <h3 class="title">About</h3>
       <p>my package description</p>
       <p>
-          <a class="link" href="http://hans.juergen.com">Homepage</a>,
+          <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
+          
           <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1+5/">API Docs</a>
       </p>
 

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -293,7 +293,8 @@ Learn more about <a href="/help#scoring">scoring</a>.
     <h3 class="title">About</h3>
       <p>my package description</p>
       <p>
-          <a class="link" href="http://hans.juergen.com">Homepage</a>,
+          <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
+          
           <a class="link" href="https://pub.dartlang.org/documentation/foobar_pkg/0.1.1+5/">API Docs</a>
       </p>
 

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -90,7 +90,8 @@ import 'package:{{package}}/{{library}}';
     {{#package.description}}
       <p>{{package.description}}</p>
       <p>
-          {{#package.homepage}}<a class="link" href="{{& package.homepage}}">Homepage</a>,{{/package.homepage}}
+          {{#package.homepage}}<a class="link" href="{{& package.homepage}}">Homepage</a><br/>{{/package.homepage}}
+          {{#package.documentation}}<a class="link" href="{{& package.documentation}}">Documentation</a><br/>{{/package.documentation}}
           <a class="link" href="{{& package.dartdocs_url}}">API Docs</a>
       </p>
     {{/package.description}}


### PR DESCRIPTION
- part of #1174
- closes #1214
- we are not displaying documentation links when they are linking to API docs or the pub site
- Display is changed from comma separated list to a new link on each line:

<img width="198" alt="screen shot 2018-04-21 at 10 07 43" src="https://user-images.githubusercontent.com/4778111/39082046-efdb6e40-454c-11e8-9850-7b11223c11d4.png">
