### PR TITLE
Serve /documentation URLs through default service (frontend).

### DIFF
--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -13,6 +13,7 @@ import 'package:logging/logging.dart';
 import 'package:pub_server/shelf_pubserver.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
+import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/history/backend.dart';
 import 'package:pub_dartlang_org/history/models.dart';
 import 'package:pub_dartlang_org/job/backend.dart';
@@ -68,6 +69,10 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
   final AnalyzerClient analyzerClient = new AnalyzerClient();
   registerAnalyzerClient(analyzerClient);
   registerScopeExitCallback(analyzerClient.close);
+
+  final Bucket dartdocBucket = await getOrCreateBucket(
+      storageService, activeConfiguration.dartdocStorageBucketName);
+  registerDartdocBackend(new DartdocBackend(db.dbService, dartdocBucket));
 
   registerDartdocMemcache(new DartdocMemcache(memcacheService));
   final dartdocClient = new DartdocClient();

--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -31,7 +31,7 @@ Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
   if (handler != null) {
     return await handler(request);
   } else if (path.startsWith('/documentation')) {
-    return _documentationHandler(request);
+    return documentationHandler(request);
   } else if (path == '/robots.txt' && !isProductionHost(request)) {
     return rejectRobotsHandler(request);
   } else if (path == '/robots.txt') {
@@ -56,7 +56,7 @@ Future<shelf.Response> _robotsTxtHandler(shelf.Request request) async {
 
 /// Handles requests for:
 ///   - /documentation/<package>/<version>
-Future<shelf.Response> _documentationHandler(shelf.Request request) async {
+Future<shelf.Response> documentationHandler(shelf.Request request) async {
   final docFilePath = parseRequestUri(request.requestedUri);
   if (docFilePath == null) {
     return _indexHandler(request);

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -114,7 +114,7 @@ shelf.Request _sanitizeRequestedUri(shelf.Request request) {
     // (The pub client will not remove it and instead directly try to request
     //  "GET //api/..." :-/ )
     final changedUri = uri.replace(path: normalizedResource);
-    return new shelf.Request(
+    final sanitized = new shelf.Request(
       request.method,
       changedUri,
       protocolVersion: request.protocolVersion,
@@ -123,5 +123,10 @@ shelf.Request _sanitizeRequestedUri(shelf.Request request) {
       encoding: request.encoding,
       context: request.context,
     );
+    if (!sanitized.context.containsKey('_originalRequest')) {
+      return sanitized.change(context: {'_originalRequest': request});
+    } else {
+      return sanitized;
+    }
   }
 }

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
+import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/handlers_redirects.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
@@ -18,6 +19,7 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
+import '../dartdoc/handlers_test.dart' show DartdocBackendMock;
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';
 
@@ -438,6 +440,56 @@ void main() {
 (\\s*)
 </feed>
 ''');
+      });
+    });
+
+    group('/documentation', () {
+      test('/documentation/flutter redirect', () async {
+        expectRedirectResponse(
+          await issueGet('/documentation/flutter'),
+          'https://docs.flutter.io/',
+        );
+      });
+
+      test('/documentation/flutter/version redirect', () async {
+        expectRedirectResponse(
+          await issueGet('/documentation/flutter/version'),
+          'https://docs.flutter.io/',
+        );
+      });
+
+      test('/documentation/foo/bar redirect', () async {
+        expectRedirectResponse(
+          await issueGet('/documentation/foor/bar'),
+          'https://pub.dartlang.org/documentation/foor/bar/',
+        );
+      });
+
+      scopedTest('trailing slash redirect', () async {
+        expectRedirectResponse(
+            await issueGet('/documentation/foo'), '/documentation/foo/latest/');
+      });
+
+      scopedTest('/documentation/no_pkg redirect', () async {
+        registerDartdocBackend(new DartdocBackendMock());
+        expectRedirectResponse(await issueGet('/documentation/no_pkg/latest/'),
+            '/packages/no_pkg/versions');
+      });
+
+      test('dartdocs.org redirect', () async {
+        expectRedirectResponse(
+          await issueGetUri(
+              Uri.parse('https://dartdocs.org/documentation/pkg/latest/')),
+          'https://pub.dartlang.org/documentation/pkg/latest/',
+        );
+      });
+
+      test('www.dartdocs.org redirect', () async {
+        expectRedirectResponse(
+          await issueGetUri(
+              Uri.parse('https://www.dartdocs.org/documentation/pkg/latest/')),
+          'https://pub.dartlang.org/documentation/pkg/latest/',
+        );
       });
     });
 

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pub_dartlang_org.handlers_test;
+library pub_dartlang_org.frontend.handlers_test;
 
 import 'dart:async';
 
@@ -22,9 +22,13 @@ import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 import 'package:pub_dartlang_org/shared/urls.dart';
 
-Future<shelf.Response> issueGet(String path) async {
+Future<shelf.Response> issueGet(String path) {
   final uri = '$siteRoot$path';
-  final request = new shelf.Request('GET', Uri.parse(uri));
+  return issueGetUri(Uri.parse(uri));
+}
+
+Future<shelf.Response> issueGetUri(Uri uri) async {
+  final request = new shelf.Request('GET', uri);
   return appHandler(request, null);
 }
 

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,10 +1,6 @@
 dispatch:
   - url: "*.dartdocs.org/*"
-    service: dartdoc
-  - url: "pub.dartlang.org/documentation"
-    service: dartdoc
-  - url: "pub.dartlang.org/documentation/*"
-    service: dartdoc
+    service: default
   - url: "dartdocs.org/*"
-    service: dartdoc
+    service: default
 


### PR DESCRIPTION
Part of https://github.com/dart-lang/pub-dartlang-dart/issues/1534

- tests and the redirect logic is copied almost verbatim
- the serving handler is referenced
- tweak added to preserve the original request after sanitization, and work on that if it is in the context