### PR TITLE
 Install tab with global activate for binary-only packages.

### DIFF
--- a/app/lib/frontend/model_properties.dart
+++ b/app/lib/frontend/model_properties.dart
@@ -88,6 +88,12 @@ class Pubspec {
     return _asString(_json['description']);
   }
 
+  Map<String, dynamic> get executables {
+    _load();
+    final map = _json['executables'];
+    return map is Map ? map : null;
+  }
+
   String get sdkConstraint {
     _load();
     final environment = _json['environment'];

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -447,6 +447,11 @@ class TemplateService {
       }).toList();
     }
 
+    final executables = selectedVersion.pubspec.executables?.keys?.toList();
+    executables?.sort();
+    final hasExecutables = executables != null && executables.isNotEmpty;
+    final onlyGlobalInstall = hasExecutables && importExamples.isEmpty;
+
     final exampleVersionConstraint = '"^${selectedVersion.version}"';
 
     final bool usePubGet = !isFlutterPackage ||
@@ -461,9 +466,9 @@ class TemplateService {
     String editorSupportedToolHtml;
     if (usePubGet && useFlutterPackagesGet) {
       editorSupportedToolHtml =
-          '<code>pub get</code> or <code>packages get</code>';
+          '<code>pub get</code> or <code>flutter packages get</code>';
     } else if (useFlutterPackagesGet) {
-      editorSupportedToolHtml = '<code>packages get</code>';
+      editorSupportedToolHtml = '<code>flutter packages get</code>';
     } else {
       editorSupportedToolHtml = '<code>pub get</code>';
     }
@@ -477,6 +482,8 @@ class TemplateService {
       'use_flutter_packages_get': useFlutterPackagesGet,
       'show_editor_support': usePubGet || useFlutterPackagesGet,
       'editor_supported_tool_html': editorSupportedToolHtml,
+      'only_global_install': onlyGlobalInstall,
+      'executables': executables,
     });
   }
 

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -449,36 +449,34 @@ class TemplateService {
 
     final exampleVersionConstraint = '"^${selectedVersion.version}"';
 
-    final bool renderGeneric = !isFlutterPackage ||
+    final bool usePubGet = !isFlutterPackage ||
         platforms == null ||
         platforms.isEmpty ||
         platforms.length > 1 ||
         platforms.first != KnownPlatforms.flutter;
 
-    final bool renderFlutter = isFlutterPackage ||
+    final bool useFlutterPackagesGet = isFlutterPackage ||
         (platforms != null && platforms.contains(KnownPlatforms.flutter));
 
-    String toolHtml;
-    if (renderGeneric && renderFlutter) {
-      toolHtml = '<code>pub get</code> or <code>packages get</code>';
-    } else if (renderFlutter) {
-      toolHtml = '<code>packages get</code>';
+    String editorSupportedToolHtml;
+    if (usePubGet && useFlutterPackagesGet) {
+      editorSupportedToolHtml =
+          '<code>pub get</code> or <code>packages get</code>';
+    } else if (useFlutterPackagesGet) {
+      editorSupportedToolHtml = '<code>packages get</code>';
     } else {
-      toolHtml = '<code>pub get</code>';
+      editorSupportedToolHtml = '<code>pub get</code>';
     }
 
     return _renderTemplate('pkg/install_tab', {
-      'package': {
-        'name': package.name,
-      },
-      'selected_version': {
-        'example_version_constraint': exampleVersionConstraint,
-        'has_libraries': importExamples.length > 0,
-        'import_examples': importExamples,
-      },
-      'generic': renderGeneric,
-      'flutter': renderFlutter,
-      'tool_html': toolHtml,
+      'package': package.name,
+      'example_version_constraint': exampleVersionConstraint,
+      'has_libraries': importExamples.isNotEmpty,
+      'import_examples': importExamples,
+      'use_pub_get': usePubGet,
+      'use_flutter_packages_get': useFlutterPackagesGet,
+      'show_editor_support': usePubGet || useFlutterPackagesGet,
+      'editor_supported_tool_html': editorSupportedToolHtml,
     });
   }
 

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -121,7 +121,7 @@ dependencies:
 $ <strong>flutter packages get</strong>
 
 </code></pre>
-<p>Alternatively, your editor might support <code>packages get</code>.
+<p>Alternatively, your editor might support <code>flutter packages get</code>.
   Check the docs for your editor to learn more.</p>
   <h3>3. Import it</h3>
   <p>Now in your Dart code, you can use:

--- a/app/views/pkg/install_tab.mustache
+++ b/app/views/pkg/install_tab.mustache
@@ -1,6 +1,21 @@
 {{! Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
     for details. All rights reserved. Use of this source code is governed by a
     BSD-style license that can be found in the LICENSE file. }}
+{{#only_global_install}}
+<h3>1. Install it</h3>
+<p>You can install the package from the command line:</p>
+<pre><code class="language-shell">
+$ <strong>pub global activate {{package}}</strong>
+</code></pre>
+<h3>2. Use it</h3>
+<p>The package has the following executables:</p>
+<pre><code class="language-shell">
+{{#executables}}
+$ <strong>{{.}}</strong>
+{{/executables}}
+</code></pre>
+{{/only_global_install}}
+{{^only_global_install}}
 <h3>1. Depend on it</h3>
 <p>Add this to your package's pubspec.yaml file:</p>
 <pre><code class="language-yaml">
@@ -37,3 +52,4 @@ $ <strong>flutter packages get</strong>
   {{/import_examples}}
   </code></pre>
 {{/has_libraries}}
+{{/only_global_install}}

--- a/app/views/pkg/install_tab.mustache
+++ b/app/views/pkg/install_tab.mustache
@@ -5,33 +5,35 @@
 <p>Add this to your package's pubspec.yaml file:</p>
 <pre><code class="language-yaml">
 dependencies:
-  <strong>{{package.name}}: {{selected_version.example_version_constraint}}</strong>
+  <strong>{{package}}: {{example_version_constraint}}</strong>
 
 </code></pre>
 <h3>2. Install it</h3>
 <p>You can install packages from the command line:</p>
-{{#generic}}
+{{#use_pub_get}}
   <p>with pub:</p>
   <pre><code class="language-shell">
 $ <strong>pub get</strong>
 
 </code></pre>
-{{/generic}}
-{{#flutter}}
+{{/use_pub_get}}
+{{#use_flutter_packages_get}}
   <p>with Flutter:</p>
   <pre><code class="language-shell">
 $ <strong>flutter packages get</strong>
 
 </code></pre>
-{{/flutter}}
-<p>Alternatively, your editor might support {{& tool_html}}.
+{{/use_flutter_packages_get}}
+{{#show_editor_support}}
+<p>Alternatively, your editor might support {{& editor_supported_tool_html}}.
   Check the docs for your editor to learn more.</p>
-{{#selected_version.has_libraries}}
+{{/show_editor_support}}
+{{#has_libraries}}
   <h3>3. Import it</h3>
   <p>Now in your Dart code, you can use:
   </p>
-  <pre><code class="language-dart">{{#selected_version.import_examples}}
+  <pre><code class="language-dart">{{#import_examples}}
       import 'package:{{package}}/{{library}}';
-  {{/selected_version.import_examples}}
+  {{/import_examples}}
   </code></pre>
-{{/selected_version.has_libraries}}
+{{/has_libraries}}


### PR DESCRIPTION
One step closer to #1213:
- The first commit is a refactor of the template for simpler structure and narrow variable names.
- The second introduces a new template part for packages that are binary-only.
