### PR TITLE
Set documentation link to the canonical doc root.

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -13,8 +13,9 @@ import '../shared/urls.dart';
 class DartdocCustomizer {
   final String packageName;
   final String packageVersion;
+  final bool isLatestStable;
 
-  DartdocCustomizer(this.packageName, this.packageVersion);
+  DartdocCustomizer(this.packageName, this.packageVersion, this.isLatestStable);
 
   Future<bool> customizeDir(String path) async {
     bool changed = false;
@@ -47,6 +48,14 @@ class DartdocCustomizer {
     if (breadcrumbs != null) {
       _addPubSiteLogo(breadcrumbs);
       _addPubPackageLink(breadcrumbs);
+      // Set "documentation" link to the canonical doc root.
+      final docRoot = isLatestStable
+          ? pkgDocUrl(packageName, isLatest: true)
+          : pkgDocUrl(packageName, version: packageVersion);
+      breadcrumbs
+          .querySelectorAll('a')
+          .where((e) => e.attributes['href'] == 'index.html')
+          .forEach((e) => e.attributes['href'] = docRoot);
     }
     return doc.outerHtml;
   }

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -100,7 +100,8 @@ class DartdocJobProcessor extends JobProcessor {
       }
 
       if (hasContent) {
-        await new DartdocCustomizer(job.packageName, job.packageVersion)
+        await new DartdocCustomizer(
+                job.packageName, job.packageVersion, job.isLatestStable)
             .customizeDir(outputDir);
 
         await _tar(tempDirPath, tarDir, outputDir, logFileOutput);

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -34,7 +34,7 @@ void main() {
   }
 
   group('pana 0.10.2', () {
-    final customization = new DartdocCustomizer('pana', '0.10.2+0');
+    final customization = new DartdocCustomizer('pana', '0.10.2+0', false);
 
     void expectMatch(String name) {
       test(name, () {

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -16,33 +16,43 @@ final _regenerateGoldens = false;
 
 void main() {
   void expectGoldenFile(String content, String fileName) {
-    // Making sure it is valid HTML
-    final htmlParser = new HtmlParser(content, strict: true);
-    final doc = htmlParser.parse();
+    if (fileName.endsWith('.html')) {
+      // Making sure it is valid HTML
+      final htmlParser = new HtmlParser(content, strict: true);
+      final doc = htmlParser.parse();
 
-    // Matching logo URLs with static files settings.
-    // If this fails, update the hard-coded customization URL to match it.
-    final logoElem = doc.documentElement.getElementsByTagName('img').first;
-    expect(logoElem.attributes['src'].endsWith(staticUrls.dartLogoSvg), isTrue);
-
+      // Matching logo URLs with static files settings.
+      // If this fails, update the hard-coded customization URL to match it.
+      final logoElem = doc.documentElement.getElementsByTagName('img').first;
+      expect(
+          logoElem.attributes['src'].endsWith(staticUrls.dartLogoSvg), isTrue);
+    }
     if (_regenerateGoldens) {
       new File('$goldenDir/$fileName').writeAsStringSync(content);
-      fail('Set `_regenerateGoldens` to `false` to run tests.');
     }
+
     final golden = new File('$goldenDir/$fileName').readAsStringSync();
     expect(content.split('\n'), golden.split('\n'));
   }
 
   group('pana 0.10.2', () {
-    final customization = new DartdocCustomizer('pana', '0.10.2+0', false);
+    final prevCustomizer = new DartdocCustomizer('pana', '0.10.2+0', false);
+    final latestCustomizer = new DartdocCustomizer('pana', '0.10.2+0', true);
 
     void expectMatch(String name) {
       test(name, () {
         final inputName = 'pana_0.10.2_$name.html';
         final outputName = 'pana_0.10.2_$name.out.html';
+        final diffName = 'pana_0.10.2_$name.latest.diff';
         final html = new File('$goldenDir/$inputName').readAsStringSync();
-        final result = customization.customizeHtml(html) ?? html;
-        expectGoldenFile(result, outputName);
+        final prevResult = prevCustomizer.customizeHtml(html) ?? html;
+        final latestResult = latestCustomizer.customizeHtml(html) ?? html;
+        expectGoldenFile(prevResult, outputName);
+        expectGoldenFile(_miniDiff(prevResult, latestResult), diffName);
+
+        if (_regenerateGoldens) {
+          fail('Set `_regenerateGoldens` to `false` to run tests.');
+        }
       });
     }
 
@@ -52,4 +62,59 @@ void main() {
     expectMatch('license_file_name_field');
     expectMatch('pretty_json');
   });
+}
+
+String _miniDiff(String text1, String text2) {
+  final lines1 = text1.split('\n');
+  final lines2 = text2.split('\n');
+
+  final report = <String>[];
+
+  while (lines1.isNotEmpty || lines2.isNotEmpty) {
+    if (lines2.isEmpty) {
+      for (String line in lines1) {
+        report.add('- $line');
+      }
+      break;
+    }
+    if (lines1.isEmpty) {
+      for (String line in lines2) {
+        report.add('+ $line');
+      }
+      break;
+    }
+    if (lines1.last == lines2.last) {
+      lines1.removeLast();
+      lines2.removeLast();
+      continue;
+    }
+    if (lines1.first == lines2.first) {
+      lines1.removeAt(0);
+      lines2.removeAt(0);
+      continue;
+    }
+    final index1in2 = lines2.indexOf(lines1.first);
+    final index2in1 = lines1.indexOf(lines2.first);
+    if (index1in2 == -1) {
+      final line = lines1.removeAt(0);
+      report.add('- $line');
+      continue;
+    }
+    if (index2in1 == -1) {
+      final line = lines2.removeAt(0);
+      report.add('+ $line');
+      continue;
+    }
+    if (index1in2 > index2in1) {
+      final line = lines1.removeAt(0);
+      report.add('- $line');
+      continue;
+    } else {
+      final line = lines2.removeAt(0);
+      report.add('+ $line');
+      continue;
+    }
+  }
+
+  return report.map((s) => '$s\n').join();
 }

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
@@ -1,0 +1,2 @@
+-     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -31,7 +31,7 @@
   <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
-    <li><a href="index.html">documentation</a></li>
+    <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li class="self-crumb">LicenseFile class</li>
   </ol>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
@@ -1,0 +1,2 @@
+-     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -31,7 +31,7 @@
   <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
-    <li><a href="index.html">documentation</a></li>
+    <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
     <li class="self-crumb">LicenseFile constructor</li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
@@ -1,0 +1,2 @@
+-     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -31,7 +31,7 @@
   <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
-    <li><a href="index.html">documentation</a></li>
+    <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li><a href="pana/LicenseFile-class.html">LicenseFile</a></li>
     <li class="self-crumb">name property</li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
@@ -1,0 +1,2 @@
+-     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -31,7 +31,7 @@
   <a href="https://pub.dartlang.org/"><img src="https://pub.dartlang.org/static/img/dart-logo.svg" style="height: 30px; margin-right: 1em;"></a>
   <ol class="breadcrumbs gt-separated dark hidden-xs">
     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
-    <li><a href="index.html">documentation</a></li>
+    <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
     <li><a href="pana/pana-library.html">pana</a></li>
     <li class="self-crumb">prettyJson function</li>
   </ol>


### PR DESCRIPTION
#1368 

Otherwise each page would point to the `/documentation/pkg/version/index.html`, which we don't want.