### PR TITLE
Don't call pub upgrade in travis

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -12,7 +12,7 @@ if [ "$#" == "0" ]; then
 fi
 
 pushd $PKG
-pub upgrade || exit $?
+pub get || exit $?
 
 EXIT_CODE=0
 


### PR DESCRIPTION
With the current script the `pub upgrade` will pull in new dependencies and that may change the generated dart code, effectively failing the tests.
