### PR TITLE
Visual update: the rendering of suggestions

### DIFF
--- a/app/lib/frontend/template_consts.dart
+++ b/app/lib/frontend/template_consts.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:pana/models.dart' show SuggestionCode;
+
 import 'package:pub_dartlang_org/shared/platform.dart' show KnownPlatforms;
 
 import '../shared/urls.dart' as urls;
@@ -149,3 +151,14 @@ final String defaultPageDescriptionEscaped = htmlEscape.convert(
 
 String flutterSpecificPackagesHtml =
     '<a href="/packages?q=dependency%3Aflutter">Flutter-specific packages...</a>';
+
+final _suggestionHelpMessages = <String, String>{
+  SuggestionCode.analysisOptionsRenameRequired: 'Read more about the setup of '
+      '<a href="https://www.dartlang.org/guides/language/analysis-options#the-analysis-options-file">'
+      '<code>analysis-options.yaml</code></a>.',
+};
+
+String getSuggestionHelpMessage(String code) {
+  if (code == null) return null;
+  return _suggestionHelpMessages[code];
+}

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -11,6 +11,7 @@ import 'dart:math';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:meta/meta.dart';
 import 'package:mustache/mustache.dart' as mustache;
+import 'package:pana/models.dart' show SuggestionLevel;
 
 import '../shared/analyzer_client.dart';
 import '../shared/markdown.dart';
@@ -222,8 +223,10 @@ class TemplateService {
 
     final List suggestions = analysis.suggestions?.map((suggestion) {
       return {
-        'title': markdownToHtml(suggestion.title, null),
-        'description': markdownToHtml(suggestion.description, null),
+        'icon_class': _suggestionIconClass(suggestion.level),
+        'title_html': markdownToHtml(suggestion.title, null),
+        'description_html': markdownToHtml(suggestion.description, null),
+        'suggestion_help_html': getSuggestionHelpMessage(suggestion.code),
       };
     })?.toList();
 
@@ -1032,4 +1035,16 @@ String _renderPlainText(String text) =>
 String _attr(String value) {
   if (value == null) return null;
   return _attrEscaper.convert(value);
+}
+
+String _suggestionIconClass(String level) {
+  if (level == null) return 'suggestion-icon-info';
+  switch (level) {
+    case SuggestionLevel.error:
+      return 'suggestion-icon-danger';
+    case SuggestionLevel.warning:
+      return 'suggestion-icon-warning';
+    default:
+      return 'suggestion-icon-info';
+  }
 }

--- a/app/test/frontend/golden/analysis_tab_http.html
+++ b/app/test/frontend/golden/analysis_tab_http.html
@@ -78,49 +78,83 @@ Learn more about <a href="/help#scoring">scoring</a>.
 </blockquote>
 
 <h4>Suggestions</h4>
-<ul>
-    <li>
-      <div><p>Running <code>dartdoc</code> failed.</p>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-danger"></span>
+    <p>Running <code>dartdoc</code> failed.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>Make sure <code>dartdoc</code> runs without any issues.</p>
+
+    
+  </div>
 </div>
-      <blockquote><p>Make sure <code>dartdoc</code> runs without any issues.</p>
-</blockquote>
-    </li>
-    <li>
-      <div><p>Fix analysis and formatting issues.</p>
-</div>
-      <blockquote><p>Analysis or formatting checks reported 37 hints.</p>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-info"></span>
+    <p>Fix analysis and formatting issues.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>Analysis or formatting checks reported 37 hints.</p>
 <p>Run <code>dartfmt</code> to format <code>lib/browser_client.dart</code>.</p>
 <p>Strong-mode analysis of <code>lib/http.dart</code> gave the following hint:</p>
 <p>line: 88 col: 29<br />
 'UTF8' is deprecated and shouldn't be used.</p>
 <p>Similar analysis of the following files failed:</p><ul><li><code>lib/src/base_client.dart</code> (hint)</li><li><code>lib/src/base_request.dart</code> (hint)</li><li><code>lib/src/base_response.dart</code> (hint)</li><li><code>lib/src/byte_stream.dart</code> (hint)</li><li><code>lib/src/client.dart</code> (hint)</li><li><code>lib/src/io_client.dart</code> (hint)</li><li><code>lib/src/mock_client.dart</code> (hint)</li><li><code>lib/src/multipart_file.dart</code> (hint)</li><li><code>lib/src/multipart_request.dart</code> (hint)</li><li><code>lib/src/request.dart</code> (hint)</li><li><code>lib/src/response.dart</code> (hint)</li><li><code>lib/src/streamed_request.dart</code> (hint)</li><li><code>lib/src/streamed_response.dart</code> (hint)</li><li><code>lib/src/utils.dart</code> (hint)</li></ul>
-</blockquote>
-    </li>
-    <li>
-      <div><p>The description is too short.</p>
+
+    
+  </div>
 </div>
-      <blockquote><p>Add more detail about the package, what it does and what is its target use case. Try to write at least 60 characters.</p>
-</blockquote>
-    </li>
-    <li>
-      <div><p>Package is pre-v1 release.</p>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-info"></span>
+    <p>The description is too short.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>Add more detail about the package, what it does and what is its target use case. Try to write at least 60 characters.</p>
+
+    
+  </div>
 </div>
-      <blockquote><p>While there is nothing inherently wrong with versions of <code>0.*.*</code>, it usually means that the author is still experimenting with the general direction API.</p>
-</blockquote>
-    </li>
-    <li>
-      <div><p>Maintain an example.</p>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-info"></span>
+    <p>Package is pre-v1 release.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>While there is nothing inherently wrong with versions of <code>0.*.*</code>, it usually means that the author is still experimenting with the general direction API.</p>
+
+    
+  </div>
 </div>
-      <blockquote><p>Create a short demo in the <code>example/</code> directory to show how to use this package. Common file name patterns include: <code>main.dart</code>, <code>example.dart</code> or you could also use <code>http.dart</code>.</p>
-</blockquote>
-    </li>
-    <li>
-      <div><p>Use <code>analysis_options.yaml</code>.</p>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-info"></span>
+    <p>Maintain an example.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>Create a short demo in the <code>example/</code> directory to show how to use this package. Common file name patterns include: <code>main.dart</code>, <code>example.dart</code> or you could also use <code>http.dart</code>.</p>
+
+    
+  </div>
 </div>
-      <blockquote><p>Rename old <code>.analysis_options</code> file to <code>analysis_options.yaml</code>.</p>
-</blockquote>
-    </li>
-</ul>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-info"></span>
+    <p>Use <code>analysis_options.yaml</code>.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>Rename old <code>.analysis_options</code> file to <code>analysis_options.yaml</code>.</p>
+
+    
+  </div>
+</div>
 
 <h4>Dependencies</h4>
 <div class="overflow-x">

--- a/app/test/frontend/golden/analysis_tab_mock.html
+++ b/app/test/frontend/golden/analysis_tab_mock.html
@@ -78,14 +78,18 @@ Learn more about <a href="/help#scoring">scoring</a>.
 </blockquote>
 
 <h4>Suggestions</h4>
-<ul>
-    <li>
-      <div><p>Fix <code>dartfmt</code>.</p>
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="suggestion-icon-danger"></span>
+    <p>Fix <code>dartfmt</code>.</p>
+
+  </div>
+  <div class="suggestion-description">
+    <p>Running <code>dartfmt -n .</code> failed.</p>
+
+    
+  </div>
 </div>
-      <blockquote><p>Running <code>dartfmt -n .</code> failed.</p>
-</blockquote>
-    </li>
-</ul>
 
 <h4>Dependencies</h4>
 <div class="overflow-x">

--- a/app/views/pkg/analysis_tab.mustache
+++ b/app/views/pkg/analysis_tab.mustache
@@ -91,14 +91,18 @@ Learn more about <a href="/help#scoring">scoring</a>.
 
 {{#hasSuggestions}}
 <h4>Suggestions</h4>
-<ul>
-  {{#suggestions}}
-    <li>
-      <div>{{& title}}</div>
-      <blockquote>{{& description}}</blockquote>
-    </li>
-  {{/suggestions}}
-</ul>
+{{#suggestions}}
+<div class="suggestion-row">
+  <div class="suggestion-title">
+    <span class="{{icon_class}}"></span>
+    {{& title_html}}
+  </div>
+  <div class="suggestion-description">
+    {{& description_html}}
+    {{& suggestion_help_html}}
+  </div>
+</div>
+{{/suggestions}}
 {{/hasSuggestions}}
 
 {{#has_dependency}}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1074,6 +1074,52 @@ pre > code {
   visibility: visible;
 }
 
+.suggestion-row {
+  padding: 2px;
+}
+
+.suggestion-row:hover {
+  background-color: #f8f8f8;
+}
+
+.suggestion-title {
+  font-weight: bold;
+}
+
+.suggestion-icon-info,
+.suggestion-icon-warning,
+.suggestion-icon-danger {
+  float: left;
+  margin: 2px 20px 0px 0px;
+}
+
+.suggestion-icon-info {
+  display: inline-block;
+  width: 0px;
+  height: 0px;
+  border: 10px solid lightblue;
+  border-radius: 10px;
+}
+
+.suggestion-icon-warning {
+  display: inline-block;
+  width: 0px;
+  height: 0px;
+  border: 10px solid orange;
+  border-radius: 10px;
+}
+
+.suggestion-icon-danger {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: red;
+}
+
+.suggestion-description {
+  margin-left: 40px;
+}
+
 /******************************************************
   searchbar
 ******************************************************/

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1105,8 +1105,9 @@ pre > code {
   display: inline-block;
   width: 0px;
   height: 0px;
-  border: 10px solid orange;
-  border-radius: 10px;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 20px solid orange;
 }
 
 .suggestion-icon-danger {


### PR DESCRIPTION
- deployed to [staging](https://dartlang-pub-dev.appspot.com/)

- visual upgrades include icon-like things and a subtle hover effect, e.g. a [bad package](https://dartlang-pub-dev.appspot.com/packages/db_executor#-analysis-tab-)

- enables additional help page (#1354), e.g. [http](https://dartlang-pub-dev.appspot.com/packages/db_executor#-analysis-tab-) packages' last entry has a link that is now customizable via the pub site's codebase
