### PR TITLE
Fix CSS style to prevent overlap.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -438,7 +438,8 @@ pre > code {
   package list
 ******************************************************/
 
-.package-list{
+.package-list {
+  clear: both;
   padding: 0;
   margin: 0;
   list-style: none;


### PR DESCRIPTION
Closes https://github.com/dart-lang/pub-dartlang-dart/issues/1579
I was able to partially reproduce the issue on Chrome, by reducing the width of the window. The right-side dropdown has an extra padding that is required for the tooltip. Both that, and the score-circle is floating to the right, and the padding pushed the score-circle out of its position.

The change adds `clear: both` to the enclosing element of the list, which will give enough space for the right-side dropdown above the list (and prevents the overlap).