### PR TITLE
Search index rewrite: two-step token matching.

### DIFF
--- a/app/test/search/angular_test.dart
+++ b/app/test/search/angular_test.dart
@@ -38,11 +38,11 @@ void main() {
         'packages': [
           {
             'package': 'angular',
-            'score': closeTo(0.971, 0.001),
+            'score': closeTo(0.993, 0.001),
           },
           {
             'package': 'angular_ui',
-            'score': closeTo(0.970, 0.001),
+            'score': closeTo(0.989, 0.001),
           },
         ],
       });

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -57,7 +57,7 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.986, 0.001), // finds package name
+            'score': closeTo(0.993, 0.001), // finds package name
           },
           {
             'package': 'other_with_api',
@@ -77,7 +77,7 @@ void main() {
         'packages': [
           {
             'package': 'other_with_api',
-            'score': closeTo(0.772, 0.001), // find serveWebPages
+            'score': closeTo(0.787, 0.001), // find serveWebPages
           },
           // should not contain `other_without_api`
         ],
@@ -94,7 +94,7 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.614, 0.001), // find WebPageGenerator
+            'score': closeTo(0.481, 0.001), // find WebPageGenerator
           },
           // should not contain `other_without_api`
         ],
@@ -110,11 +110,11 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.731, 0.001), // find WebPageGenerator
+            'score': closeTo(0.572, 0.001), // find WebPageGenerator
           },
           {
             'package': 'other_with_api',
-            'score': closeTo(0.617, 0.001), // find serveWebPages
+            'score': closeTo(0.147, 0.001), // find serveWebPages
           },
           // should not contain `other_without_api`
         ],

--- a/app/test/search/bluetooth_test.dart
+++ b/app/test/search/bluetooth_test.dart
@@ -39,7 +39,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_blue',
-            'score': closeTo(0.916, 0.001),
+            'score': closeTo(0.935, 0.001),
           },
         ],
       });

--- a/app/test/search/exact_name_test.dart
+++ b/app/test/search/exact_name_test.dart
@@ -21,13 +21,14 @@ void main() {
         version: '0.0.1',
         description: compactDescription(
             'Support for parsing `build.yaml` configuration.'),
+        readme: compactReadme('blah'),
         popularity: 0.1,
       ));
       await index.addPackage(new PackageDocument(
         package: 'build',
         version: '0.0.1',
         description: compactDescription('A build system for Dart.'),
-        readme: 'build and configure',
+        readme: compactReadme('build and configure'),
         popularity: 1.0,
       ));
       await index.merge();
@@ -42,11 +43,11 @@ void main() {
         'packages': [
           {
             'package': 'build_config',
-            'score': closeTo(0.5689, 0.0001),
+            'score': closeTo(0.579, 0.001),
           },
           {
             'package': 'build',
-            'score': closeTo(0.5683, 0.0001),
+            'score': closeTo(0.573, 0.001),
           },
         ],
       });

--- a/app/test/search/flutter_iap_test.dart
+++ b/app/test/search/flutter_iap_test.dart
@@ -57,7 +57,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.970, 0.001),
+            'score': closeTo(0.989, 0.001),
           },
         ],
       });
@@ -72,7 +72,7 @@ void main() {
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.970, 0.001),
+            'score': closeTo(0.989, 0.001),
           },
         ],
       });

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -89,7 +89,7 @@ void main() {
               'packages': [
                 {
                   'package': 'pkg_foo',
-                  'score': closeTo(0.30, 0.01),
+                  'score': closeTo(0.31, 0.01),
                 }
               ],
             });

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -376,7 +376,7 @@ MIT'''),
       await index.merge();
     });
 
-    test('hoversine', () async {
+    test('haversine', () async {
       final PackageSearchResult result = await index.search(
           new SearchQuery.parse(query: 'haversine', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
@@ -386,17 +386,40 @@ MIT'''),
           {
             // should be the top
             'package': 'haversine',
-            'score': closeTo(0.968, 0.001),
+            'score': closeTo(0.99, 0.01),
           },
           {
             // should be present
             'package': 'great_circle_distance',
-            'score': closeTo(0.843, 0.001),
+            'score': closeTo(0.86, 0.01),
           },
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(0.841, 0.001),
+            'score': closeTo(0.36, 0.01),
+          },
+        ]
+      });
+    });
+
+    test('type: hoversine', () async {
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(query: 'hoversine', order: SearchOrder.text));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 3,
+        'packages': [
+          {
+            'package': 'haversine',
+            'score': closeTo(0.99, 0.01),
+          },
+          {
+            'package': 'great_circle_distance',
+            'score': closeTo(0.86, 0.01),
+          },
+          {
+            'package': 'latlong',
+            'score': closeTo(0.86, 0.01),
           },
         ]
       });

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -35,7 +35,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.970, 0.001),
+            'score': closeTo(0.989, 0.001),
           },
         ],
       });
