### PR TITLE
Upgrade to dartdoc 0.19

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -156,6 +156,7 @@ class DartdocJobProcessor extends JobProcessor {
         hostedUrl: siteRoot,
         timeout: _dartdocTimeout,
         validateLinks: validateLinks,
+        linkToRemote: true,
       );
     }
 

--- a/app/lib/shared/service_utils.dart
+++ b/app/lib/shared/service_utils.dart
@@ -211,15 +211,17 @@ void _wrapper(List fnAndMessage) {
 
 Future initDartdoc(Logger logger) async {
   Future<bool> checkVersion() async {
-    final pr =
-        await Process.run('pub', ['global', 'run', 'dartdoc', '--version']);
+    final pr = await Process.run('pub', ['global', 'list']);
     if (pr.exitCode == 0) {
-      final RegExp versionRegExp = new RegExp(r'dartdoc version: (.*)$');
-      final match = versionRegExp.firstMatch(pr.stdout.toString().trim());
-      if (match == null) {
-        throw new Exception('Unable to parse dartdoc version: ${pr.stdout}');
+      final lines = pr.stdout
+          .toString()
+          .split('\n')
+          .where((line) => line.startsWith('dartdoc '))
+          .toList();
+      if (lines.isEmpty) {
+        return false;
       }
-      final version = match.group(1).trim();
+      final version = lines.single.split(' ').last;
       return version == dartdocVersion;
     } else {
       return false;

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -7,7 +7,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'utils.dart' show isNewer;
 
 // update this whenever one of the other versions change
-final String runtimeVersion = '2018.5.14+1';
+final String runtimeVersion = '2018.5.15';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 // keep in-sync with SDK version in .mono_repo.yml and Dockerfile
@@ -23,7 +23,7 @@ final String flutterVersion = '0.4.4';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
 // keep in-sync with SDK version in .mono_repo.yml and Dockerfile
-final String dartdocVersion = '0.18.1';
+final String dartdocVersion = '0.19.0';
 final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
 
 /// The version of our customization going into the output of the dartdoc static
@@ -33,7 +33,7 @@ final Version semanticCustomizationVersion =
     new Version.parse(customizationVersion);
 
 // Version that control the dartdoc serving.
-final dartdocServingRuntime = new Version.parse('2018.5.14+1');
+final dartdocServingRuntime = new Version.parse('2018.5.15');
 
 // Version that marks the default runtime version for analyzer entries created
 // before the runtime version was tracked.

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -19,7 +19,7 @@ void main() {
       dartdocVersion,
       customizationVersion,
     ].join('//').hashCode;
-    expect(hash, 192767651);
+    expect(hash, 22147483);
   });
 
   test('sdk version should match travis and dockerfile', () async {


### PR DESCRIPTION
#1254

- deployed to staging, looks good
- re-writing version checker to use `pub global list` as `dartdoc --version` does not work in 0.19.0 (fixed at head but not released yet)