### PR TITLE
Update customization tests with dartdoc 0.19.0 outputs

### DIFF
--- a/app/test/dartdoc/golden/pana_0.10.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.16.0">
+  <meta name="generator" content="made with love by dartdoc 0.19.0">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/index.html">
@@ -33,12 +33,10 @@
 <main>
 
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
-    <h5>pana package</h5>
-
-
+    <h5><span class="package-name">pana</span> <span class="package-kind">package</span></h5>
     <ol>
-      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
-      <li><a href="pana/pana-library.html">pana</a></li>
+          <li class="section-title">Libraries</li>
+          <li><a href="pana/pana-library.html">pana</a></li>
     </ol>
   </div>
 
@@ -69,18 +67,16 @@ Options:
 </code></pre>
       </section>
       
-
-      <section class="summary" id="libraries">
-        <h2>Libraries</h2>
-        <dl>
+        <section class="summary">
+            <h2>Libraries</h2>
+          <dl>
             <dt id="pana">
               <span class="name"><a href="pana/pana-library.html">pana</a></span>
             </dt>
             <dd>
               
-            </dd>
-        </dl>
-      </section>
+            </dd>          </dl>
+        </section>
 
   </div> <!-- /.main-content -->
 
@@ -93,7 +89,7 @@ Options:
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -9,7 +9,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.16.0">
+  <meta name="generator" content="made with love by dartdoc 0.19.0">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/index.html">
@@ -40,12 +40,10 @@
 <main>
 
   <div class="col-xs-6 col-sm-3 col-md-2 sidebar sidebar-offcanvas-left">
-    <h5>pana package</h5>
-
-
+    <h5><span class="package-name">pana</span> <span class="package-kind">package</span></h5>
     <ol>
-      <li class="section-title"><a href="index.html#libraries">Libraries</a></li>
-      <li><a href="pana/pana-library.html">pana</a></li>
+          <li class="section-title">Libraries</li>
+          <li><a href="pana/pana-library.html">pana</a></li>
     </ol>
   </div>
 
@@ -76,18 +74,16 @@ Options:
 </code></pre>
       </section>
       
-
-      <section class="summary" id="libraries">
-        <h2>Libraries</h2>
-        <dl>
+        <section class="summary">
+            <h2>Libraries</h2>
+          <dl>
             <dt id="pana">
               <span class="name"><a href="pana/pana-library.html">pana</a></span>
             </dt>
             <dd>
               
-            </dd>
-        </dl>
-      </section>
+            </dd>          </dl>
+        </section>
 
   </div> <!-- /.main-content -->
 
@@ -100,7 +96,7 @@ Options:
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.html
@@ -113,7 +113,7 @@
 
         <dt>Annotations</dt>
         <dd><ul class="annotation-list clazz-relationships">
-          <li>@JsonSerializable()</li>
+          <li>@<a href="https://pub.dartlang.org/documentation/json_annotation/0.2.2/json_annotation/JsonSerializable-class.html">JsonSerializable</a>()</li>
         </ul></dd>
       </dl>
     </section>
@@ -123,13 +123,13 @@
 
       <dl class="constructor-summary-list">
         <dt id="LicenseFile" class="callable">
-          <span class="name"><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })</span>
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span></span> })</span>
         </dt>
         <dd>
           
         </dd>
         <dt id="LicenseFile.fromJson" class="callable">
-          <span class="name"><a href="pana/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
         </dt>
         <dd>
           
@@ -144,7 +144,7 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
           <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/int-class.html">int</a></span>
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
@@ -152,7 +152,7 @@
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
@@ -160,7 +160,7 @@
 </dd>
         <dt id="path" class="property">
           <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
@@ -168,7 +168,7 @@
 </dd>
         <dt id="shortFormatted" class="property">
           <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
@@ -176,23 +176,23 @@
 </dd>
         <dt id="url" class="property">
           <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+          <div class="features">@<a href="https://pub.dartlang.org/documentation/json_annotation/0.2.2/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
 </dd>
         <dt id="version" class="property">
           <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
-          <span class="signature">&#8594; String</span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+          <div class="features">@<a href="https://pub.dartlang.org/documentation/json_annotation/0.2.2/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span>
+          <span class="name"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></span>
+          <span class="signature">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Type-class.html">Type</a></span>
         </dt>
         <dd class="inherited">
           A representation of the runtime type of the object.
@@ -205,7 +205,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="change" class="callable">
-          <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+          <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span></span> })
             <span class="returntype parameter">&#8594; <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
           </span>
         </dt>
@@ -215,7 +215,7 @@
 </dd>
         <dt id="toString" class="callable">
           <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; String</span>
+            <span class="returntype parameter">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
           </span>
         </dt>
         <dd>
@@ -223,17 +223,17 @@
           
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Invocation-class.html">Invocation</a></span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed. <a href="pana/LicenseFile/noSuchMethod.html">[...]</a>
+          Invoked when a non-existent method or property is accessed. <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">[...]</a>
           <div class="features">inherited</div>
 </dd>
         <dt id="toJson" class="callable inherited">
