### PR TITLE
Cleanup shared/urls.dart

### DIFF
--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -101,13 +101,3 @@ void syntaxCheckHomepageUrl(String url) {
     throw new Exception('Homepage URL has no valid host: $url');
   }
 }
-
-// TODO: lib/shared/analyzer_client.dart
-
-// TODO: lib/shared/configuration.dart
-
-// TODO: lib/shared/dartdoc_client.dart
-
-// TODO: lib/shared/notification.dart
-
-// TODO: lib/shared/search_client.dart


### PR DESCRIPTION
Closes #1156 

I'm not aware of any further use-facing url-related task, the rest (e.g. simplification of PlatformPredicate) can be considered a separate task.