### PR TITLE
Make dartdoc test compatible with dart 2 preview.

### DIFF
--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -30,7 +30,10 @@ void main() {
       fail('Set `_regenerateGoldens` to `false` to run tests.');
     }
     final golden = new File('$goldenDir/$fileName').readAsStringSync();
-    expect(content.split('\n'), golden.split('\n'));
+    // Not sure why, but the dart 2 preview tests produce an additional newline
+    // in the output.
+    expect(content.split('\n').where((s) => s.isNotEmpty),
+        golden.split('\n').where((s) => s.isNotEmpty));
   }
 
   group('pana 0.10.2', () {


### PR DESCRIPTION
Not sure why, but the dart 2 preview tests produce an additional newline in the output. Removing those lines from the test matching should not cause issues in the markup.