### PR TITLE
Prefix memcache entries with the current runtimeVersion.

### DIFF
--- a/app/lib/shared/dartdoc_memcache.dart
+++ b/app/lib/shared/dartdoc_memcache.dart
@@ -69,8 +69,7 @@ class DartdocMemcache {
     ]);
   }
 
-  String _entryKey(String package, String version) =>
-      '/$package/$version/${versions.runtimeVersion}';
+  String _entryKey(String package, String version) => '/$package/$version';
 
   String _fileInfoKey(String objectName) => objectName;
 }

--- a/app/lib/shared/memcache.dart
+++ b/app/lib/shared/memcache.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:memcache/memcache.dart';
 
+import 'versions.dart';
+
 const Duration indexUiPageExpiration = const Duration(minutes: 10);
 const Duration packageJsonExpiration = const Duration(minutes: 10);
 const Duration packageUiPageExpiration = const Duration(minutes: 10);
@@ -34,7 +36,7 @@ class SimpleMemcache {
 
   SimpleMemcache(this._logger, this._memcache, this._prefix, this._expiration);
 
-  String _key(String key) => '$_prefix$key';
+  String _key(String key) => '$runtimeVersion/$_prefix$key';
 
   Future<String> getText(String key) async {
     try {


### PR DESCRIPTION
I thought we had a tracking for this, but apparently this got forgotten. In effect this will use separate caches for different runtime versions, and UI / data caches will be handled separately, there won't be any cross-pollute between versions (which may be breaking or may be visually different).