### PR TITLE
Highly reduce the window of 404 on /documentation/[pkg]/latest.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -107,7 +107,7 @@ class DartdocJobProcessor extends JobProcessor {
       await _writeLog(outputDir, logFileOutput);
 
       final oldEntry = await dartdocBackend.getLatestEntry(
-          job.packageName, job.packageVersion, false);
+          job.packageName, job.packageVersion);
       if (entry.isRegression(oldEntry)) {
         _logger.severe('Regression detected in $job, aborting upload.');
       } else {

--- a/app/lib/shared/dartdoc_memcache.dart
+++ b/app/lib/shared/dartdoc_memcache.dart
@@ -59,6 +59,8 @@ class DartdocMemcache {
     return Future.wait([
       _entry.invalidate(_entryKey(package, version, true)),
       _entry.invalidate(_entryKey(package, version, false)),
+      _entry.invalidate(_entryKey(package, 'latest', true)),
+      _entry.invalidate(_entryKey(package, 'latest', false)),
     ]);
   }
 


### PR DESCRIPTION
Separated `getServingEntry`, with new fallback mechanism for `/latest/` URLs:
- If there is a doc generated for the latest stable version, let's use that.
- Otherwise tried the latest 10 versions, and if a stable version has a documentation, it will use that.

It handles #1316 for most use cases, except when the latest 10 version is all pre-release or they were uploaded in quick succession.
