### PR TITLE
Display a short message before reporting a pub site issue.

### DIFF
--- a/static/js/script.dart
+++ b/static/js/script.dart
@@ -18,6 +18,7 @@ void main() {
   _setEventForMobileNav();
   _setEventForHashChange();
   _setEventForSearchInput();
+  _guardReportIssue();
   _fixIssueLinks();
   _setEventForSortControl();
   _setEventForCheckboxChanges();
@@ -314,6 +315,18 @@ void _setEventForCheckboxChanges() {
     // TODO: instead of submitting, compose the URL here (also removing the single `?`)
     formElement.submit();
   });
+}
+
+void _guardReportIssue() {
+  for (AnchorElement bugLink in document.querySelectorAll('a.github_issue')) {
+    bugLink.onClick.listen((event) {
+      if (!window.confirm('This link is for reporting issues for the pub site. '
+          'If you would like to report a problem with a package, please visit '
+          'its homepage or contact its developers.')) {
+        event.preventDefault();
+      }
+    });
+  }
 }
 
 void _fixIssueLinks() {


### PR DESCRIPTION
You can try this in staging, by clicking on the "report an issue" link at the bottom of the page: https://dartlang-pub-dev.appspot.com/

<img width="1028" alt="screen shot 2018-09-06 at 17 37 09" src="https://user-images.githubusercontent.com/4778111/45168431-8ae57000-b1fb-11e8-9fb3-1fa5e10663b5.png">

I'm not sure what the best wording would be, /cc @mit-mit 