### PR TITLE
Refactor JobProcessor and JobMaintenance

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -25,6 +25,14 @@ class AnalyzerJobProcessor extends JobProcessor {
       : super(service: JobService.analyzer, lockDuration: lockDuration);
 
   @override
+  Future<bool> shouldProcess(
+      String package, String version, DateTime updated) async {
+    final status =
+        await analysisBackend.checkTargetStatus(package, version, updated);
+    return !status.shouldSkip;
+  }
+
+  @override
   Future<JobStatus> process(Job job) async {
     final packageStatus = await analysisBackend.getPackageStatus(
         job.packageName, job.packageVersion);

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -35,6 +35,14 @@ class DartdocJobProcessor extends JobProcessor {
       : super(service: JobService.dartdoc, lockDuration: lockDuration);
 
   @override
+  Future<bool> shouldProcess(
+      String package, String version, DateTime updated) async {
+    final status =
+        await dartdocBackend.checkTargetStatus(package, version, updated, true);
+    return !status.shouldSkip;
+  }
+
+  @override
   Future<JobStatus> process(Job job) async {
     final tempDir =
         await Directory.systemTemp.createTemp('pub-dartlang-dartdoc');


### PR DESCRIPTION
- moved the `ShouldProcess` callback inside `JobProcessor`
- passing the processor reference into `JobMaintenance`
- `JobMaintenance.run()` to have the shared processing code in one place

In preparation of some change in #1310