### PR TITLE
Bugfix: analyzer overrides the wrong list of suggestions.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -146,7 +146,8 @@ class AnalyzerJobProcessor extends JobProcessor {
 
   Future<Summary> _expandSummary(Summary summary, Duration age) async {
     if (summary.maintenance != null) {
-      final suggestions = new List<Suggestion>.from(summary.suggestions ?? []);
+      final suggestions =
+          new List<Suggestion>.from(summary.maintenance.suggestions ?? []);
 
       // age suggestion
       final ageSuggestion = getAgeSuggestion(age);


### PR DESCRIPTION
As a sideeffect, we are displaying non-perfect health scores without any explanation why the score is not perfect.