### PR TITLE
Add route for dartdocs.org.

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -5,4 +5,6 @@ dispatch:
     service: dartdoc
   - url: "pub.dartlang.org/documentation/*"
     service: dartdoc
+  - url: "dartdocs.org/*"
+    service: dartdoc
 


### PR DESCRIPTION
Already deployed, just forgot to commit the update.