### PR TITLE
Reducing the update period for popularity data.

### DIFF
--- a/app/lib/shared/popularity_storage.dart
+++ b/app/lib/shared/popularity_storage.dart
@@ -43,7 +43,7 @@ class PopularityStorage {
 
   Future init() async {
     await fetch('init');
-    new Timer.periodic(const Duration(days: 1), (_) {
+    new Timer.periodic(const Duration(hours: 4), (_) {
       fetch('refetch');
     });
   }


### PR DESCRIPTION
If there is a large gap in the updates, the score will be changing abruptly, and more frequent updates will reduce the window of potential inconsistency between different parts of our stack.