### PR TITLE
Add API page references to the search results.

### DIFF
--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -11,6 +11,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../shared/analyzer_service.dart' show AnalysisExtract, AnalysisStatus;
 import '../shared/model_properties.dart';
+import '../shared/search_service.dart' show ApiPageRef;
 import '../shared/utils.dart';
 
 import 'model_properties.dart';
@@ -227,6 +228,7 @@ class PackageView {
   final double overallScore;
   final List<String> platforms;
   final bool isNewPackage;
+  final List<ApiPageRef> apiPages;
 
   PackageView({
     this.name,
@@ -239,12 +241,14 @@ class PackageView {
     this.overallScore,
     this.platforms,
     this.isNewPackage,
+    this.apiPages,
   });
 
   factory PackageView.fromModel({
     Package package,
     PackageVersion version,
     AnalysisExtract analysis,
+    List<ApiPageRef> apiPages,
   }) {
     final String devVersion =
         package != null && package.latestVersion != package.latestDevVersion
@@ -261,6 +265,7 @@ class PackageView {
       overallScore: analysis?.overallScore,
       platforms: analysis?.platforms,
       isNewPackage: package?.isNewPackage(),
+      apiPages: apiPages,
     );
   }
 }

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -27,17 +27,16 @@ class SearchService {
   /// max [numResults].
   Future<SearchResultPage> search(SearchQuery query) async {
     final result = await searchClient.search(query);
-    final List<String> packages =
-        result.packages.map((ps) => ps.package).toList();
-    return _loadResultForPackages(query, result.totalCount, packages);
+    return _loadResultForPackages(query, result.totalCount, result.packages);
   }
 
   Future close() async {}
 }
 
 Future<SearchResultPage> _loadResultForPackages(
-    SearchQuery query, int totalCount, List<String> packages) async {
-  final List<Key> packageKeys = packages
+    SearchQuery query, int totalCount, List<PackageScore> packageScores) async {
+  final List<Key> packageKeys = packageScores
+      .map((ps) => ps.package)
       .map((package) => dbService.emptyKey.append(Package, id: package))
       .toList();
   final List<Package> packageEntries = await dbService.lookup(packageKeys);
@@ -64,6 +63,7 @@ Future<SearchResultPage> _loadResultForPackages(
               package: packageEntries[i],
               version: versions[i],
               analysis: analysisExtracts[i],
+              apiPages: packageScores[i].apiPages,
             ));
     return new SearchResultPage(query, totalCount, resultPackages);
   } else {

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -130,6 +130,17 @@ class TemplateService {
             package: view.name),
         'score_box_html': _renderScoreBox(view.analysisStatus, overallScore,
             isNewPackage: view.isNewPackage, package: view.name),
+        'has_api_pages': view.apiPages != null && view.apiPages.isNotEmpty,
+        'api_pages': view.apiPages
+            ?.map((page) => {
+                  'title': page.title ?? page.path,
+                  'href': urls.pkgDocUrl(
+                    view.name,
+                    isLatest: true,
+                    relativePath: page.path,
+                  )
+                })
+            ?.toList(),
       });
     }
 

--- a/app/lib/shared/search_service.dart
+++ b/app/lib/shared/search_service.dart
@@ -441,11 +441,37 @@ class PackageScore extends Object with _$PackageScoreSerializerMixin {
   @JsonKey(includeIfNull: false)
   final double score;
 
+  @JsonKey(includeIfNull: false)
+  final List<ApiPageRef> apiPages;
+
   PackageScore({
     this.package,
     this.score,
+    this.apiPages,
   });
 
   factory PackageScore.fromJson(Map<String, dynamic> json) =>
       _$PackageScoreFromJson(json);
+
+  PackageScore change({
+    double score,
+    List<ApiPageRef> apiPages,
+  }) {
+    return new PackageScore(
+      package: package,
+      score: score ?? this.score,
+      apiPages: apiPages ?? this.apiPages,
+    );
+  }
+}
+
+@JsonSerializable()
+class ApiPageRef extends Object with _$ApiPageRefSerializerMixin {
+  final String title;
+  final String path;
+
+  ApiPageRef({this.title, this.path});
+
+  factory ApiPageRef.fromJson(Map<String, dynamic> json) =>
+      _$ApiPageRefFromJson(json);
 }

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -121,12 +121,18 @@ abstract class _$PackageSearchResultSerializerMixin {
 PackageScore _$PackageScoreFromJson(Map<String, dynamic> json) {
   return new PackageScore(
       package: json['package'] as String,
-      score: (json['score'] as num)?.toDouble());
+      score: (json['score'] as num)?.toDouble(),
+      apiPages: (json['apiPages'] as List)
+          ?.map((e) => e == null
+              ? null
+              : new ApiPageRef.fromJson(e as Map<String, dynamic>))
+          ?.toList());
 }
 
 abstract class _$PackageScoreSerializerMixin {
   String get package;
   double get score;
+  List<ApiPageRef> get apiPages;
   Map<String, dynamic> toJson() {
     var val = <String, dynamic>{
       'package': package,
@@ -139,6 +145,19 @@ abstract class _$PackageScoreSerializerMixin {
     }
 
     writeNotNull('score', score);
+    writeNotNull('apiPages', apiPages);
     return val;
   }
+}
+
+ApiPageRef _$ApiPageRefFromJson(Map<String, dynamic> json) {
+  return new ApiPageRef(
+      title: json['title'] as String, path: json['path'] as String);
+}
+
+abstract class _$ApiPageRefSerializerMixin {
+  String get title;
+  String get path;
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'title': title, 'path': path};
 }

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
 </head>
 <body>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
 </head>
 <body>

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="foobar_pkg Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="foobar_pkg Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="foobar_pkg Flutter and Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -26,7 +26,7 @@
   <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -26,7 +26,7 @@
   <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -26,7 +26,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
