### PR TITLE
Upgrade Dart and Flutter SDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,19 @@ jobs:
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="app"
-      dart: 2.0.0-dev.58.0
+      dart: 2.0.0-dev.59.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="app"
-      dart: 2.0.0-dev.58.0
+      dart: 2.0.0-dev.59.0
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="pkg/_popularity"
-      dart: 2.0.0-dev.58.0
+      dart: 2.0.0-dev.59.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="pkg/_popularity"
-      dart: 2.0.0-dev.58.0
+      dart: 2.0.0-dev.59.0
 
 stages:
   - smoke_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep version in-sync with .travis.yml, .mono_repo.yml and app/lib/shared/versions.dart
-FROM google/dart-runtime-base:2.0.0-dev.58.0
+FROM google/dart-runtime-base:2.0.0-dev.59.0
 
 # `apt-mark hold dart` ensures that Dart is not upgraded with the other packages
 #   We want to make sure SDK upgrades are explicit.

--- a/app/.mono_repo.yml
+++ b/app/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.0.0-dev.58.0
+  - 2.0.0-dev.59.0
 
 stages:
   - smoke_test:

--- a/app/lib/shared/analyzer_service.g.dart
+++ b/app/lib/shared/analyzer_service.g.dart
@@ -23,10 +23,8 @@ AnalysisData _$AnalysisDataFromJson(Map<String, dynamic> json) =>
         runtimeVersion: json['runtimeVersion'] as String,
         panaVersion: json['panaVersion'] as String,
         flutterVersion: json['flutterVersion'] as String,
-        analysisStatus: json['analysisStatus'] == null
-            ? null
-            : AnalysisStatus.values.singleWhere((e) =>
-                e.toString() == 'AnalysisStatus.${json['analysisStatus']}'),
+        analysisStatus: $enumDecodeNullable('AnalysisStatus',
+            AnalysisStatus.values, json['analysisStatus'] as String),
         analysisContent: json['analysisContent'] as Map<String, dynamic>,
         maintenanceScore: (json['maintenanceScore'] as num)?.toDouble());
 
@@ -49,9 +47,7 @@ abstract class _$AnalysisDataSerializerMixin {
         'runtimeVersion': runtimeVersion,
         'panaVersion': panaVersion,
         'flutterVersion': flutterVersion,
-        'analysisStatus': analysisStatus == null
-            ? null
-            : analysisStatus.toString().split('.')[1],
+        'analysisStatus': analysisStatus?.toString()?.split('.')?.last,
         'maintenanceScore': maintenanceScore,
         'analysisContent': analysisContent
       };
@@ -59,10 +55,8 @@ abstract class _$AnalysisDataSerializerMixin {
 
 AnalysisExtract _$AnalysisExtractFromJson(Map<String, dynamic> json) =>
     new AnalysisExtract(
-        analysisStatus: json['analysisStatus'] == null
-            ? null
-            : AnalysisStatus.values.singleWhere((e) =>
-                e.toString() == 'AnalysisStatus.${json['analysisStatus']}'),
+        analysisStatus: $enumDecodeNullable('AnalysisStatus',
+            AnalysisStatus.values, json['analysisStatus'] as String),
         health: (json['health'] as num)?.toDouble(),
         maintenance: (json['maintenance'] as num)?.toDouble(),
         popularity: (json['popularity'] as num)?.toDouble(),
@@ -80,9 +74,7 @@ abstract class _$AnalysisExtractSerializerMixin {
   List<String> get platforms;
   DateTime get timestamp;
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'analysisStatus': analysisStatus == null
-            ? null
-            : analysisStatus.toString().split('.')[1],
+        'analysisStatus': analysisStatus?.toString()?.split('.')?.last,
         'health': health,
         'maintenance': maintenance,
         'popularity': popularity,

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -32,9 +32,8 @@ PackageDocument _$PackageDocumentFromJson(Map<String, dynamic> json) =>
         health: (json['health'] as num)?.toDouble(),
         popularity: (json['popularity'] as num)?.toDouble(),
         maintenance: (json['maintenance'] as num)?.toDouble(),
-        dependencies: json['dependencies'] == null
-            ? null
-            : new Map<String, String>.from(json['dependencies'] as Map),
+        dependencies: (json['dependencies'] as Map<String, dynamic>)
+            ?.map((k, e) => new MapEntry(k, e as String)),
         emails: (json['emails'] as List)?.map((e) => e as String)?.toList(),
         apiDocPages: (json['apiDocPages'] as List)
             ?.map((e) => e == null

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -7,11 +7,11 @@ import 'package:pub_semver/pub_semver.dart';
 import 'utils.dart' show isNewer;
 
 // update this whenever one of the other versions change
-final String runtimeVersion = '2018.5.25';
+final String runtimeVersion = '2018.5.31';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
-final String sdkVersion = '2.0.0-dev.58.0';
+final String sdkVersion = '2.0.0-dev.59.0';
 final Version semanticSdkVersion = new Version.parse(sdkVersion);
 
 // keep in-sync with app/pubspec.yaml
@@ -19,7 +19,7 @@ final String panaVersion = '0.11.3';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
 // keep in-sync with app/script/setup-flutter.sh
-final String flutterVersion = '0.4.4';
+final String flutterVersion = '0.5.1';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
 // keep in-sync with SDK version in .mono_repo.yml and Dockerfile
@@ -33,7 +33,7 @@ final Version semanticCustomizationVersion =
     new Version.parse(customizationVersion);
 
 // Version that control the dartdoc serving.
-final dartdocServingRuntime = new Version.parse('2018.5.25');
+final dartdocServingRuntime = new Version.parse('2018.5.31');
 
 // Version that marks the default runtime version for analyzer entries created
 // before the runtime version was tracked.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.32.0"
+    version: "0.32.1"
   appengine:
     dependency: "direct main"
     description:
@@ -175,7 +175,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   gcloud:
     dependency: "direct main"
     description:
@@ -224,7 +224,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.3+1"
   http:
     dependency: "direct main"
     description:
@@ -287,21 +287,21 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.6"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.4+1"
+    version: "0.5.5"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   logging:
     dependency: "direct main"
     description:
@@ -576,4 +576,4 @@ packages:
     source: hosted
     version: "2.1.14"
 sdks:
-  dart: ">=2.0.0-dev.55.0 <=2.0.0-dev.58.0"
+  dart: ">=2.0.0-dev.55.0 <=2.0.0-dev.59.0"

--- a/app/script/setup-flutter.sh
+++ b/app/script/setup-flutter.sh
@@ -22,7 +22,7 @@ then
   exit 1
 fi
 
-git clone -b v0.4.4 --single-branch https://github.com/flutter/flutter.git $FLUTTER_SDK
+git clone -b v0.5.1 --single-branch https://github.com/flutter/flutter.git $FLUTTER_SDK
 
 # Keep in-sync with app/lib/shared/versions.dart
 cd $FLUTTER_SDK

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -19,7 +19,7 @@ void main() {
       dartdocVersion,
       customizationVersion,
     ].join('//').hashCode;
-    expect(hash, 969849833);
+    expect(hash, 636211223);
   });
 
   test('sdk version should match travis and dockerfile', () async {

--- a/pkg/_popularity/.mono_repo.yml
+++ b/pkg/_popularity/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.0.0-dev.58.0
+  - 2.0.0-dev.59.0
 
 stages:
   - smoke_test:


### PR DESCRIPTION
- Some packages already depend on dev-59 as the minimum version, blocking analysis.
- Flutter 0.4.* is now a few weeks old, and Flutter devs are eager on upgrading.
- Deploying to staging.