### PR TITLE
Cache pana's ToolEnvironment for a limited amount of access.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -87,7 +87,7 @@ class AnalyzerJobProcessor extends JobProcessor {
 
     Future<Summary> analyze() async {
       Directory tempDir;
-      final toolEnvRef = await createToolEnvRef();
+      final toolEnvRef = await getOrCreateToolEnvRef();
       try {
         tempDir = await Directory.systemTemp.createTemp('pana');
         final PackageAnalyzer analyzer =

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -60,7 +60,7 @@ class DartdocJobProcessor extends JobProcessor {
     // directories need to be created
     await new Directory(outputDir).create(recursive: true);
 
-    final toolEnvRef = await createToolEnvRef();
+    final toolEnvRef = await getOrCreateToolEnvRef();
 
     final latestVersion =
         await dartdocBackend.getLatestVersion(job.packageName);

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -9,6 +9,12 @@ import 'package:pana/pana.dart';
 
 import 'configuration.dart';
 
+/// Subsequent calls of the analyzer or dartdoc job can use the same [ToolEnvRef]
+/// instance [_maxCount] times.
+///
+/// Until the limit is reached, the [ToolEnvRef] will reuse the pub cache
+/// directory for its `pub upgrade` calls, but once it is reached, the cache
+/// will be deleted and a new [ToolEnvRef] with a new directory will be created.
 const _maxCount = 100;
 
 ToolEnvRef _current;
@@ -17,6 +23,10 @@ Completer _ongoing;
 /// Tracks the temporary directory of the downloaded package cache with the
 /// [ToolEnvironment] (that was initialized with that directory), along with its
 /// use stats.
+///
+/// The pub cache will be reused between `pub upgrade` calls, until the
+/// [_maxCount] threshold is reached. The directory will be deleted once all of
+/// the associated jobs complete.
 class ToolEnvRef {
   final Directory _pubCacheDir;
   final ToolEnvironment toolEnv;
@@ -43,7 +53,7 @@ class ToolEnvRef {
 }
 
 /// Gets a currently available [ToolEnvRef] if it is used less than the
-/// configured threshold (_maxCount, currently 100). If it it has already
+/// configured threshold ([_maxCount]). If it it has already
 /// reached the amount, a new cache dir and environment will be created.
 Future<ToolEnvRef> getOrCreateToolEnvRef() async {
   if (_current != null && _current._started < _maxCount) {

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:pana/pana.dart';
+
+import 'configuration.dart';
+
+const _maxCount = 100;
+
+ToolEnvRef _current;
+
+class ToolEnvRef {
+  final Directory _pubCacheDir;
+  final ToolEnvironment toolEnv;
+  int _started = 0;
+  int _active = 0;
+
+  ToolEnvRef(this._pubCacheDir, this.toolEnv);
+
+  void _aquire() {
+    _started++;
+    _active++;
+  }
+
+  Future release() async {
+    _active--;
+    if (_started >= _maxCount && _active == 0) {
+      await _pubCacheDir.delete(recursive: true);
+    }
+  }
+}
+
+Future<ToolEnvRef> createToolEnvRef() async {
+  if (_current != null && _current._started < _maxCount) {
+    _current._aquire();
+    return _current;
+  }
+  final cacheDir = await Directory.systemTemp.createTemp('pub-cache-dir');
+  final resolvedDirName = await cacheDir.resolveSymbolicLinks();
+  final toolEnv = await ToolEnvironment.create(
+    dartSdkDir: envConfig.toolEnvDartSdkDir,
+    flutterSdkDir: envConfig.flutterSdkDir,
+    pubCacheDir: resolvedDirName,
+  );
+  _current = new ToolEnvRef(cacheDir, toolEnv);
+  _current._aquire();
+  return _current;
+}

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -13,6 +13,9 @@ const _maxCount = 100;
 
 ToolEnvRef _current;
 
+/// Tracks the temporary directory of the downloaded package cache with the
+/// [ToolEnvironment] (that was initialized with that directory), along with its
+/// use stats.
 class ToolEnvRef {
   final Directory _pubCacheDir;
   final ToolEnvironment toolEnv;
@@ -34,6 +37,9 @@ class ToolEnvRef {
   }
 }
 
+/// Gets a currently available [ToolEnvRef] if it is used less than the
+/// configured threshold (_maxCount, currently 100). If it it has already
+/// reached the amount, a new cache dir and environment will be created.
 Future<ToolEnvRef> createToolEnvRef() async {
   if (_current != null && _current._started < _maxCount) {
     _current._aquire();

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -31,8 +31,12 @@ class ToolEnvRef {
 
   Future release() async {
     _active--;
-    if (_started >= _maxCount && _active == 0) {
-      await _pubCacheDir.delete(recursive: true);
+    if (_active == 0) {
+      // Delete directory if the instance is no longer active or it reached the
+      // maximum threshold.
+      if (_started >= _maxCount || _current != this) {
+        await _pubCacheDir.delete(recursive: true);
+      }
     }
   }
 }

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -40,7 +40,7 @@ class ToolEnvRef {
 /// Gets a currently available [ToolEnvRef] if it is used less than the
 /// configured threshold (_maxCount, currently 100). If it it has already
 /// reached the amount, a new cache dir and environment will be created.
-Future<ToolEnvRef> createToolEnvRef() async {
+Future<ToolEnvRef> getOrCreateToolEnvRef() async {
   if (_current != null && _current._started < _maxCount) {
     _current._aquire();
     return _current;


### PR DESCRIPTION
- Caches the dart and flutter runtime information and doesn't need to run e.g. `dart --version` before each analysis. (related to https://github.com/dart-lang/pub-dartlang-dart/issues/1347)

- Caches the downloaded packages for up to 100 separate analysis/dartdoc runs. Previously all of these were started from a clean state, and this part of the change should improve the `pub upgrade` part because it won't download the common dependencies in subsequent runs. (related to https://github.com/dart-lang/pub-dartlang-dart/issues/1521)

Because we don't want to have an unbounded number of packages being downloaded locally, I've set the arbitrary limit of 100. We could also monitor the total size of the directory, but I think we have enough value out of the simpler approach.