### PR TITLE
Simplified static file cache handling.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -87,11 +87,8 @@ Future<shelf.Response> appHandler(
     return _docHandler(request);
   } else if (path == '/robots.txt' && !isProductionHost(request)) {
     return rejectRobotsHandler(request);
-  } else if (path.startsWith(staticUrls.staticPath)) {
+  } else if (staticFileCache.hasFile(request.requestedUri.path)) {
     return _staticsHandler(request);
-  } else if (staticRootFiles.contains(path)) {
-    return _staticsHandler(request,
-        pathOverride: '${staticUrls.staticPath}$path');
   } else {
     return _formattedNotFoundHandler(request);
   }
@@ -260,12 +257,10 @@ Future<shelf.Response> _packagesHandler(shelf.Request request) async {
   }
 }
 
-Future<shelf.Response> _staticsHandler(shelf.Request request,
-    {String pathOverride}) async {
+Future<shelf.Response> _staticsHandler(shelf.Request request) async {
   // Simplifies all of '.', '..', '//'!
-  final String normalized =
-      path.normalize(pathOverride ?? request.requestedUri.path);
-  final StaticFile staticFile = staticsCache.getFile(normalized);
+  final String normalized = path.normalize(request.requestedUri.path);
+  final StaticFile staticFile = staticFileCache.getFile(normalized);
   if (staticFile != null) {
     if (isNotModified(request, staticFile.lastModified, staticFile.etag)) {
       return new shelf.Response.notModified();

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -21,7 +21,7 @@ import '../shared/utils.dart';
 
 import 'model_properties.dart' show Author;
 import 'models.dart';
-import 'static_files.dart' as sf;
+import 'static_files.dart';
 import 'template_consts.dart';
 
 String _escapeAngleBrackets(String msg) =>
@@ -46,12 +46,7 @@ class TemplateService {
   /// A cache which keeps all used mustach templates parsed in memory.
   final Map<String, mustache.Template> _CachedMustacheTemplates = {};
 
-  final sf.StaticUrls staticUrls;
-
-  TemplateService({
-    this.templateDirectory: '/project/app/views',
-    sf.StaticUrls staticUrls,
-  }) : staticUrls = staticUrls ?? sf.staticUrls;
+  TemplateService({this.templateDirectory: '/project/app/views'});
 
   /// Renders the `views/pkg/versions/index` template.
   String renderPkgVersionsPage(String package, List<PackageVersion> versions,
@@ -409,8 +404,8 @@ class TemplateService {
         'dependencies_html': _renderDependencyList(analysis),
         'analysis_html': renderAnalysisTab(package.name,
             selectedVersion.pubspec.sdkConstraint, extract, analysis),
-        'schema_org_pkgmeta_json': json.encode(
-            _schemaOrgPkgMeta(staticUrls, package, selectedVersion, analysis)),
+        'schema_org_pkgmeta_json':
+            json.encode(_schemaOrgPkgMeta(package, selectedVersion, analysis)),
       },
       'version_table_rows': versionTableRows,
       'show_versions_link': totalNumberOfVersions > versions.length,
@@ -986,8 +981,7 @@ const _schemaOrgSearchAction = const {
   },
 };
 
-Map _schemaOrgPkgMeta(sf.StaticUrls staticUrls, Package p, PackageVersion pv,
-    AnalysisView analysis) {
+Map _schemaOrgPkgMeta(Package p, PackageVersion pv, AnalysisView analysis) {
   final Map map = {
     '@context': 'http://schema.org',
     '@type': 'SoftwareSourceCode',

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -15,7 +15,6 @@ import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
-import 'package:pub_dartlang_org/frontend/static_files.dart' as sf;
 import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
@@ -171,9 +170,6 @@ class TemplateMock implements TemplateService {
 
   @override
   String get templateDirectory => null;
-
-  @override
-  sf.StaticUrls get staticUrls => sf.staticUrls;
 
   @override
   String renderAuthorizedPage() {

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -19,7 +19,7 @@ void main() {
     Future checkAsset(String url, String path) async {
       final rs = await http.get(url);
       expect(rs.statusCode, 200);
-      final staticContent = staticsCache.getFile(path);
+      final staticContent = staticFileCache.getFile(path);
       expect(staticContent.bytes.length, rs.bodyBytes.length);
       final staticHash = crypto.sha256.convert(staticContent.bytes).toString();
       final dartdocHash = crypto.sha256.convert(rs.bodyBytes).toString();
@@ -42,7 +42,7 @@ void main() {
   group('mocked static files', () {
     test('exists', () {
       for (String path in mockStaticFiles) {
-        final file = staticsCache.getFile('/static/$path');
+        final file = staticFileCache.getFile('/static/$path');
         expect(file, isNotNull);
         expect(file.bytes.length, greaterThan(1000));
         expect(file.etag.contains('mocked_hash'), isFalse);

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -24,18 +24,21 @@ final _regenerateGoldens = false;
 
 void main() {
   group('templates', () {
-    final templates = new TemplateService(
-        templateDirectory: 'views',
-        staticUrls: new StaticUrls(
-          cache: new StaticsCache.fromFiles(
-            mockStaticFiles
-                .map(
-                  (path) => new StaticFile(path, 'text/mock', [],
-                      new DateTime.now(), 'mocked_hash_${path.hashCode.abs()}'),
-                )
-                .toList(),
-          ),
-        ));
+    setUpAll(() {
+      final cache = new StaticFileCache();
+      for (String path in mockStaticFiles) {
+        final file = new StaticFile(
+            '${staticUrls.staticPath}/$path',
+            'text/mock',
+            [],
+            new DateTime.now(),
+            'mocked_hash_${path.hashCode.abs()}');
+        cache.addFile(file);
+      }
+      registerStaticFileCache(cache);
+    });
+
+    final templates = new TemplateService(templateDirectory: 'views');
 
     void expectGoldenFile(String content, String fileName,
         {bool isFragment: false}) {


### PR DESCRIPTION
A follow-up to a previous comment:
- Enables explicit override of the static file cache (for tests).
- Simplifies request handler and templates.