### PR TITLE
Use runtimeVersion in dartdoc memcache's key.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -134,10 +134,9 @@ class DartdocBackend {
 
   /// Return the latest entry that should be used to serve the content.
   Future<DartdocEntry> getServingEntry(String package, String version) async {
-    final cachedContent =
-        await dartdocMemcache?.getEntryBytes(package, version, true);
-    if (cachedContent != null) {
-      return new DartdocEntry.fromBytes(cachedContent);
+    final cachedEntry = await dartdocMemcache?.getEntry(package, version);
+    if (cachedEntry != null) {
+      return cachedEntry;
     }
 
     Future<DartdocEntry> loadVersion(String v) async {
@@ -173,10 +172,7 @@ class DartdocBackend {
       }
     }
 
-    if (entry != null) {
-      await dartdocMemcache?.setEntryBytes(
-          package, version, true, entry.asBytes());
-    }
+    await dartdocMemcache?.setEntry(entry);
     return entry;
   }
 

--- a/app/lib/shared/dartdoc_client.dart
+++ b/app/lib/shared/dartdoc_client.dart
@@ -78,16 +78,16 @@ class DartdocClient {
   }
 
   Future<DartdocEntry> getEntry(String package, String version) async {
-    final cachedContent =
-        await dartdocMemcache?.getEntryBytes(package, version, true);
-    if (cachedContent != null) {
-      return new DartdocEntry.fromBytes(cachedContent);
+    final cachedEntry = await dartdocMemcache?.getEntry(package, version);
+    if (cachedEntry != null) {
+      return cachedEntry;
     }
     final content = await getContentBytes(package, version, statusFilePath);
-    if (content != null) {
-      await dartdocMemcache?.setEntryBytes(package, version, true, content);
-      return new DartdocEntry.fromBytes(content);
+    if (content == null) {
+      return null;
     }
-    return null;
+    final entry = new DartdocEntry.fromBytes(content);
+    await dartdocMemcache?.setEntry(entry);
+    return entry;
   }
 }


### PR DESCRIPTION
This makes sure that a given service will serve entries only with its runtime version, and won't set / override the cache of a newer one. When a traffic migrations happens, the new versions will be served without any cache invalidation delay.

Closes #1376