@@ -51,7 +51,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.784, 0.001),
+            'score': closeTo(0.840, 0.001),
           },
         ],
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -18,8 +18,7 @@ void main() {
 
       expect(index.search('xml'), {
         // no match for http
-        // the letter 'm' matches from http_magic
-        'uri://http_magic': closeTo(0.97, 0.01),
+        // no match for http_magic
       });
     });
 
@@ -28,8 +27,8 @@ void main() {
         ..add('uri://http', 'http')
         ..add('uri://http_magic', 'http_magic');
       expect(index.search('http'), {
-        'uri://http': closeTo(0.98, 0.01),
-        'uri://http_magic': closeTo(0.97, 0.01),
+        'uri://http': closeTo(0.993, 0.001),
+        'uri://http_magic': closeTo(0.989, 0.001),
       });
     });
 
@@ -40,14 +39,13 @@ void main() {
         ..add('queue_lower', queueText.toLowerCase())
         ..add('unmodifiable', 'CustomUnmodifiableMapBase');
       expect(index.search('queue'), {
-        'queue': closeTo(0.96, 0.01),
-        'queue_lower': closeTo(0.51, 0.01),
+        'queue': closeTo(0.98, 0.01),
       });
       expect(index.search('unmodifiab'), {
-        'unmodifiable': closeTo(0.95, 0.01),
+        'unmodifiable': closeTo(0.98, 0.01),
       });
       expect(index.search('unmodifiable'), {
-        'unmodifiable': closeTo(0.95, 0.01),
+        'unmodifiable': closeTo(0.98, 0.01),
       });
     });
 
@@ -58,11 +56,11 @@ void main() {
         ..add('uri://teamspeak', 'teamspeak');
 
       expect(index.search('riak'), {
-        'uri://riak_client': closeTo(0.97, 0.01),
+        'uri://riak_client': closeTo(0.99, 0.01),
       });
 
       expect(index.search('riak client'), {
-        'uri://riak_client': closeTo(0.97, 0.01),
+        'uri://riak_client': closeTo(0.99, 0.01),
       });
     });
 
@@ -70,11 +68,11 @@ void main() {
       final TokenIndex index = new TokenIndex();
       expect(index.tokenCount, 0);
       index.add('url1', 'text');
-      expect(index.tokenCount, 9);
+      expect(index.tokenCount, 1);
       index.add('url2', 'another');
-      expect(index.tokenCount, 32);
+      expect(index.tokenCount, 2);
       index.remove('url2');
-      expect(index.tokenCount, 9);
+      expect(index.tokenCount, 1);
     });
   });
 
@@ -195,7 +193,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'async',
-            'score': closeTo(0.91, 0.01),
+            'score': closeTo(0.92, 0.01),
           },
         ]
       });
@@ -210,7 +208,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {
             'package': 'http',
-            'score': closeTo(0.82, 0.01),
+            'score': closeTo(0.83, 0.01),
           },
         ]
       });
@@ -238,8 +236,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.85, 0.01)},
-          {'package': 'http', 'score': closeTo(0.76, 0.01)},
+          {'package': 'async', 'score': closeTo(0.86, 0.01)},
+          {'package': 'http', 'score': closeTo(0.78, 0.01)},
         ]
       });
     });
@@ -261,8 +259,8 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 2,
         'packages': [
-          {'package': 'async', 'score': closeTo(0.85, 0.01)},
-          {'package': 'http', 'score': closeTo(0.76, 0.01)},
+          {'package': 'async', 'score': closeTo(0.86, 0.01)},
+          {'package': 'http', 'score': closeTo(0.78, 0.01)},
         ],
       });
     });
@@ -289,21 +287,6 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 0,
         'packages': [],
-      });
-    });
-
-    test('order by text: double-letter tt', () async {
-      final PackageSearchResult result = await index
-          .search(new SearchQuery.parse(query: 'tt', order: SearchOrder.text));
-      expect(json.decode(json.encode(result)), {
-        'indexUpdated': isNotNull,
-        'totalCount': 1,
-        'packages': [
-          {
-            'package': 'http',
-            'score': closeTo(0.98, 0.01),
-          },
-        ],
       });
     });
 
@@ -451,7 +434,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.816, 0.001)},
+          {'package': 'http', 'score': closeTo(0.831, 0.001)},
         ],
       });
     });
@@ -488,7 +471,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.91, 0.01)},
+          {'package': 'http', 'score': closeTo(0.93, 0.01)},
         ],
       });
 
