### PR TITLE
Revert to dev.63 SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,27 @@ jobs:
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="app"
-      dart: 2.0.0-dev.66.0
+      dart: 2.0.0-dev.63.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="app"
-      dart: 2.0.0-dev.66.0
+      dart: 2.0.0-dev.63.0
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="pkg/_popularity"
-      dart: 2.0.0-dev.66.0
+      dart: 2.0.0-dev.63.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="pkg/_popularity"
-      dart: 2.0.0-dev.66.0
+      dart: 2.0.0-dev.63.0
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="pkg/pub_dartdoc"
-      dart: 2.0.0-dev.66.0
+      dart: 2.0.0-dev.63.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="pkg/pub_dartdoc"
-      dart: 2.0.0-dev.66.0
+      dart: 2.0.0-dev.63.0
 
 stages:
   - smoke_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,11 @@ RUN pub get --offline --no-precompile
 ENV GAE_MEMCACHE_HOST 35.190.255.1
 ENV GAE_MEMCACHE_PORT 11211
 
+RUN cd / && \
+    curl -sS https://storage.googleapis.com/dart-archive/channels/dev/release/2.0.0-dev.69.0/sdk/dartsdk-linux-x64-release.zip >/dartsdk.zip && \
+    unzip -q /dartsdk.zip && \
+    rm -f /dartsdk.zip
+
 # Clear out any arguments the base images might have set and ensure we start
 # memcached and wait for it to come up before running the Dart app.
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep version in-sync with .travis.yml, .mono_repo.yml and app/lib/shared/versions.dart
-FROM google/dart-runtime-base:2.0.0-dev.66.0
+FROM google/dart-runtime-base:2.0.0-dev.63.0
 
 # `apt-mark hold dart` ensures that Dart is not upgraded with the other packages
 #   We want to make sure SDK upgrades are explicit.

--- a/analyzer.yaml
+++ b/analyzer.yaml
@@ -9,6 +9,7 @@ env_variables:
   # Needs to be in sync with app/script/setup-flutter.sh and with app/lib/shared/configuration.dart
   FLUTTER_ROOT: '/flutter'
   FLUTTER_SDK: '/flutter'
+  TOOL_ENV_DART_SDK: '/dart-sdk'
 
 resources:
   cpu: 1