-          <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">&#8594; Map<span class="signature">&lt;String, dynamic&gt;</span></span>
+          <span class="name">toJson</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -247,8 +247,8 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable">
-          <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">&#8594; bool</span>
+          <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object-class.html">Object</a></span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">&#8594; <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/bool-class.html">bool</a></span>
           </span>
         </dt>
         <dd>
@@ -278,13 +278,13 @@
       <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
       <li><a href="pana/LicenseFile/url.html">url</a></li>
       <li><a href="pana/LicenseFile/version.html">version</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
       <li><a href="pana/LicenseFile/change.html">change</a></li>
       <li><a href="pana/LicenseFile/toString.html">toString</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited">toJson</li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
       <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
@@ -303,7 +303,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -120,7 +120,7 @@
 
         <dt>Annotations</dt>
         <dd><ul class="annotation-list clazz-relationships">
-          <li>@JsonSerializable()</li>
+          <li>@<a href="https://pub.dartlang.org/documentation/json_annotation/0.2.2/json_annotation/JsonSerializable-class.html">JsonSerializable</a>()</li>
         </ul></dd>
       </dl>
     </section>
@@ -130,13 +130,13 @@
 
       <dl class="constructor-summary-list">
         <dt id="LicenseFile" class="callable">
-          <span class="name"><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })</span>
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.html">LicenseFile</a></span><span class="signature">(<span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span></span> })</span>
         </dt>
         <dd>
           
         </dd>
         <dt id="LicenseFile.fromJson" class="callable">
-          <span class="name"><a href="pana/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation">Map<span class="signature">&lt;String, dynamic&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
+          <span class="name"><a href="pana/LicenseFile/LicenseFile.fromJson.html">LicenseFile.fromJson</a></span><span class="signature">(<span class="parameter" id="fromJson-param-json"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span> <span class="parameter-name">json</span></span>)</span>
         </dt>
         <dd>
           
@@ -151,7 +151,7 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
           <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
-          <span class="signature">→ int</span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/int-class.html">int</a></span>
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
@@ -159,7 +159,7 @@
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
-          <span class="signature">→ String</span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
@@ -167,7 +167,7 @@
 </dd>
         <dt id="path" class="property">
           <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
-          <span class="signature">→ String</span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
@@ -175,7 +175,7 @@
 </dd>
         <dt id="shortFormatted" class="property">
           <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-          <span class="signature">→ String</span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
@@ -183,23 +183,23 @@
 </dd>
         <dt id="url" class="property">
           <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
-          <span class="signature">→ String</span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+          <div class="features">@<a href="https://pub.dartlang.org/documentation/json_annotation/0.2.2/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
 </dd>
         <dt id="version" class="property">
           <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
-          <span class="signature">→ String</span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+          <div class="features">@<a href="https://pub.dartlang.org/documentation/json_annotation/0.2.2/json_annotation/JsonKey-class.html">JsonKey</a>(includeIfNull: false), final</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
-          <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
-          <span class="signature">→ Type</span>
+          <span class="name"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></span>
+          <span class="signature">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Type-class.html">Type</a></span>
         </dt>
         <dd class="inherited">
           A representation of the runtime type of the object.
@@ -212,7 +212,7 @@
       <h2>Methods</h2>
       <dl class="callables">
         <dt id="change" class="callable">
-          <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+          <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span></span> })
             <span class="returntype parameter">→ <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
           </span>
         </dt>
@@ -222,7 +222,7 @@
 </dd>
         <dt id="toString" class="callable">
           <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">→ String</span>
+            <span class="returntype parameter">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
           </span>
         </dt>
         <dd>
@@ -230,17 +230,17 @@
           
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
-          <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
+          <span class="name"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Invocation-class.html">Invocation</a></span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">→ dynamic</span>
           </span>
         </dt>
         <dd class="inherited">
-          Invoked when a non-existent method or property is accessed. <a href="pana/LicenseFile/noSuchMethod.html">[...]</a>
+          Invoked when a non-existent method or property is accessed. <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">[...]</a>
           <div class="features">inherited</div>
 </dd>
         <dt id="toJson" class="callable inherited">
-          <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
-            <span class="returntype parameter">→ Map<span class="signature">&lt;String, dynamic&gt;</span></span>
+          <span class="name">toJson</span><span class="signature">(<wbr>)
+            <span class="returntype parameter">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Map-class.html">Map</a><span class="signature">&lt;<wbr><span class="type-parameter"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
           </span>
         </dt>
         <dd class="inherited">
@@ -254,8 +254,8 @@
       <h2>Operators</h2>
       <dl class="callables">
         <dt id="operator ==" class="callable">
-          <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
-            <span class="returntype parameter">→ bool</span>
+          <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object-class.html">Object</a></span> <span class="parameter-name">other</span></span>)
+            <span class="returntype parameter">→ <a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/bool-class.html">bool</a></span>
           </span>
         </dt>
         <dd>
@@ -285,13 +285,13 @@
       <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
       <li><a href="pana/LicenseFile/url.html">url</a></li>
       <li><a href="pana/LicenseFile/version.html">version</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
       <li><a href="pana/LicenseFile/change.html">change</a></li>
       <li><a href="pana/LicenseFile/toString.html">toString</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited">toJson</li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
       <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
