### PR TITLE
Fix JS console error in cases where name is a numerical value.

### DIFF
--- a/static/js/script.dart
+++ b/static/js/script.dart
@@ -143,7 +143,9 @@ void _changeTabOnUrlHash() {
 }
 
 void _changeTab(String name) {
-  if (tabRoot.querySelector('[data-name="$name"]') != null) {
+  final tabOrContentElem =
+      tabRoot.querySelector('[data-name="${Uri.encodeQueryComponent(name)}"]');
+  if (tabOrContentElem != null) {
     // toggle tab highlights
     tabRoot.children.forEach((node) {
       if (node.dataset['name'] != name) {

--- a/static/js/script.dart
+++ b/static/js/script.dart
@@ -143,7 +143,7 @@ void _changeTabOnUrlHash() {
 }
 
 void _changeTab(String name) {
-  if (tabRoot.querySelector('[data-name=' + name + ']') != null) {
+  if (tabRoot.querySelector('[data-name="$name"]') != null) {
     // toggle tab highlights
     tabRoot.children.forEach((node) {
       if (node.dataset['name'] != name) {


### PR DESCRIPTION
Found via investigating https://github.com/dart-lang/pub-dartlang-dart/issues/1429
If the id is number-like, chrome throws an exception on that part of the code.