### PR TITLE
Refactoring static files handling for tests and auto-generated assets

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -110,18 +110,18 @@ class StaticUrls {
       'style_css': _getCacheableStaticUrl('/css/style.css'),
     };
   }
-}
 
-/// Returns the URL of a static resource
-String _getCacheableStaticUrl(String relativePath) {
-  if (!relativePath.startsWith('/')) {
-    relativePath = '/$relativePath';
-  }
-  final String requestPath = '${staticUrls.staticPath}$relativePath';
-  final file = staticsCache.getFile(requestPath);
-  if (file == null) {
-    throw new Exception('Static resource not found: $relativePath');
-  } else {
-    return '$requestPath?hash=${file.etag}';
+  /// Returns the URL of a static resource
+  String _getCacheableStaticUrl(String relativePath) {
+    if (!relativePath.startsWith('/')) {
+      relativePath = '/$relativePath';
+    }
+    final String requestPath = '$staticPath$relativePath';
+    final file = staticsCache.getFile(requestPath);
+    if (file == null) {
+      throw new Exception('Static resource not found: $relativePath');
+    } else {
+      return '$requestPath?hash=${file.etag}';
+    }
   }
 }

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -78,9 +78,10 @@ class StaticFile {
   );
 }
 
-final staticUrls = new StaticUrls(staticsCache.staticPath);
+final staticUrls = new StaticUrls();
 
 class StaticUrls {
+  final StaticsCache _cache;
   final String staticPath;
   final String smallDartFavicon;
   final String dartLogoSvg;
@@ -90,7 +91,12 @@ class StaticUrls {
   Map _versionsTableIcons;
   Map _assets;
 
-  StaticUrls(this.staticPath)
+  factory StaticUrls({StaticsCache cache}) {
+    cache ??= staticsCache;
+    return new StaticUrls._(cache, cache.staticPath);
+  }
+
+  StaticUrls._(this._cache, this.staticPath)
       : smallDartFavicon = '$staticPath/favicon.ico',
         dartLogoSvg = '$staticPath/img/dart-logo.svg',
         flutterLogo32x32 = '$staticPath/img/flutter-logo-32x32.png',
@@ -117,7 +123,7 @@ class StaticUrls {
       relativePath = '/$relativePath';
     }
     final String requestPath = '$staticPath$relativePath';
-    final file = staticsCache.getFile(requestPath);
+    final file = _cache.getFile(requestPath);
     if (file == null) {
       throw new Exception('Static resource not found: $relativePath');
     } else {

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -93,7 +93,7 @@ class StaticUrls {
   final String documentationIcon;
   final String downloadIcon;
   Map _versionsTableIcons;
-  Map _assets;
+  Map<String, String> _assets;
 
   factory StaticUrls({StaticsCache cache}) {
     cache ??= staticsCache;
@@ -114,7 +114,7 @@ class StaticUrls {
     };
   }
 
-  Map get assets {
+  Map<String, String> get assets {
     return _assets ??= {
       'script_dart_js': _getCacheableStaticUrl('/js/script.dart.js'),
       'style_css': _getCacheableStaticUrl('/css/style.css'),

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -28,6 +28,7 @@ String _resolveStaticDirPath() {
   throw new Exception('Unknown script: ${Platform.script}');
 }
 
+/// Stores static files in memory for fast http serving.
 class StaticsCache {
   final String staticPath = _defaultStaticPath;
   final Map<String, StaticFile> _staticFiles = <String, StaticFile>{};

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -21,7 +21,7 @@ import '../shared/utils.dart';
 
 import 'model_properties.dart' show Author;
 import 'models.dart';
-import 'static_files.dart';
+import 'static_files.dart' as sf;
 import 'template_consts.dart';
 
 String _escapeAngleBrackets(String msg) =>
@@ -46,7 +46,12 @@ class TemplateService {
   /// A cache which keeps all used mustach templates parsed in memory.
   final Map<String, mustache.Template> _CachedMustacheTemplates = {};
 
-  TemplateService({this.templateDirectory: '/project/app/views'});
+  final sf.StaticUrls staticUrls;
+
+  TemplateService({
+    this.templateDirectory: '/project/app/views',
+    sf.StaticUrls staticUrls,
+  }) : staticUrls = staticUrls ?? sf.staticUrls;
 
   /// Renders the `views/pkg/versions/index` template.
   String renderPkgVersionsPage(String package, List<PackageVersion> versions,
@@ -404,8 +409,8 @@ class TemplateService {
         'dependencies_html': _renderDependencyList(analysis),
         'analysis_html': renderAnalysisTab(package.name,
             selectedVersion.pubspec.sdkConstraint, extract, analysis),
-        'schema_org_pkgmeta_json':
-            json.encode(_schemaOrgPkgMeta(package, selectedVersion, analysis)),
+        'schema_org_pkgmeta_json': json.encode(
+            _schemaOrgPkgMeta(staticUrls, package, selectedVersion, analysis)),
       },
       'version_table_rows': versionTableRows,
       'show_versions_link': totalNumberOfVersions > versions.length,
@@ -981,7 +986,8 @@ const _schemaOrgSearchAction = const {
   },
 };
 
-Map _schemaOrgPkgMeta(Package p, PackageVersion pv, AnalysisView analysis) {
+Map _schemaOrgPkgMeta(sf.StaticUrls staticUrls, Package p, PackageVersion pv,
+    AnalysisView analysis) {
   final Map map = {
     '@context': 'http://schema.org',
     '@type': 'SoftwareSourceCode',

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
 </head>
 <body>
 <header class="site-header">

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
 </head>
 <body>
 <header class="site-header">

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -25,8 +25,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="foobar_pkg Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -25,8 +25,8 @@
   <meta property="og:description" content="foobar_pkg Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="foobar_pkg Flutter and Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -26,8 +26,8 @@
   <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -26,8 +26,8 @@
   <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -26,8 +26,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -25,8 +25,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -25,8 +25,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -25,8 +25,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -24,8 +24,8 @@
   <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="/static/highlight/github.css" rel="stylesheet" />
-  <link href="/static/css/style.css?hash=cc69ncs8qti1ldoshp4tnusgh051fi9j" rel="stylesheet" type="text/css" />
-  <script src="/static/js/script.dart.js?hash=2prutgjojfgngfkd798ggu39fqei61o5" defer></script>
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
   <script async="" defer="" src="//www.google.com/insights/consumersurveys/async_survey?site=5wdvu4vc5lhop3xbatxof6lzcm"></script>
 </head>
 <body>

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -15,6 +15,7 @@ import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
+import 'package:pub_dartlang_org/frontend/static_files.dart' as sf;
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
@@ -170,6 +171,9 @@ class TemplateMock implements TemplateService {
 
   @override
   String get templateDirectory => null;
+
+  @override
+  sf.StaticUrls get staticUrls => sf.staticUrls;
 
   @override
   String renderAuthorizedPage() {

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -12,6 +12,8 @@ import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 
+import 'utils.dart';
+
 void main() {
   group('dartdoc assets', () {
     Future checkAsset(String url, String path) async {
@@ -35,5 +37,26 @@ void main() {
         () => checkAsset(
             'https://github.com/dart-lang/dartdoc/raw/master/lib/resources/highlight.pack.js',
             '/static/highlight/highlight.pack.js'));
+  });
+
+  group('mocked static files', () {
+    test('exists', () {
+      for (String path in mockStaticFiles) {
+        final file = staticsCache.getFile('/static/$path');
+        expect(file, isNotNull);
+        expect(file.bytes.length, greaterThan(1000));
+        expect(file.etag.contains('mocked_hash'), isFalse);
+      }
+    });
+
+    test('urls populated with hash', () {
+      final assets = staticUrls.assets;
+      expect(assets.length, mockStaticFiles.length);
+      for (String value in assets.values) {
+        final parts = value.split('?hash=');
+        expect(parts.length, greaterThan(1));
+        expect(parts.last.length, greaterThan(20));
+      }
+    });
   });
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -13,6 +13,7 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/frontend/static_files.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 
 import 'utils.dart';
@@ -23,7 +24,18 @@ final _regenerateGoldens = false;
 
 void main() {
   group('templates', () {
-    final templates = new TemplateService(templateDirectory: 'views');
+    final templates = new TemplateService(
+        templateDirectory: 'views',
+        staticUrls: new StaticUrls(
+          cache: new StaticsCache.fromFiles(
+            mockStaticFiles
+                .map(
+                  (path) => new StaticFile(path, 'text/mock', [],
+                      new DateTime.now(), 'mocked_hash_${path.hashCode.abs()}'),
+                )
+                .toList(),
+          ),
+        ));
 
     void expectGoldenFile(String content, String fileName,
         {bool isFragment: false}) {

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -10,6 +10,11 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/frontend/model_properties.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 
+const mockStaticFiles = const <String>[
+  'js/script.dart.js',
+  'css/style.css',
+];
+
 class TestDelayCompletion {
   final int count;
   final Function _complete = expectAsync0(() {});


### PR DESCRIPTION
This is a follow-up PR to prepare the removal of the checked-in script.dart.js file. I've restructured the handling of static files to enable mocking in templates, and also added a pre-submit check to make sure that the mocked files do exists.