@@ -103,6 +103,13 @@
             <span class="package-tag missing" title="Analysis should be ready soon.">[awaiting]</span>
 
       </p>
+      <div class="api_pages">
+        API results:
+        <ul>
+          <li><a href="/documentation/foobar_pkg/latest/some/some-library.html">some&#x2F;some-library.html</a></li>
+          <li><a href="/documentation/foobar_pkg/latest/some/x-class.html">Class X</a></li>
+        </ul>
+      </div>
     </li>
     <li class="list-item -full">
       <a href="/packages/foobar_pkg#-analysis-tab-"><div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div></a>

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -25,7 +25,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -24,7 +24,7 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=18js5k8h2d638mkc6lerk5gr5g5hjavp" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
   <script src="/static/js/script.dart.js?hash=lh0u05gpmq85kgttnv1mvbecvkdb6g09" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -342,6 +342,10 @@ void main() {
             package: testPackage,
             version: testPackageVersion,
             analysis: new AnalysisExtract(),
+            apiPages: [
+              new ApiPageRef(path: 'some/some-library.html'),
+              new ApiPageRef(title: 'Class X', path: 'some/x-class.html'),
+            ],
           ),
           new PackageView.fromModel(
             package: testPackage,

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -62,6 +62,9 @@ void main() {
           {
             'package': 'other_with_api',
             'score': closeTo(0.794, 0.001), // finds foo method
+            'apiPages': [
+              {'title': null, 'path': 'main.html'},
+            ],
           },
           // should not contain `other_without_api`
         ],
@@ -78,6 +81,9 @@ void main() {
           {
             'package': 'other_with_api',
             'score': closeTo(0.787, 0.001), // find serveWebPages
+            'apiPages': [
+              {'title': null, 'path': 'serve.html'},
+            ],
           },
           // should not contain `other_without_api`
         ],
@@ -95,6 +101,9 @@ void main() {
           {
             'package': 'foo',
             'score': closeTo(0.481, 0.001), // find WebPageGenerator
+            'apiPages': [
+              {'title': null, 'path': 'generator.html'},
+            ],
           },
           // should not contain `other_without_api`
         ],
@@ -111,10 +120,16 @@ void main() {
           {
             'package': 'foo',
             'score': closeTo(0.572, 0.001), // find WebPageGenerator
+            'apiPages': [
+              {'title': null, 'path': 'generator.html'},
+            ],
           },
           {
             'package': 'other_with_api',
             'score': closeTo(0.147, 0.001), // find serveWebPages
+            'apiPages': [
+              {'title': null, 'path': 'serve.html'},
+            ],
           },
           // should not contain `other_without_api`
         ],

--- a/app/views/pkg/index.mustache
+++ b/app/views/pkg/index.mustache
@@ -34,6 +34,16 @@
         • Updated: <span>{{last_uploaded}}</span>
         {{& tags_html}}
       </p>
+      {{#has_api_pages}}
+      <div class="api_pages">
+        API results:
+        <ul>
+        {{#api_pages}}
+          <li><a href="{{& href}}">{{title}}</a></li>
+        {{/api_pages}}
+        </ul>
+      </div>
+      {{/has_api_pages}}
     </li>
   {{/packages}}
 </ul>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -458,13 +458,17 @@ pre > code {
   margin: 0;
 }
 
-.list-item > .metadata{
+.list-item > .metadata {
   font-size: 12px;
-  margin: 4px 0 0;
+  margin: 4px 0;
 }
 
 .list-item.-simple > .metadata > .package-tag:first-of-type{
   margin-left: 0;
+}
+
+.list-item > .api_pages {
+  font-size: 12px;
 }
 
 .score-box {


### PR DESCRIPTION
There is a bit more processing going on inside the search index, but I haven't noticed much slowdown during regular searches. The current changes are non-breaking, either of the services can be upgraded without the other.

An early version of the code is still deployed to staging, but the style changes have not been deployed there. The result looks like this:

<img width="395" alt="screen shot 2018-06-11 at 14 19 04" src="https://user-images.githubusercontent.com/4778111/41231317-fc1283fc-6d82-11e8-99d9-62fbc7437a3c.png">

Later on the visible text of the links should become `ecb_fx library` or `EcbFxClient class`, but that will be done only with the new dartdoc extraction code PR.