### PR TITLE
Add timeout for fetching dartdoc-generated content.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -69,8 +69,9 @@ class SearchBackend {
         versionList.where((pv) => pv != null),
         key: (pv) => (pv as PackageVersion).package);
 
-    final indexJsonFutures = Future.wait(packages.map(
-        (p) => dartdocClient.getContentBytes(p.name, 'latest', 'index.json')));
+    final indexJsonFutures = Future.wait(packages.map((p) =>
+        dartdocClient.getContentBytes(p.name, 'latest', 'index.json',
+            timeout: const Duration(seconds: 10))));
 
     final List<AnalysisView> analysisViews =
         await analyzerClient.getAnalysisViews(packages.map((p) =>

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -106,6 +106,9 @@ class BatchIndexUpdater implements TaskRunner {
     }
     if (_batch.isEmpty) return;
 
+    final Timer timer = new Timer(const Duration(minutes: 5), () {
+      _logger.severe('Batch updated failed to complete in 5 minutes.');
+    });
     final Completer completer = new Completer();
     _ongoingBatchUpdate = completer.future;
 
@@ -133,6 +136,7 @@ class BatchIndexUpdater implements TaskRunner {
     } finally {
       completer.complete();
       _ongoingBatchUpdate = null;
+      timer.cancel();
     }
   }
 

--- a/app/lib/shared/dartdoc_client.dart
+++ b/app/lib/shared/dartdoc_client.dart
@@ -60,17 +60,19 @@ class DartdocClient {
   }
 
   Future<List<int>> getContentBytes(
-      String package, String version, String relativePath) async {
+      String package, String version, String relativePath,
+      {Duration timeout}) async {
     final url = p.join(_dartdocServiceHttpHostPort, 'documentation', package,
         version, relativePath);
     try {
-      final rs = await getUrlWithRetry(_client, url);
+      final rs = await getUrlWithRetry(_client, url, timeout: timeout);
       if (rs.statusCode != 200) {
         return null;
       }
       return rs.bodyBytes;
     } catch (e) {
-      _logger.info('Error requesting entry for: $package $version');
+      _logger
+          .info('Error getting content for: $package $version $relativePath');
     }
     return null;
   }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -316,7 +316,7 @@ String formatDuration(Duration d) {
 }
 
 Future<http.Response> getUrlWithRetry(http.Client client, String url,
-    {int retryCount: 1}) async {
+    {int retryCount: 1, Duration timeout}) async {
   http.Response result;
   Map<String, String> headers;
   if (context?.traceId != null) {
@@ -325,7 +325,11 @@ Future<http.Response> getUrlWithRetry(http.Client client, String url,
   for (int i = 0; i <= retryCount; i++) {
     try {
       _logger.info('HTTP GET $url');
-      result = await client.get(url, headers: headers);
+      Future<http.Response> future = client.get(url, headers: headers);
+      if (timeout != null) {
+        future = future.timeout(timeout);
+      }
+      result = await future;
       if (i == retryCount ||
           result.statusCode == 200 ||
           result.statusCode == 404) {

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -321,7 +321,8 @@ class DartdocClientMock implements DartdocClient {
 
   @override
   Future<List<int>> getContentBytes(
-      String package, String version, String relativePath) async {
+      String package, String version, String relativePath,
+      {Duration timeout}) async {
     return null;
   }
 }


### PR DESCRIPTION
This seems to be a likely candidate that (a) explains the regression of #1281 and (b) adds a fix for it.