@@ -310,7 +310,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.html
@@ -53,13 +53,13 @@
       <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
       <li><a href="pana/LicenseFile/url.html">url</a></li>
       <li><a href="pana/LicenseFile/version.html">version</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
       <li><a href="pana/LicenseFile/change.html">change</a></li>
       <li><a href="pana/LicenseFile/toString.html">toString</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited">toJson</li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
       <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
@@ -74,7 +74,7 @@
 
     <section class="multi-line-signature">
       
-      <span class="name ">LicenseFile</span>(<wbr><span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+      <span class="name ">LicenseFile</span>(<wbr><span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span></span> })
     </section>
 
     
@@ -97,7 +97,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -60,13 +60,13 @@
       <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
       <li><a href="pana/LicenseFile/url.html">url</a></li>
       <li><a href="pana/LicenseFile/version.html">version</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
       <li><a href="pana/LicenseFile/change.html">change</a></li>
       <li><a href="pana/LicenseFile/toString.html">toString</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited">toJson</li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
       <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
@@ -81,7 +81,7 @@
 
     <section class="multi-line-signature">
       
-      <span class="name ">LicenseFile</span>(<wbr><span class="parameter" id="-param-path"><span class="type-annotation">String</span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation">String</span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation">String</span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
+      <span class="name ">LicenseFile</span>(<wbr><span class="parameter" id="-param-path"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">path</span>, </span> <span class="parameter" id="-param-name"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">name</span>, {</span> <span class="parameter" id="-param-version"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">version</span>, </span> <span class="parameter" id="-param-url"><span class="type-annotation"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span> <span class="parameter-name">url</span></span> })
     </section>
 
     
@@ -104,7 +104,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.html
@@ -53,13 +53,13 @@
       <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
       <li><a href="pana/LicenseFile/url.html">url</a></li>
       <li><a href="pana/LicenseFile/version.html">version</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
       <li><a href="pana/LicenseFile/change.html">change</a></li>
       <li><a href="pana/LicenseFile/toString.html">toString</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited">toJson</li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
       <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
@@ -73,7 +73,7 @@
     <h1>name property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype">String</span>
+          <span class="returntype"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
           <span class="name ">name</span>
           <div class="features">final</div>
         </section>
@@ -98,7 +98,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -60,13 +60,13 @@
       <li><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></li>
       <li><a href="pana/LicenseFile/url.html">url</a></li>
       <li><a href="pana/LicenseFile/version.html">version</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/runtimeType.html">runtimeType</a></li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#instance-methods">Methods</a></li>
       <li><a href="pana/LicenseFile/change.html">change</a></li>
       <li><a href="pana/LicenseFile/toString.html">toString</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></li>
-      <li class="inherited"><a href="pana/LicenseFile/toJson.html">toJson</a></li>
+      <li class="inherited"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/Object/noSuchMethod.html">noSuchMethod</a></li>
+      <li class="inherited">toJson</li>
     
       <li class="section-title"><a href="pana/LicenseFile-class.html#operators">Operators</a></li>
       <li><a href="pana/LicenseFile/operator_equals.html">operator ==</a></li>
@@ -80,7 +80,7 @@
     <h1>name property</h1>
 
         <section class="multi-line-signature">
-          <span class="returntype">String</span>
+          <span class="returntype"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
           <span class="name ">name</span>
           <div class="features">final</div>
         </section>
@@ -105,7 +105,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.html
@@ -105,9 +105,9 @@
     <h1>prettyJson function</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">String</span>
+        <span class="returntype"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         <span class="name ">prettyJson</span>
-(<wbr><span class="parameter" id="prettyJson-param-obj"><span class="parameter-name">obj</span></span>)
+(<wbr><span class="parameter" id="prettyJson-param-obj"><span class="type-annotation">dynamic</span> <span class="parameter-name">obj</span></span>)
     </section>
     
     <section class="summary source-code" id="source">
@@ -147,7 +147,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -112,9 +112,9 @@
     <h1>prettyJson function</h1>
 
     <section class="multi-line-signature">
-        <span class="returntype">String</span>
+        <span class="returntype"><a href="https://api.dartlang.org/dev/2.0.0-dev.54.0/dart-core/String-class.html">String</a></span>
         <span class="name ">prettyJson</span>
-(<wbr><span class="parameter" id="prettyJson-param-obj"><span class="parameter-name">obj</span></span>)
+(<wbr><span class="parameter" id="prettyJson-param-obj"><span class="type-annotation">dynamic</span> <span class="parameter-name">obj</span></span>)
     </section>
     
     <section class="summary source-code" id="source">
@@ -154,7 +154,7 @@
 
 </footer>
 
-<script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 <script src="static-assets/typeahead.bundle.min.js"></script>
 <script src="static-assets/highlight.pack.js"></script>
 <script src="static-assets/URI.js"></script>


### PR DESCRIPTION
#1254

- This is using the new `--link-to-remote` flag.
- Looks like it doesn't affect our customization at all.
- Will update `dartdoc` version separately, with or after the `pana` fix and upgrade.