### PR TITLE
Proposal: ScoreCard model

### DIFF
--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:gcloud/db.dart' as db;
+import 'package:meta/meta.dart';
+
+import 'package:pub_dartlang_org/search/scoring.dart'
+    show calculateOverallScore;
+
+import '../shared/model_properties.dart';
+
+String _id(String packageName, String packageVersion) =>
+    '$packageName/$packageVersion';
+
+final _gzipCodec = new GZipCodec();
+
+/// Summary of various reports for a given PackageVersion.
+@db.Kind(name: 'ScoreCard', idType: db.IdType.String)
+class ScoreCard extends db.ExpandoModel {
+  @db.StringProperty(required: true)
+  String packageName;
+
+  @db.StringProperty(required: true)
+  String packageVersion;
+
+  @db.DateTimeProperty(required: true)
+  DateTime packageCreated;
+
+  @db.DateTimeProperty(required: true)
+  DateTime packageVersionCreated;
+
+  @db.BoolProperty()
+  bool isDiscontinued;
+
+  @CompatibleStringListProperty()
+  List<String> panaPlatformTags;
+
+  @db.DoubleProperty()
+  double documentationScore;
+
+  @db.DoubleProperty()
+  double healthScore;
+
+  @db.DoubleProperty()
+  double maintenanceScore;
+
+  @db.DoubleProperty()
+  double popularityScore;
+
+  @db.DoubleProperty()
+  double overallScore;
+
+  ScoreCard();
+
+  ScoreCard.init({
+    @required this.packageName,
+    @required this.packageVersion,
+    @required this.packageCreated,
+    @required this.packageVersionCreated,
+  }) {
+    id = _id(packageName, packageVersion);
+  }
+
+  void updateOverallScore() {
+    // TODO: use documentationScore too
+    overallScore = calculateOverallScore(
+      health: healthScore ?? 0.0,
+      maintenance: maintenanceScore ?? 0.0,
+      popularity: popularityScore ?? 0.0,
+    );
+  }
+}
+
+/// Detail of a specific report for a given PackageVersion.
+@db.Kind(name: 'ScoreCardReport', idType: db.IdType.String)
+class ScoreCardReport extends db.ExpandoModel {
+  @db.StringProperty(required: true)
+  String packageName;
+
+  @db.StringProperty(required: true)
+  String packageVersion;
+
+  @db.StringProperty(required: true)
+  String reportType;
+
+  @db.BlobProperty()
+  List<int> reportJsonGz;
+
+  ScoreCardReport();
+
+  ScoreCardReport.init({
+    @required this.packageName,
+    @required this.packageVersion,
+    @required this.reportType,
+  }) {
+    parentKey = db.dbService.emptyKey
+        .append(ScoreCard, id: _id(packageName, packageVersion));
+    id = reportType;
+  }
+
+  Map<String, dynamic> get reportJson {
+    if (reportJsonGz == null) return null;
+    return json.decode(utf8.decode(_gzipCodec.decode(reportJsonGz)))
+        as Map<String, dynamic>;
+  }
+
+  set reportJson(Map<String, dynamic> map) {
+    if (map == null) {
+      reportJsonGz = null;
+    } else {
+      reportJsonGz = _gzipCodec.encode(utf8.encode(json.encode(map)));
+    }
+  }
+}

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -33,21 +33,27 @@ class ScoreCard extends db.ExpandoModel {
   @db.DateTimeProperty(required: true)
   DateTime packageVersionCreated;
 
+  /// Whether the package has its discontinued flag set.
   @db.BoolProperty()
   bool isDiscontinued;
 
+  /// The platform tags (flutter, web, other) set by `pana` analysis.
   @CompatibleStringListProperty()
   List<String> panaPlatformTags;
 
+  /// Score for documentation coverage (0.0 - 1.0).
   @db.DoubleProperty()
   double documentationScore;
 
+  /// Score for code health (0.0 - 1.0).
   @db.DoubleProperty()
   double healthScore;
 
+  /// Score for package maintenance (0.0 - 1.0).
   @db.DoubleProperty()
   double maintenanceScore;
 
+  /// Score for package popularity (0.0 - 1.0).
   @db.DoubleProperty()
   double popularityScore;
 

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -57,9 +57,6 @@ class ScoreCard extends db.ExpandoModel {
   @db.DoubleProperty()
   double popularityScore;
 
-  @db.DoubleProperty()
-  double overallScore;
-
   ScoreCard();
 
   ScoreCard.init({
@@ -71,14 +68,13 @@ class ScoreCard extends db.ExpandoModel {
     id = _id(packageName, packageVersion);
   }
 
-  void updateOverallScore() {
-    // TODO: use documentationScore too
-    overallScore = calculateOverallScore(
-      health: healthScore ?? 0.0,
-      maintenance: maintenanceScore ?? 0.0,
-      popularity: popularityScore ?? 0.0,
-    );
-  }
+  double get overallScore =>
+      // TODO: use documentationScore too
+      calculateOverallScore(
+        health: healthScore ?? 0.0,
+        maintenance: maintenanceScore ?? 0.0,
+        popularity: popularityScore ?? 0.0,
+      );
 }
 
 /// Detail of a specific report for a given PackageVersion.


### PR DESCRIPTION
This is the first step for #1352:

`ScoreCard` would be the new all-unifying Datastore entity that holds PackageVersion score and other details (the current `AnalysisExtract`), while `ScoreCardReport` would be the new place for detailed reports for: `pana` (the current `AnalysisView`), `dartdoc` (coverage report and score), and possible further ones like runtime analysis.

I've opted to not having a two-level structure (like `Package` and `PackageVersion`), rather having a single entry for a given combination of that.

A long-term aspect: this should make the items in `lib/analysis/models.dart` obsolete.