### PR TITLE
Unblock updating a Job with errors.

### DIFF
--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -76,10 +76,6 @@ class JobBackend {
             // already scheduled for processing
             return;
           }
-          if (current.errorCount > 0) {
-            // prevent untimely re-try of a failed job
-            return;
-          }
         }
         if (isNewer(
             versions.semanticRuntimeVersion, current.semanticRuntimeVersion)) {


### PR DESCRIPTION
Big part of #1409: the package analysis was failing and had `errorCount > 0`. We already make the re-analysis periods longer and longer on each new error, no need to block when an update is called.