--- a/app/.mono_repo.yml
+++ b/app/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.0.0-dev.66.0
+  - 2.0.0-dev.63.0
 
 stages:
   - smoke_test:

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -79,6 +79,7 @@ class AnalyzerJobProcessor extends JobProcessor {
         final pubCacheDir = p.join(tempDirPath, 'pub-cache');
         await new Directory(pubCacheDir).create();
         final toolEnv = await ToolEnvironment.create(
+          dartSdkDir: envConfig.toolEnvDartSdkDir,
           flutterSdkDir: envConfig.flutterSdkDir,
           pubCacheDir: pubCacheDir,
         );

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -63,8 +63,9 @@ class DartdocJobProcessor extends JobProcessor {
     await new Directory(outputDir).create(recursive: true);
 
     final toolEnv = await ToolEnvironment.create(
-      pubCacheDir: pubCacheDir,
+      dartSdkDir: envConfig.toolEnvDartSdkDir,
       flutterSdkDir: envConfig.flutterSdkDir,
+      pubCacheDir: pubCacheDir,
     );
 
     final latestVersion =

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -259,7 +259,7 @@ class DartdocJobProcessor extends JobProcessor {
       isObsolete: isObsolete,
       usesFlutter: usesFlutter,
       runtimeVersion: versions.runtimeVersion,
-      sdkVersion: versions.sdkVersion,
+      sdkVersion: versions.toolEnvSdkVersion,
       dartdocVersion: versions.dartdocVersion,
       flutterVersion: versions.flutterVersion,
       customizationVersion: versions.customizationVersion,

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -117,7 +117,7 @@ class DartdocEntry extends Object with _$DartdocEntrySerializerMixin {
       if (hasContent &&
           !usesFlutter &&
           flutterVersion != versions.flutterVersion &&
-          sdkVersion == versions.sdkVersion &&
+          sdkVersion == versions.toolEnvSdkVersion &&
           dartdocVersion == versions.dartdocVersion &&
           customizationVersion == versions.customizationVersion) {
         return new TaskTargetStatus.skip(

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -91,6 +91,7 @@ class EnvConfig {
   final String gaeService;
   final String gcloudKey;
   final String gcloudProject;
+  final String toolEnvDartSdkDir;
   final String flutterSdkDir;
   final int frontendCount;
   final int workerCount;
@@ -99,6 +100,7 @@ class EnvConfig {
     this.gaeService,
     this.gcloudProject,
     this.gcloudKey,
+    this.toolEnvDartSdkDir,
     this.flutterSdkDir,
     this.frontendCount,
     this.workerCount,
@@ -117,6 +119,7 @@ class EnvConfig {
       Platform.environment['GAE_SERVICE'],
       Platform.environment['GCLOUD_PROJECT'],
       Platform.environment['GCLOUD_KEY'],
+      Platform.environment['TOOL_ENV_DART_SDK'],
       Platform.environment['FLUTTER_SDK'],
       frontendCount,
       workerCount,

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -78,7 +78,8 @@ shelf.Response debugResponse([Map<String, dynamic> data]) {
     },
     'versions': {
       'runtime': runtimeVersion,
-      'sdk': sdkVersion,
+      'runtime-sdk': runtimeSdkVersion,
+      'tool-env-sdk': toolEnvSdkVersion,
       'pana': panaVersion,
       'flutter': flutterVersion,
       'dartdoc': dartdocVersion,

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -7,11 +7,11 @@ import 'package:pub_semver/pub_semver.dart';
 import 'utils.dart' show isNewer;
 
 // update this whenever one of the other versions change
-final String runtimeVersion = '2018.7.12';
+final String runtimeVersion = '2018.7.19';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
-final String sdkVersion = '2.0.0-dev.66.0';
+final String sdkVersion = '2.0.0-dev.63.0';
 final Version semanticSdkVersion = new Version.parse(sdkVersion);
 
 // keep in-sync with app/pubspec.yaml

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -11,8 +11,8 @@ final String runtimeVersion = '2018.7.19';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
-final String sdkVersion = '2.0.0-dev.63.0';
-final Version semanticSdkVersion = new Version.parse(sdkVersion);
+final String runtimeSdkVersion = '2.0.0-dev.63.0';
+final String toolEnvSdkVersion = '2.0.0-dev.69.0';
 
 // keep in-sync with app/pubspec.yaml
 final String panaVersion = '0.11.7';

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _discoveryapis_commons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.6+1"
+    version: "0.1.6"
   _popularity:
     dependency: "direct main"
     description:
@@ -42,7 +42,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3"
+    version: "1.4.4"
   async:
     dependency: transitive
     description:
@@ -63,35 +63,35 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.7"
+    version: "0.12.7+2"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1"
+    version: "0.3.1+1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.1+1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "0.9.1+1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.1+2"
   built_collection:
     dependency: transitive
     description:
@@ -119,7 +119,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.3+2"
   code_builder:
     dependency: transitive
     description:
@@ -133,14 +133,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.10"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   crypto:
     dependency: "direct main"
     description:
@@ -154,7 +154,7 @@ packages:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.4"
+    version: "0.14.4+1"
   dart2_constant:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   fixnum:
     dependency: transitive
     description:
@@ -196,7 +196,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
   googleapis:
     dependency: "direct main"
     description:
@@ -224,7 +224,7 @@ packages:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2"
+    version: "0.1.2+1"
   html:
     dependency: "direct main"
     description:
@@ -273,7 +273,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.15.6"
+    version: "0.15.7"
   io:
     dependency: transitive
     description:
@@ -287,7 +287,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "0.6.1+1"
   json_annotation:
     dependency: "direct main"
     description:
@@ -322,21 +322,21 @@ packages:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+1"
+    version: "0.11.3+2"
   markdown:
     dependency: "direct main"
     description:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3"
+    version: "0.12.3+1"
   memcache:
     dependency: "direct main"
     description:
@@ -350,7 +350,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   mime:
     dependency: "direct main"
     description:
@@ -385,7 +385,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   package_resolver:
     dependency: transitive
     description:
@@ -406,14 +406,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.2"
   plugin:
     dependency: transitive
     description:
       name: plugin
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0+2"
+    version: "0.2.0+3"
   pool:
     dependency: "direct main"
     description:
@@ -462,14 +462,14 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3+2"
+    version: "0.7.3+3"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   shelf_static:
     dependency: transitive
     description:
@@ -483,7 +483,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+2"
+    version: "0.2.2+3"
   source_gen:
     dependency: "direct dev"
     description:
@@ -504,14 +504,14 @@ packages:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.6"
+    version: "0.10.7"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   stack_trace:
     dependency: "direct main"
     description:
@@ -525,49 +525,49 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.7+1"
+    version: "1.6.8"
   stream_transform:
     dependency: "direct main"
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.14"
+    version: "0.0.14+1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   utf:
     dependency: transitive
     description:
       name: utf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0+4"
+    version: "0.9.0+5"
   uuid:
     dependency: "direct main"
     description:
@@ -588,20 +588,20 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+9"
+    version: "0.9.7+10"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   yaml:
     dependency: "direct main"
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.14"
+    version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.64.0 <=2.0.0-dev.66.0"
+  dart: ">=2.0.0-dev.63 <=2.0.0-dev.63.0"

--- a/app/test/ensure_build_test.dart
+++ b/app/test/ensure_build_test.dart
@@ -47,7 +47,8 @@ final _whitespace = new RegExp(r'\s');
 Set<String> _changedGeneratedFiles() {
   final output = _runProc('git', ['status', '--porcelain']);
 
-  return LineSplitter.split(output)
+  return LineSplitter
+      .split(output)
       .map((line) => line.split(_whitespace).last)
       .where((path) => path.endsWith('.dart'))
       .toSet();

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -29,8 +29,7 @@ void main() {
       (<String, List<Package>>{
         'one package': [testPackage],
         'empty': [],
-      })
-          .forEach((String testName, List<Package> expectedPackages) {
+      }).forEach((String testName, List<Package> expectedPackages) {
         test(testName, () async {
           final completion = new TestDelayCompletion();
           Stream<Package> queryRunFun(
@@ -135,8 +134,7 @@ void main() {
       (<String, List<Package>>{
         'exists': [testPackage],
         'does not exist': [null],
-      })
-          .forEach((String testName, List<Package> expectedPackages) {
+      }).forEach((String testName, List<Package> expectedPackages) {
         test(testName, () async {
           List<Package> lookupFun(List<Key> keys) {
             expect(keys, hasLength(1));
@@ -158,8 +156,7 @@ void main() {
       (<String, List<PackageVersion>>{
         'exists': [testPackageVersion],
         'does not exist': [null],
-      })
-          .forEach((String testName, List<PackageVersion> expectedVersions) {
+      }).forEach((String testName, List<PackageVersion> expectedVersions) {
         test(testName, () async {
           List<PackageVersion> lookupFun(List<Key> keys) {
             expect(keys, hasLength(1));
@@ -181,8 +178,7 @@ void main() {
       (<String, List<PackageVersion>>{
         'one version': [testPackageVersion],
         'empty': [null],
-      })
-          .forEach((String testName, List<PackageVersion> expectedVersions) {
+      }).forEach((String testName, List<PackageVersion> expectedVersions) {
         test(testName, () async {
           List<PackageVersion> lookupFun(List<Key> keys) {
             expect(keys, hasLength(1));
@@ -204,8 +200,7 @@ void main() {
       (<String, List<PackageVersion>>{
         'one version': [testPackageVersion],
         'empty': [null],
-      })
-          .forEach((String testName, List<PackageVersion> expectedVersions) {
+      }).forEach((String testName, List<PackageVersion> expectedVersions) {
         test(testName, () async {
           final completion = new TestDelayCompletion();
           Stream<PackageVersion> queryRunFun(

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -20,7 +20,7 @@ void main() {
       dartdocVersion,
       customizationVersion,
     ].join('//').hashCode;
-    expect(hash, 812421699);
+    expect(hash, 846425735);
   });
 
   test('sdk version should match travis and dockerfile', () async {

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -14,23 +14,30 @@ void main() {
   test('do not forget to update runtimeVersion when any version changes', () {
     final hash = [
       runtimeVersion,
-      sdkVersion,
+      runtimeSdkVersion,
+      toolEnvSdkVersion,
       flutterVersion,
       panaVersion,
       dartdocVersion,
       customizationVersion,
     ].join('//').hashCode;
-    expect(hash, 846425735);
+    expect(hash, 783366632);
   });
 
-  test('sdk version should match travis and dockerfile', () async {
+  test('runtime sdk version should match travis and dockerfile', () async {
     final String docker = await new File('../Dockerfile').readAsString();
-    expect(docker.contains('\nFROM google/dart-runtime-base:$sdkVersion\n'),
+    expect(
+        docker.contains('\nFROM google/dart-runtime-base:$runtimeSdkVersion\n'),
         isTrue);
     final String rootTravis = await new File('.mono_repo.yml').readAsString();
-    expect(rootTravis.contains('\n  - $sdkVersion\n'), isTrue);
+    expect(rootTravis.contains('\n  - $runtimeSdkVersion\n'), isTrue);
     final String appTravis = await new File('.mono_repo.yml').readAsString();
-    expect(appTravis.contains('\n  - $sdkVersion\n'), isTrue);
+    expect(appTravis.contains('\n  - $runtimeSdkVersion\n'), isTrue);
+  });
+
+  test('tool-env sdk version should match dockerfile', () async {
+    final String docker = await new File('../Dockerfile').readAsString();
+    expect(docker.contains('release/2.0.0-dev.69.0/sdk'), isTrue);
   });
 
   test('analyzer version should match resolved pana version', () async {

--- a/dartdoc.yaml
+++ b/dartdoc.yaml
@@ -9,6 +9,7 @@ env_variables:
   # Needs to be in sync with app/script/setup-flutter.sh and with app/lib/shared/configuration.dart
   FLUTTER_ROOT: '/flutter'
   FLUTTER_SDK: '/flutter'
+  TOOL_ENV_DART_SDK: '/dart-sdk'
 
 resources:
   cpu: 1

--- a/pkg/_popularity/.mono_repo.yml
+++ b/pkg/_popularity/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.0.0-dev.66.0
+  - 2.0.0-dev.63.0
 
 stages:
   - smoke_test:

--- a/pkg/_popularity/lib/popularity.dart
+++ b/pkg/_popularity/lib/popularity.dart
@@ -15,12 +15,15 @@ class PackagePopularity extends Object with _$PackagePopularitySerializerMixin {
   static final String popularityFileName = 'v$version/popularity.json.gz';
 
   @JsonKey(name: 'date_first', nullable: false)
+  @override
   final DateTime dateFirst;
 
   @JsonKey(name: 'date_last', nullable: false)
+  @override
   final DateTime dateLast;
 
   @JsonKey(nullable: false)
+  @override
   final Map<String, VoteTotals> items;
 
   PackagePopularity(this.dateFirst, this.dateLast, this.items);
@@ -34,16 +37,22 @@ class VoteTotals extends Object
     with _$VoteTotalsSerializerMixin
     implements VoteData {
   @JsonKey(nullable: false)
+  @override
   final VoteData flutter;
   @JsonKey(nullable: false)
+  @override
   final VoteData notFlutter;
 
+  @override
   int get direct => flutter.direct + notFlutter.direct;
 
+  @override
   int get dev => flutter.dev + notFlutter.dev;
 
+  @override
   int get total => flutter.total + notFlutter.total;
 
+  @override
   int get score => VoteData._score(this);
 
   VoteTotals(this.flutter, this.notFlutter);
@@ -55,12 +64,15 @@ class VoteTotals extends Object
 @JsonSerializable()
 class VoteData extends Object with _$VoteDataSerializerMixin {
   @JsonKey(name: 'votes_direct', nullable: false)
+  @override
   final int direct;
 
   @JsonKey(name: 'votes_dev', nullable: false)
+  @override
   final int dev;
 
   @JsonKey(name: 'votes_total', nullable: false)
+  @override
   final int total;
 
   int get score => _score(this);

--- a/pkg/pub_dartdoc/.mono_repo.yml
+++ b/pkg/pub_dartdoc/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.0.0-dev.66.0
+  - 2.0.0-dev.63.0
 
 stages:
   - smoke_test:


### PR DESCRIPTION
- runtime SDK is back at dev.63
- we download a separately tracked tool-env SDK for `analyzer`/`dartdoc` during docker image creation, set currently to dev.69
- tracking the two SDK separately, adjusted tests

/cc @sortie 