### PR TITLE
Dartdoc SEO updates

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -50,6 +50,7 @@ class DartdocCustomizer {
     _addAlternateUrl(doc.head, canonical);
     _addAnalyticsTracker(doc.head);
     final breadcrumbs = doc.body.querySelector('.breadcrumbs');
+    final breadcrumbsDepth = breadcrumbs?.children?.length ?? 0;
     if (breadcrumbs != null) {
       _addPubSiteLogo(breadcrumbs);
       _addPubPackageLink(breadcrumbs);
@@ -62,7 +63,7 @@ class DartdocCustomizer {
           .where((e) => e.attributes['href'] == 'index.html')
           .forEach((e) => e.attributes['href'] = docRoot);
     }
-    if (!isLatestStable) {
+    if (!isLatestStable || breadcrumbsDepth > 3) {
       _addMetaNoIndex(doc.head);
     }
     return doc.outerHtml;

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -62,6 +62,9 @@ class DartdocCustomizer {
           .where((e) => e.attributes['href'] == 'index.html')
           .forEach((e) => e.attributes['href'] = docRoot);
     }
+    if (!isLatestStable) {
+      _addMetaNoIndex(doc.head);
+    }
     return doc.outerHtml;
   }
 
@@ -88,6 +91,15 @@ class DartdocCustomizer {
 
     head.insertBefore(link, canonical);
     head.insertBefore(new Text('\n  '), canonical);
+  }
+
+  void _addMetaNoIndex(Element head) {
+    final meta = new Element.tag('meta');
+    meta.attributes['name'] = 'robots';
+    meta.attributes['content'] = 'noindex';
+
+    head.insertBefore(meta, head.firstChild);
+    head.insertBefore(new Text('\n  '), head.firstChild);
   }
 
   void _addAnalyticsTracker(Element head) {

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -42,7 +42,11 @@ class DartdocCustomizer {
 
   String customizeHtml(String html) {
     final doc = html_parser.parse(html);
-    _stripCanonicalUrl(doc);
+    final canonical = doc.head.getElementsByTagName('link').firstWhere(
+          (elem) => elem.attributes['rel'] == 'canonical',
+          orElse: () => null,
+        );
+    _stripCanonicalUrl(canonical);
     _addAnalyticsTracker(doc.head);
     final breadcrumbs = doc.body.querySelector('.breadcrumbs');
     if (breadcrumbs != null) {
@@ -60,19 +64,13 @@ class DartdocCustomizer {
     return doc.outerHtml;
   }
 
-  void _stripCanonicalUrl(Document doc) {
-    doc.head
-        .getElementsByTagName('link')
-        .where((elem) => elem.attributes['rel'] == 'canonical')
-        .forEach(
-      (elem) {
-        final href = elem.attributes['href'];
-        if (href != null && href.endsWith('/index.html')) {
-          elem.attributes['href'] =
-              href.substring(0, href.length - 'index.html'.length);
-        }
-      },
-    );
+  void _stripCanonicalUrl(Element elem) {
+    if (elem == null) return;
+    final href = elem.attributes['href'];
+    if (href != null && href.endsWith('/index.html')) {
+      elem.attributes['href'] =
+          href.substring(0, href.length - 'index.html'.length);
+    }
   }
 
   void _addAnalyticsTracker(Element head) {

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -47,6 +47,7 @@ class DartdocCustomizer {
           orElse: () => null,
         );
     _stripCanonicalUrl(canonical);
+    _addAlternateUrl(doc.head, canonical);
     _addAnalyticsTracker(doc.head);
     final breadcrumbs = doc.body.querySelector('.breadcrumbs');
     if (breadcrumbs != null) {
@@ -71,6 +72,22 @@ class DartdocCustomizer {
       elem.attributes['href'] =
           href.substring(0, href.length - 'index.html'.length);
     }
+  }
+
+  void _addAlternateUrl(Element head, Element canonical) {
+    if (isLatestStable) return;
+
+    final link = new Element.tag('link');
+    link.attributes['rel'] = 'alternate';
+    link.attributes['href'] = pkgDocUrl(packageName, isLatest: true);
+
+    if (canonical == null) {
+      head.append(link);
+      return;
+    }
+
+    head.insertBefore(link, canonical);
+    head.insertBefore(new Text('\n  '), canonical);
   }
 
   void _addAnalyticsTracker(Element head) {

--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -108,8 +108,8 @@ class DartdocCustomizer {
   }
 
   void _addPubPackageLink(Element breadcrumbs) {
-    final pubPackageLink =
-        pkgPageUrl(packageName, version: packageVersion, includeHost: true);
+    final pubPackageLink = pkgPageUrl(packageName,
+        version: isLatestStable ? null : packageVersion, includeHost: true);
     final pubPackageText = '$packageName package';
     if (breadcrumbs.children.length == 1) {
       // we are on the index page

--- a/app/test/dartdoc/golden/pana_0.10.2_index.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.latest.diff
@@ -1,0 +1,2 @@
+-     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
++     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.latest.diff
@@ -1,3 +1,4 @@
+-   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 +     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.latest.diff
@@ -1,2 +1,3 @@
+-   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 +     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
+  <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/app/test/dartdoc/golden/pana_0.10.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_index.out.html
@@ -12,6 +12,7 @@
   <meta name="generator" content="made with love by dartdoc 0.20.0">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
+  <link rel="alternate" href="/documentation/pana/latest/">
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/">
 
   <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500,400i,400,300|Source+Sans+Pro:400,300,700" rel="stylesheet">

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
@@ -1,3 +1,4 @@
+-   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
@@ -1,2 +1,4 @@
+-     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>
 +     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.latest.diff
@@ -1,3 +1,4 @@
+-   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
 +     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -11,6 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="API docs for the LicenseFile class from the pana library, for the Dart programming language.">
   <title>LicenseFile class - pana library - Dart API</title>
+  <link rel="alternate" href="/documentation/pana/latest/">
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/pana/LicenseFile-class.html">
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_class.out.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
+  <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
@@ -1,4 +1,3 @@
--   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
@@ -1,3 +1,4 @@
+-   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
@@ -1,2 +1,4 @@
+-     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>
 +     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.latest.diff
@@ -1,3 +1,4 @@
+-   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
 +     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
+  <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_constructor.out.html
@@ -11,6 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="API docs for the LicenseFile constructor from the Class LicenseFile class from the pana library, for the Dart programming language.">
   <title>LicenseFile constructor - LicenseFile class - pana library - Dart API</title>
+  <link rel="alternate" href="/documentation/pana/latest/">
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/pana/LicenseFile/LicenseFile.html">
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
@@ -1,4 +1,3 @@
--   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
@@ -1,3 +1,4 @@
+-   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
@@ -1,2 +1,4 @@
+-     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>
 +     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.latest.diff
@@ -1,3 +1,4 @@
+-   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
 +     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
+  <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_license_file_name_field.out.html
@@ -11,6 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="API docs for the name property from the LicenseFile class, for the Dart programming language.">
   <title>name property - LicenseFile class - pana library - Dart API</title>
+  <link rel="alternate" href="/documentation/pana/latest/">
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/pana/LicenseFile/name.html">
   <!-- required because all the links are pseudo-absolute -->
   <base href="../..">

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
@@ -1,3 +1,4 @@
+-   <meta name="robots" content="noindex">
 -   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
@@ -1,2 +1,4 @@
+-     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
++     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>
 +     <li><a href="/documentation/pana/latest/">documentation</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.latest.diff
@@ -1,3 +1,4 @@
+-   <link rel="alternate" href="/documentation/pana/latest/">
 -     <li><a href="https://pub.dartlang.org/packages/pana/versions/0.10.2+0">pana package</a></li>
 -     <li><a href="/documentation/pana/0.10.2+0/">documentation</a></li>
 +     <li><a href="https://pub.dartlang.org/packages/pana">pana package</a></li>

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><html lang="en"><head>
+  <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.10.2_pretty_json.out.html
@@ -11,6 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="API docs for the prettyJson function from the pana library, for the Dart programming language.">
   <title>prettyJson function - pana library - Dart API</title>
+  <link rel="alternate" href="/documentation/pana/latest/">
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.10.2/pana/prettyJson.html">
   <!-- required because all the links are pseudo-absolute -->
   <base href="..">


### PR DESCRIPTION
Handles all of the currently pending items in #1368. One notable difference compared to the comments on that issue: I'm not adding a visible link to the latest stable documentation (yet), only a `<link rel="alternate">` element in the header. I've found it a bit confusing, and couldn't figure a good place for it yet. 