### PR TITLE
Remove IDF weight from token weights.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -558,6 +558,8 @@ class TokenMatch {
 
   double get sumWeight =>
       _sumWeight ??= _tokenWeights.values.fold(0.0, (a, b) => a + b);
+
+  Map<String, double> get tokenWeights => new Map.unmodifiable(_tokenWeights);
 }
 
 class TokenIndex {
@@ -631,8 +633,7 @@ class TokenIndex {
         if (candidateWeight > 0.3) {
           final int foundCount = _inverseIds[candidate]?.length ?? 0;
           if (foundCount <= 0) continue;
-          final double idf = 1.0 + math.log(documentCount / foundCount);
-          final double score = idf * candidateWeight;
+          final double score = candidateWeight;
           final double old = tokenMatch[candidate];
           if (old == null || old < score) {
             tokenMatch[candidate] = score;

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -396,7 +396,7 @@ MIT'''),
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(0.36, 0.01),
+            'score': closeTo(0.47, 0.01),
           },
         ]
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -76,6 +76,33 @@ void main() {
     });
   });
 
+  group('TokenMatch', () {
+    test('longer words', () {
+      final index = new TokenIndex(minLength: 2);
+      final names = [
+        'location',
+        'geolocator',
+        'firestore_helpers',
+        'geolocation',
+        'location_context',
+        'amap_location',
+        'flutter_location_picker',
+        'flutter_amap_location',
+        'location_picker',
+        'background_location_updates',
+      ];
+      for (String name in names) {
+        index.add(name, name);
+      }
+      final match = index.lookupTokens('location');
+      // location should be the top value, everything else should be lower
+      expect(match.tokenWeights, {
+        'location': 1.0,
+        'geolocation': closeTo(0.578, 0.001),
+      });
+    });
+  });
+
   group('Score', () {
     Score score;
     setUp(() {


### PR DESCRIPTION
- fixes the `location` vs. `geolocation` issue in https://github.com/dart-lang/pub-dartlang-dart/issues/1553
- other search results seem to be fine with the change