### PR TITLE
Enable some internal packages with pana 0.12 new API.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -17,6 +17,7 @@ import '../shared/analyzer_service.dart';
 import '../shared/configuration.dart';
 import '../shared/dartdoc_client.dart';
 import '../shared/platform.dart';
+import '../shared/utils.dart' show internalPackageNames;
 
 import 'backend.dart';
 import 'models.dart';
@@ -99,9 +100,11 @@ class AnalyzerJobProcessor extends JobProcessor {
         );
         final PackageAnalyzer analyzer =
             new PackageAnalyzer(toolEnv, urlChecker: _urlChecker);
+        final isInternal = internalPackageNames.contains(job.packageName);
         return await analyzer.inspectPackage(
           job.packageName,
           version: job.packageVersion,
+          options: new InspectOptions(isInternal: isInternal),
           logger: new Logger.detached(
               'pana/${job.packageName}/${job.packageVersion}'),
         );

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -166,6 +166,13 @@ const List<String> _reservedWords = const <String>[
   'with'
 ];
 
+/// 'internal' packages are developed by the Dart team, and they are allowed to
+/// point their URLs to *.dartlang.org (others would get a penalty for it).
+const internalPackageNames = const <String>[
+  'angular',
+  'angular_components',
+];
+
 final Set<String> knownMixedCasePackages = _knownMixedCasePackages.toSet();
 final Set<String> _blockedLowerCasePackages = _knownMixedCasePackages
     .map((s) => s.toLowerCase())


### PR DESCRIPTION
https://github.com/dart-lang/pana/issues/386

I think the package-related utils should be refactored in a separate file, but would do it in a subsequent PR.