### PR TITLE
Fix use of the dependency graph.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -55,12 +55,12 @@ class Backend {
   final DatastoreDB db;
   final GCloudPackageRepository repository;
   final UIPackageCache uiPackageCache;
-  final FinishedUploadCallback finishCallback;
 
   Backend(DatastoreDB db, TarballStorage storage,
-      {UIPackageCache cache, this.finishCallback})
+      {UIPackageCache cache, FinishedUploadCallback finishCallback})
       : db = db,
-        repository = new GCloudPackageRepository(db, storage, cache: cache),
+        repository = new GCloudPackageRepository(db, storage,
+            cache: cache, finishCallback: finishCallback),
         uiPackageCache = cache;
 
   /// Retrieves packages ordered by their created date.

--- a/app/lib/shared/deps_graph.dart
+++ b/app/lib/shared/deps_graph.dart
@@ -75,7 +75,9 @@ class PackageDependencyBuilder {
     final sw = new Stopwatch()..start();
     final builder = new PackageDependencyBuilder._(db);
     await builder.scanExistingPackageGraph();
-    _logger.warning('Scanned initial dependency graph in ${sw.elapsed}.');
+    if (sw.elapsed.inMinutes >= 1) {
+      _logger.warning('Scanned initial dependency graph in ${sw.elapsed}.');
+    }
     builder.monitorInBackground();
     return builder;
   }

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -53,9 +53,6 @@ class BackendMock implements Backend {
   final Function versionsOfPackageFun;
   final Function downloadUrlFun;
 
-  @override
-  final FinishedUploadCallback finishCallback;
-
   BackendMock({
     this.newestPackagesFun,
     this.latestPackageVersionsFun,
@@ -65,7 +62,6 @@ class BackendMock implements Backend {
     this.lookupPackageVersionFun,
     this.versionsOfPackageFun,
     this.downloadUrlFun,
-    this.finishCallback,
   });
 
   @override


### PR DESCRIPTION
I was chasing log entries, and it turns out that we have never really called the cascading analysis of the dependent packages when a new version is uploaded. We've stored the callback in the backend, and never called it or passed it to the real place where it is getting called.

I'm also changing the `await` logic of the notification: if there is an upload happening right after the instance is started, it could wait a minute on the graph to be built, before confirming to the upload.