@@ -498,9 +481,9 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 3,
         'packages': [
-          {'package': 'chrome_net', 'score': closeTo(0.91, 0.01)},
-          {'package': 'async', 'score': closeTo(0.90, 0.01)},
-          {'package': 'http', 'score': closeTo(0.85, 0.01)},
+          {'package': 'chrome_net', 'score': closeTo(0.93, 0.01)},
+          {'package': 'async', 'score': closeTo(0.93, 0.01)},
+          {'package': 'http', 'score': closeTo(0.65, 0.01)},
         ],
       });
 
@@ -512,7 +495,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.814, 0.001)},
+          {'package': 'http', 'score': closeTo(0.623, 0.001)},
         ],
       });
     });

--- a/app/test/search/platform_specificity_test.dart
+++ b/app/test/search/platform_specificity_test.dart
@@ -111,15 +111,15 @@ void main() {
         'packages': [
           {
             'package': 'json_1',
-            'score': closeTo(0.2939, 0.0001),
+            'score': closeTo(0.2967, 0.0001),
           },
           {
             'package': 'json_2',
-            'score': closeTo(0.2645, 0.0001),
+            'score': closeTo(0.2670, 0.0001),
           },
           {
             'package': 'json_3',
-            'score': closeTo(0.2351, 0.0001),
+            'score': closeTo(0.2374, 0.0001),
           },
         ],
       });

--- a/app/test/search/rest_api_test.dart
+++ b/app/test/search/rest_api_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/search/index_simple.dart';
+import 'package:pub_dartlang_org/search/text_utils.dart';
+import 'package:pub_dartlang_org/shared/search_service.dart';
+
+void main() {
+  group('REST API', () {
+    SimplePackageIndex index;
+
+    setUpAll(() async {
+      index = new SimplePackageIndex();
+      await index.addPackage(new PackageDocument(
+        package: 'cloud_firestore',
+        version: '0.7.2',
+        description: compactDescription(
+            'Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database '
+            'with live synchronization and offline support on Android and iOS.'),
+        readme: compactReadme('''# Cloud Firestore Plugin for Flutter
+
+A Flutter plugin to use the [Cloud Firestore API](https://firebase.google.com/docs/firestore/).
+
+[![pub package](https://img.shields.io/pub/v/cloud_firestore.svg)](https://pub.dartlang.org/packages/cloud_firestore)
+
+For Flutter plugins for other Firebase products, see [FlutterFire.md](https://github.com/flutter/plugins/blob/master/FlutterFire.md).
+
+*Note*: This plugin is still under development, and some APIs might not be available yet. [Feedback](https://github.com/flutter/flutter/issues) and [Pull Requests](https://github.com/flutter/plugins/pulls) are most welcome!
+
+Recent versions (0.3.x and 0.4.x) of this plugin require [extensible codec functionality](https://github.com/flutter/flutter/pull/15414) that is not yet released to the [beta channel](https://github.com/flutter/flutter/wiki/Flutter-build-release-channels) of Flutter. If you're encountering issues using those versions, consider switching to the dev channel.'''),
+      ));
+      await index.addPackage(new PackageDocument(
+        package: 'currency_cloud',
+        version: '0.2.1',
+        description: compactDescription(
+            'A dart library for the Currency Cloud service. It operates as a '
+            'wrapper for the Currency Cloud REST API.'),
+        readme: compactReadme(
+            'Currency Cloud Dart API A dart library for the Currency Cloud '
+            'service Usage A simple usage example'),
+      ));
+      await index.merge();
+    });
+
+    test('REST API', () async {
+      final PackageSearchResult result = await index.search(
+          new SearchQuery.parse(query: 'rest api', order: SearchOrder.text));
+      expect(json.decode(json.encode(result)), {
+        'indexUpdated': isNotNull,
+        'totalCount': 1,
+        'packages': [
+          {
+            'package': 'currency_cloud',
+            'score': closeTo(0.879, 0.001),
+          },
+          // cloud_firestore should not show up
+        ],
+      });
+    });
+  });
+}

--- a/app/test/search/travis_test.dart
+++ b/app/test/search/travis_test.dart
@@ -60,7 +60,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
         'packages': [
           {
             'package': 'travis',
-            'score': closeTo(0.974, 0.001),
+            'score': closeTo(0.993, 0.001),
           },
         ],
       });


### PR DESCRIPTION
The new index will store only the tokens, and won't store the sub-strings (n-grams) anymore.

The lookup time is a bit longer, as we are trying to match a subset of tokens with the search terms, but in practice I haven't found slow lookups.

Closes #1329.