### PR TITLE
Remove static_files dependency from dartdoc customization

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart' as html_parser;
 
-import '../frontend/static_files.dart';
 import '../shared/urls.dart';
 
 class DartdocCustomizer {
@@ -76,7 +75,7 @@ class DartdocCustomizer {
     final logoLink = new Element.tag('a');
     logoLink.attributes['href'] = '$siteRoot/';
     final imgRef = new Element.tag('img');
-    imgRef.attributes['src'] = '$siteRoot${staticUrls.dartLogoSvg}';
+    imgRef.attributes['src'] = '$siteRoot/static/img/dart-logo.svg';
     imgRef.attributes['style'] = 'height: 30px; margin-right: 1em;';
     logoLink.append(imgRef);
     parent.insertBefore(logoLink, breadcrumbs);

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -8,6 +8,7 @@ import 'package:html/parser.dart';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/dartdoc/customization.dart';
+import 'package:pub_dartlang_org/frontend/static_files.dart';
 
 const String goldenDir = 'test/dartdoc/golden';
 
@@ -17,7 +18,12 @@ void main() {
   void expectGoldenFile(String content, String fileName) {
     // Making sure it is valid HTML
     final htmlParser = new HtmlParser(content, strict: true);
-    htmlParser.parse();
+    final doc = htmlParser.parse();
+
+    // Matching logo URLs with static files settings.
+    // If this fails, update the hard-coded customization URL to match it.
+    final logoElem = doc.documentElement.getElementsByTagName('img').first;
+    expect(logoElem.attributes['src'].endsWith(staticUrls.dartLogoSvg), isTrue);
 
     if (_regenerateGoldens) {
       new File('$goldenDir/$fileName').writeAsStringSync(content);


### PR DESCRIPTION
The URL match is still checked in the customization test, but the runtime dependency on it is removed, making `static_files.dart` only used inside the `app` service and no more in `dartdoc`. (Makes `script.dart.js` generation required only in one service instead of two.)