### PR TITLE
Reduce concurrency in dartdoc job execution

### DIFF
--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -76,7 +76,7 @@ void _workerMain(WorkerEntryMessage message) {
       message.statsSendPort.send(await jobBackend.stats(JobService.dartdoc));
     });
 
-    await jobMaintenance.run(taskReceivePort, concurrency: 2);
+    await jobMaintenance.run(taskReceivePort);
   });
 }
 

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -78,16 +78,14 @@ class JobMaintenance {
   final JobProcessor _processor;
   JobMaintenance(this._db, this._processor);
 
-  Future run(Stream taskStream, {int concurrency: 1}) {
+  Future run(Stream taskStream) {
     final futures = <Future>[
       syncNotifications(taskStream),
       syncDatastoreHead(),
       syncDatastoreHistory(),
       updateStates(),
+      _processor.run(),
     ];
-    for (int i = 0; i < concurrency; i++) {
-      futures.add(_processor.run());
-    }
     return Future.wait(futures);
   }
 


### PR DESCRIPTION
Fixes #1390

- As we don't use that flag anywhere else, I'm also removing the related setup code.
- To my surprise, it didn't slow down the estimated overall time of the processing too much (I was expecting 5 days instead of 2.5, but it was only 3.5).
- If we want to re-introduce more parallel processing that involves Flutter, we should do that by having multiple Flutter instances on the local machine.