### PR TITLE
Upgrade dependencies and adjust exceptions and logging

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -217,7 +217,7 @@ packages:
       name: googleapis_beta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.46.1"
+    version: "0.47.0"
   graphs:
     dependency: transitive
     description:
@@ -308,7 +308,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   kernel:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: memcache
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0+1"
+    version: "0.3.0+2"
   meta:
     dependency: "direct main"
     description:
@@ -441,7 +441,7 @@ packages:
       name: pub_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4+2"
+    version: "0.1.5"
   pubspec_parse:
     dependency: "direct main"
     description:

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -287,7 +287,7 @@ void main() {
         final pkg = testPackage.name;
         registerLoggedInUser(testPackage.uploaderEmails.first);
         await getMethod(repo)(pkg, 'a@b.com').catchError(expectAsync2((e, _) {
-          expect('$e', equals('Exception: Package "null" does not exist'));
+          expect('$e', equals('Package "null" does not exist'));
         }));
       });
     }
@@ -423,7 +423,7 @@ void main() {
         await repo
             .removeUploader(pkg, 'foo2@bar.com')
             .catchError(expectAsync2((e, _) {
-          expect('$e', 'Exception: The uploader to remove does not exist.');
+          expect('$e', 'The uploader to remove does not exist.');
         }));
       });
 
@@ -446,7 +446,7 @@ void main() {
             .removeUploader(pkg, 'foo1@bar.com')
             .catchError(expectAsync2((e, _) {
           expect('$e',
-              'Exception: Self-removal is not allowed. Use another account to remove this e-mail address.');
+              'Self-removal is not allowed. Use another account to remove this e-mail address.');
         }));
       });
 


### PR DESCRIPTION
- `pub_server` `0.1.5` enables the exception change, so that we can skip warning logs, and have info on client-side problems. Closes https://github.com/dart-lang/pub-dartlang-dart/issues/1456
- `memcache` update addresses the exception in https://github.com/dart-lang/pub-dartlang-dart/issues/1547
