### PR TITLE
Increase upload and delete parallelism in dartdoc, and add further logging.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -25,8 +25,8 @@ import 'storage_path.dart' as storage_path;
 final Logger _logger = new Logger('pub.dartdoc.backend');
 
 final Duration _contentDeleteThreshold = const Duration(days: 1);
-final int _concurrentUploads = 4;
-final int _concurrentDeletes = 4;
+final int _concurrentUploads = 8;
+final int _concurrentDeletes = 8;
 
 /// Sets the dartdoc backend.
 void registerDartdocBackend(DartdocBackend backend) =>

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -211,7 +211,11 @@ class DartdocJobProcessor extends JobProcessor {
           pr, pr.exitCode == 15, hasIndexHtml, hasIndexJson);
     }
 
+    final sw = new Stopwatch()..start();
     DartdocResult r = await runDartdoc(true);
+    sw.stop();
+    _logger.info('Running dartdoc for ${job.packageName} ${job.packageVersion} '
+        'completed in ${sw.elapsed}.');
     if (r.wasTimeout) {
       r = await runDartdoc(false);
     }


### PR DESCRIPTION
#1333

It should be OK to double this, because in a previous PR ~ two weeks ago we have cut in half the concurrently running dartdoc builds and uploads, so doubling this only match the total server load of that time.

The logging should give use a bit more insight about the proportion of the timing, and where to focus the efforts.