### PR TITLE
Use JobBackend instead of HTTP-based notification trigger.

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -18,7 +18,6 @@ import 'package:pub_dartlang_org/shared/dartdoc_memcache.dart';
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
-import 'package:pub_dartlang_org/shared/task_client.dart';
 
 import 'package:pub_dartlang_org/analyzer/backend.dart';
 import 'package:pub_dartlang_org/analyzer/handlers.dart';
@@ -45,7 +44,6 @@ void _frontendMain(FrontendEntryMessage message) {
 
   final statsConsumer = new ReceivePort();
   registerSchedulerStatsStream(statsConsumer as Stream<Map>);
-  registerTaskSendPort(message.taskSendPort);
   message.protocolSendPort.send(new FrontendProtocolMessage(
     statsConsumerPort: statsConsumer.sendPort,
   ));
@@ -59,9 +57,7 @@ void _frontendMain(FrontendEntryMessage message) {
 void _workerMain(WorkerEntryMessage message) {
   setupServiceIsolate();
 
-  final ReceivePort taskReceivePort = new ReceivePort();
-  message.protocolSendPort
-      .send(new WorkerProtocolMessage(taskSendPort: taskReceivePort.sendPort));
+  message.protocolSendPort.send(new WorkerProtocolMessage());
 
   withAppEngineServices(() async {
     _registerServices();
@@ -72,7 +68,7 @@ void _workerMain(WorkerEntryMessage message) {
       message.statsSendPort.send(await jobBackend.stats(JobService.analyzer));
     });
 
-    await jobMaintenance.run(taskReceivePort);
+    await jobMaintenance.run();
   });
 }
 

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -20,7 +20,6 @@ import 'package:pub_dartlang_org/shared/dartdoc_memcache.dart';
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
-import 'package:pub_dartlang_org/shared/task_client.dart';
 
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/dartdoc/dartdoc_runner.dart';
@@ -47,7 +46,6 @@ void _frontendMain(FrontendEntryMessage message) {
 
   final statsConsumer = new ReceivePort();
   registerSchedulerStatsStream(statsConsumer as Stream<Map>);
-  registerTaskSendPort(message.taskSendPort);
   message.protocolSendPort.send(new FrontendProtocolMessage(
     statsConsumerPort: statsConsumer.sendPort,
   ));
@@ -61,9 +59,7 @@ void _frontendMain(FrontendEntryMessage message) {
 void _workerMain(WorkerEntryMessage message) {
   setupServiceIsolate();
 
-  final ReceivePort taskReceivePort = new ReceivePort();
-  message.protocolSendPort
-      .send(new WorkerProtocolMessage(taskSendPort: taskReceivePort.sendPort));
+  message.protocolSendPort.send(new WorkerProtocolMessage());
 
   withAppEngineServices(() async {
     await _registerServices();
@@ -76,7 +72,7 @@ void _workerMain(WorkerEntryMessage message) {
       message.statsSendPort.send(await jobBackend.stats(JobService.dartdoc));
     });
 
-    await jobMaintenance.run(taskReceivePort);
+    await jobMaintenance.run();
   });
 }
 

--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -15,6 +15,7 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import 'package:pub_dartlang_org/history/backend.dart';
 import 'package:pub_dartlang_org/history/models.dart';
+import 'package:pub_dartlang_org/job/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/analyzer_memcache.dart';
 import 'package:pub_dartlang_org/shared/configuration.dart';
@@ -78,6 +79,7 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
   registerScopeExitCallback(searchClient.close);
 
   registerHistoryBackend(new HistoryBackend(db.dbService));
+  registerJobBackend(new JobBackend(db.dbService));
 
   new NameTrackerUpdater(db.dbService).startNameTrackerUpdates();
 

--- a/app/bin/tools/flag.dart
+++ b/app/bin/tools/flag.dart
@@ -11,6 +11,7 @@ import 'package:gcloud/db.dart';
 
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/service_utils.dart';
+import 'package:pub_dartlang_org/job/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/package_memcache.dart';
 
@@ -72,6 +73,7 @@ Future _read(String packageName) async {
 }
 
 Future _set(String packageName, {String discontinued, String doNotAdvertise}) {
+  registerJobBackend(new JobBackend(dbService));
   return dbService.withTransaction((Transaction tx) async {
     final Package p =
         (await tx.lookup([dbService.emptyKey.append(Package, id: packageName)]))

--- a/app/bin/tools/notify_service.dart
+++ b/app/bin/tools/notify_service.dart
@@ -4,7 +4,10 @@
 
 import 'dart:async';
 
+import 'package:gcloud/db.dart';
+
 import 'package:pub_dartlang_org/frontend/service_utils.dart';
+import 'package:pub_dartlang_org/job/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_client.dart';
@@ -25,6 +28,7 @@ Future main(List<String> args) async {
   }
 
   await withProdServices(() async {
+    registerJobBackend(new JobBackend(dbService));
     registerAnalyzerClient(new AnalyzerClient());
     registerDartdocClient(new DartdocClient());
     registerSearchClient(new SearchClient());

--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -8,7 +8,6 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/analyzer_service.dart';
 import '../shared/handlers.dart';
-import '../shared/notification.dart';
 
 import 'backend.dart';
 
@@ -16,7 +15,6 @@ import 'backend.dart';
 Future<shelf.Response> analyzerServiceHandler(shelf.Request request) async {
   final path = request.requestedUri.path;
   final shelf.Handler handler = {
-    apiNotificationEndpoint: notificationHandler,
     '/debug': _debugHandler,
     '/robots.txt': rejectRobotsHandler,
   }[path];

--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -9,7 +9,6 @@ import 'package:http_parser/http_parser.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/handlers.dart';
-import '../shared/notification.dart';
 import '../shared/urls.dart';
 import '../shared/utils.dart' show contentType, redirectDartdocPages;
 
@@ -38,7 +37,6 @@ Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
   final path = request.requestedUri.path;
   final shelf.Handler handler = {
     '/': _indexHandler,
-    apiNotificationEndpoint: notificationHandler,
     '/debug': _debugHandler,
   }[path];
 

--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -54,7 +54,7 @@ class JobBackend {
     final pList = await _db.lookup([pKey]);
     final Package p = pList[0];
     if (p == null) {
-      _logger.info('Couldn\'t trigger $service job: $package not found.');
+      _logger.info("Couldn't trigger $service job: $package not found.");
       return;
     }
 
@@ -64,7 +64,7 @@ class JobBackend {
     final PackageVersion pv = list[0];
     if (pv == null) {
       _logger
-          .info('Couldn\'t trigger $service job: $package $version not found.');
+          .info("Couldn't trigger $service job: $package $version not found.");
       return;
     }
 

--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -10,6 +10,8 @@ import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
 import 'package:uuid/uuid.dart';
 
+import '../frontend/models.dart';
+
 import '../shared/utils.dart';
 import '../shared/versions.dart' as versions;
 
@@ -46,6 +48,30 @@ class JobBackend {
           version,
         ],
       ).toString();
+
+  Future trigger(JobService service, String package, [String version]) async {
+    final pKey = _db.emptyKey.append(Package, id: package);
+    final pList = await _db.lookup([pKey]);
+    final Package p = pList[0];
+    if (p == null) {
+      _logger.info('Couldn\'t trigger $service job: $package not found.');
+      return;
+    }
+
+    version ??= p.latestVersion;
+    final pvKey = pKey.append(PackageVersion, id: version);
+    final list = await _db.lookup([pvKey]);
+    final PackageVersion pv = list[0];
+    if (pv == null) {
+      _logger
+          .info('Couldn\'t trigger $service job: $package $version not found.');
+      return;
+    }
+
+    final isLatestStable = p.latestVersion == version;
+    await createOrUpdate(
+        service, package, version, isLatestStable, pv.created, true);
+  }
 
   Future createOrUpdate(
     JobService service,

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -78,27 +78,14 @@ class JobMaintenance {
   final JobProcessor _processor;
   JobMaintenance(this._db, this._processor);
 
-  Future run(Stream taskStream) {
+  Future run() {
     final futures = <Future>[
-      syncNotifications(taskStream),
       syncDatastoreHead(),
       syncDatastoreHistory(),
       updateStates(),
       _processor.run(),
     ];
     return Future.wait(futures);
-  }
-
-  /// Completes when the taskStream closes.
-  Future syncNotifications(Stream taskStream) async {
-    await for (Task task in taskStream) {
-      try {
-        await jobBackend.trigger(
-            _processor.service, task.package, task.version);
-      } catch (e, st) {
-        _logger.warning('Notification processing failed for $task', e, st);
-      }
-    }
   }
 
   /// Never completes.

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -93,24 +93,12 @@ class JobMaintenance {
   Future syncNotifications(Stream taskStream) async {
     await for (Task task in taskStream) {
       try {
-        await _updateFromTask(task);
+        await jobBackend.trigger(
+            _processor.service, task.package, task.version);
       } catch (e, st) {
         _logger.warning('Notification processing failed for $task', e, st);
       }
     }
-  }
-
-  Future _updateFromTask(Task task) async {
-    final pKey = _db.emptyKey.append(Package, id: task.package);
-    final pvKey = pKey.append(PackageVersion, id: task.version);
-    final list = await _db.lookup([pKey, pvKey]);
-    final Package p = list[0];
-    final PackageVersion pv = list[1];
-    if (p == null || pv == null) return;
-
-    final isLatestStable = p.latestVersion == task.version;
-    await jobBackend.createOrUpdate(_processor.service, task.package,
-        task.version, isLatestStable, pv.created, true);
   }
 
   /// Never completes.
@@ -120,7 +108,8 @@ class JobMaintenance {
     final stream = source.startStreaming();
     await for (Task task in stream) {
       try {
-        await _updateFromTask(task);
+        await jobBackend.trigger(
+            _processor.service, task.package, task.version);
       } catch (e, st) {
         _logger.info('Head sync failed for $task', e, st);
       }

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -10,11 +10,12 @@ import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:pana/pana.dart';
 
+import '../job/backend.dart';
+
 import 'analyzer_memcache.dart';
 import 'analyzer_service.dart';
 import 'configuration.dart';
 import 'memcache.dart' show analyzerDataLocalExpiration;
-import 'notification.dart' show notifyService;
 import 'platform.dart';
 import 'popularity_storage.dart';
 import 'utils.dart';
@@ -152,11 +153,13 @@ class AnalyzerClient {
 
   Future triggerAnalysis(
       String package, String version, Set<String> dependentPackages) async {
-    await notifyService(
-        _client, _analyzerServiceHttpHostPort, package, version);
-
+    if (jobBackend == null) {
+      _logger.warning('Job backend is not initialized!');
+      return;
+    }
+    await jobBackend.trigger(JobService.analyzer, package, version);
     for (final String package in dependentPackages) {
-      await notifyService(_client, _analyzerServiceHttpHostPort, package, null);
+      await jobBackend.trigger(JobService.analyzer, package);
     }
   }
 

--- a/app/lib/shared/dartdoc_client.dart
+++ b/app/lib/shared/dartdoc_client.dart
@@ -12,10 +12,10 @@ import 'package:pool/pool.dart';
 
 import '../dartdoc/dartdoc_runner.dart' show statusFilePath;
 import '../dartdoc/models.dart' show DartdocEntry;
+import '../job/backend.dart';
 
 import 'configuration.dart';
 import 'dartdoc_memcache.dart';
-import 'notification.dart' show notifyService;
 import 'utils.dart' show getUrlWithRetry;
 
 export '../dartdoc/models.dart' show DartdocEntry;
@@ -48,10 +48,13 @@ class DartdocClient {
 
   Future triggerDartdoc(
       String package, String version, Set<String> dependentPackages) async {
-    await notifyService(_client, _dartdocServiceHttpHostPort, package, version);
-
+    if (jobBackend == null) {
+      _logger.warning('Job backend is not initialized!');
+      return;
+    }
+    await jobBackend.trigger(JobService.dartdoc, package, version);
     for (final String package in dependentPackages) {
-      await notifyService(_client, _dartdocServiceHttpHostPort, package, null);
+      await jobBackend.trigger(JobService.dartdoc, package);
     }
   }
 

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -107,20 +107,6 @@ void main() {
             });
       });
     });
-
-    group('trigger analysis', () {
-      scopedTest('/packages/pkg', () async {
-        await expectNotFoundResponse(await issuePost('/packages/pkg'));
-      });
-
-      scopedTest('/api/notification', () async {
-        // TODO: mock notification secret and re-enable testing task receive
-        await expectJsonResponse(
-            await issuePost('/api/notification',
-                body: {'package': 'foo', 'version': '1.0.0'}),
-            body: {'success': false});
-      });
-    });
   });
 }
 


### PR DESCRIPTION
#1409

The direct use of the `JobBackend` was long overdue, the http-based notification predates it and it is less reliable. It also allows a cleanup in the isolate initialization and handling, as less coordination is needed at that point.