### PR TITLE
Tune search scoring/ranking

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -539,19 +539,19 @@ class Score {
 
 class TokenMatch {
   final Map<String, double> _tokenWeights = <String, double>{};
-  double _sumWeight;
+  double _maxWeight;
 
   double operator [](String token) => _tokenWeights[token];
 
   void operator []=(String token, double weight) {
     _tokenWeights[token] = weight;
-    _sumWeight = null;
+    _maxWeight = null;
   }
 
   Iterable<String> get tokens => _tokenWeights.keys;
 
-  double get sumWeight =>
-      _sumWeight ??= _tokenWeights.values.fold(0.0, (a, b) => a + b);
+  double get maxWeight =>
+      _maxWeight ??= _tokenWeights.values.fold(0.0, math.max);
 
   Map<String, double> get tokenWeights => new Map.unmodifiable(_tokenWeights);
 }
@@ -655,12 +655,12 @@ class TokenIndex {
   Map<String, double> scoreDocs(TokenMatch tokenMatch,
       {double weight: 1.0, int wordCount: 1}) {
     // Summarize the scores for the documents.
-    final queryWeight = tokenMatch.sumWeight;
+    final queryWeight = tokenMatch.maxWeight;
     final Map<String, double> docScores = <String, double>{};
     for (String token in tokenMatch.tokens) {
       for (String id in _inverseIds[token]) {
         final double prevValue = docScores[id] ?? 0.0;
-        docScores[id] = prevValue + tokenMatch[token];
+        docScores[id] = math.max(prevValue, tokenMatch[token]);
       }
     }
 

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -103,7 +103,7 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.478, 0.001), // find WebPageGenerator
+            'score': closeTo(0.624, 0.001), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],
@@ -122,14 +122,14 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.570, 0.001), // find WebPageGenerator
+            'score': closeTo(0.744, 0.001), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],
           },
           {
             'package': 'other_with_api',
-            'score': closeTo(0.147, 0.001), // find serveWebPages
+            'score': closeTo(0.192, 0.001), // find serveWebPages
             'apiPages': [
               {'title': null, 'path': 'serve.html'},
             ],

--- a/app/test/search/haversine_test.dart
+++ b/app/test/search/haversine_test.dart
@@ -396,7 +396,7 @@ MIT'''),
           {
             // should be present
             'package': 'latlong',
-            'score': closeTo(0.47, 0.01),
+            'score': closeTo(0.86, 0.01),
           },
         ]
       });

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -510,7 +510,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'packages': [
           {'package': 'chrome_net', 'score': closeTo(0.93, 0.01)},
           {'package': 'async', 'score': closeTo(0.93, 0.01)},
-          {'package': 'http', 'score': closeTo(0.65, 0.01)},
+          {'package': 'http', 'score': closeTo(0.87, 0.01)},
         ],
       });
 
@@ -522,7 +522,7 @@ server.dart adds a small, prescriptive server (PicoServer) that can be configure
         'indexUpdated': isNotNull,
         'totalCount': 1,
         'packages': [
-          {'package': 'http', 'score': closeTo(0.623, 0.001)},
+          {'package': 'http', 'score': closeTo(0.829, 0.001)},
         ],
       });
     });


### PR DESCRIPTION
https://github.com/dart-lang/pub-dartlang-dart/issues/1553

The change is subtle, but the implication is the following:

A token lookup returns a weighted map of tokens for each field separately. In a non-trivial corpus (like our real dataset), it could have been like the following:
```
name: {'location': 1.0, 'geolocation': 0.57}
description: {'location': 1.0, 'geolocation': 0.57, 'locate': 0.43, 'locator': 0.83, ...}
```

Previously, the tokens were aggregated by their weighted sum, and divided by their total sum (for that field specifically). When the `description` field contained much more tokens then the `name` field (and was divided by a larger number), a query for `location` resulted in a much lower score then a match in the `name` field.

Skipping the sum, and using `max` fixes this imbalance.

I've tried a few other (and usually more complex) routes to keep the sum of tokens, but it didn't improve the results that much, so I'd rather stick with the simpler solution, which would also allow a few more simplification in a subsequent refactoring (if this solution sticks for good).