### PR TITLE
Decrease log level of concurrent transaction failures in the job processing.

### DIFF
--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -183,7 +183,7 @@ class JobBackend {
       try {
         await _unlock(job);
       } catch (e, st) {
-        _logger.warning('Unlock of $job failed.', e, st);
+        _logger.info('Unlock of $job failed.', e, st);
       }
     }
   }
@@ -235,7 +235,7 @@ class JobBackend {
           await _extend(job);
         }
       } catch (e, st) {
-        _logger.warning('Idle check of $job failed.', e, st);
+        _logger.info('Idle check of $job failed.', e, st);
       }
     }
   }

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -124,7 +124,7 @@ class JobMaintenance {
       try {
         await _updateFromTask(task);
       } catch (e, st) {
-        _logger.warning('Head sync failed for $task', e, st);
+        _logger.info('Head sync failed for $task', e, st);
       }
     }
   }
@@ -148,7 +148,7 @@ class JobMaintenance {
         await jobBackend.createOrUpdate(_processor.service, pv.package,
             pv.version, isLatestStable, pv.created, shouldProcess);
       } catch (e, st) {
-        _logger.warning(
+        _logger.info(
             'History sync failed for ${pv.package} ${pv.version}', e, st);
       }
     }


### PR DESCRIPTION
These events are considered normal under the conditions (8 or 16 concurrent process running against the same dataset, and if they happen to start about the same time, they might have conflicts).