### PR TITLE
Upgrade markdown package to 2.0.0

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -322,7 +322,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   intl: '>=0.13.0 <0.16.0'
   json_annotation: '^0.2.0'
   logging: '>=0.9.3 <1.0.0'
-  markdown: '>=1.1.0 <1.2.0'
+  markdown: '>=2.0.0 <2.1.0'
   memcache: '^0.2.2'
   meta: ^1.1.2
   mime: '>=0.9.3 <0.10.0'


### PR DESCRIPTION
/cc @kevmoo: looks like we have a smooth upgrade
