### PR TITLE
Runtime SDK change doesn't need to change the reference runtimeVersion.

### DIFF
--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -14,14 +14,13 @@ void main() {
   test('do not forget to update runtimeVersion when any version changes', () {
     final hash = [
       runtimeVersion,
-      runtimeSdkVersion,
       toolEnvSdkVersion,
       flutterVersion,
       panaVersion,
       dartdocVersion,
       customizationVersion,
     ].join('//').hashCode;
-    expect(hash, 672612609);
+    expect(hash, 916406136);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {


### PR DESCRIPTION
As discussed in a previous PR: because we are running the analysis with a separate SDK, we don't need to tie the `runtimeVersion` to this SDK version.