### PR TITLE
Remove deleted packages from the index and from the snapshot.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -253,5 +253,10 @@ class SearchSnapshot {
     docs.forEach(add);
   }
 
+  void remove(String packageName) {
+    updated = new DateTime.now().toUtc();
+    documents.remove(packageName);
+  }
+
   Map<String, dynamic> toJson() => _$SearchSnapshotToJson(this);
 }

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -124,6 +124,12 @@ class BatchIndexUpdater implements TaskRunner {
           .toList();
       _snapshot.addAll(docs);
       await packageIndex.addPackages(docs);
+      final removedPackages = tasks.map((t) => t.package).toSet()
+        ..removeAll(docs.map((pd) => pd.package));
+      for (String package in removedPackages) {
+        _snapshot.remove(package);
+        await packageIndex.removePackage(package);
+      }
       final bool doMerge =
           _firstScanCount != null && _taskCount >= _firstScanCount;
       if (doMerge) {


### PR DESCRIPTION
There is an extra check when we were displaying the results, so deleted packages wouldn't show up in the results, but it is better to remove them explicitly.