### PR TITLE
Delete old ScoreCard and SDK dartdoc data.

### DIFF
--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -80,8 +80,12 @@ Future _workerMain(WorkerEntryMessage message) async {
     });
 
     // Run GC in the next 6 hours (randomized wait to reduce race).
-    new Timer(new Duration(minutes: _random.nextInt(360)), () {
-      dartdocBackend.deleteOldSdkData();
+    new Timer(new Duration(minutes: _random.nextInt(360)), () async {
+      try {
+        await dartdocBackend.deleteOldSdkData();
+      } catch (e, st) {
+        logger.warning('Error while deleting old SDK data.', e, st);
+      }
     });
 
     await jobMaintenance.run();

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:isolate';
+import 'dart:math' as math;
 
 import 'package:appengine/appengine.dart';
 import 'package:gcloud/db.dart';
@@ -29,6 +30,7 @@ import 'package:pub_dartlang_org/dartdoc/dartdoc_runner.dart';
 import 'package:pub_dartlang_org/dartdoc/handlers.dart';
 
 final Logger logger = new Logger('pub.dartdoc');
+final _random = new math.Random.secure();
 
 Future main() async {
   Future workerSetup() async {
@@ -75,6 +77,11 @@ Future _workerMain(WorkerEntryMessage message) async {
 
     new Timer.periodic(const Duration(minutes: 15), (_) async {
       message.statsSendPort.send(await jobBackend.stats(JobService.dartdoc));
+    });
+
+    // Run GC in the next 6 hours (randomized wait to reduce race).
+    new Timer(new Duration(minutes: _random.nextInt(360)), () {
+      dartdocBackend.deleteOldSdkData();
     });
 
     await jobMaintenance.run();

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -95,8 +95,9 @@ class DartdocBackend {
       }
       final name = p.basename(entry.name);
       final version = name.replaceAll('.json.gz', '');
-      if (version.length == 10 &&
-          version.compareTo('2018.00.00') > 0 &&
+      final matchesPattern = version.length == 10 &&
+          shared_versions.runtimeVersionPattern.hasMatch(version);
+      if (matchesPattern &&
           version.compareTo(shared_versions.gcBeforeRuntimeVersion) < 0) {
         await _storage.delete(entry.name);
       }

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -29,6 +29,7 @@ final Logger _logger = new Logger('pub.dartdoc.backend');
 final _gzip = new GZipCodec();
 
 final Duration _contentDeleteThreshold = const Duration(days: 1);
+final Duration _sdkDeleteThreshold = const Duration(days: 182);
 final int _concurrentUploads = 8;
 final int _concurrentDeletes = 8;
 
@@ -99,7 +100,11 @@ class DartdocBackend {
           shared_versions.runtimeVersionPattern.hasMatch(version);
       if (matchesPattern &&
           version.compareTo(shared_versions.gcBeforeRuntimeVersion) < 0) {
-        await _storage.delete(entry.name);
+        final info = await _storage.info(entry.name);
+        final age = new DateTime.now().difference(info.updated);
+        if (age > _sdkDeleteThreshold) {
+          await _storage.delete(entry.name);
+        }
       }
     }
   }

--- a/app/lib/dartdoc/storage_path.dart
+++ b/app/lib/dartdoc/storage_path.dart
@@ -56,7 +56,13 @@ String sdkObjectName(String relativePath) {
   return p.join(_sdkAssetPrefix, relativePath);
 }
 
+/// The parent prefix for the Dart SDK's extracted dartdoc content.
+String dartSdkDartdocPrefix() {
+  return sdkObjectName('dart/pub-dartdoc-data');
+}
+
 /// The ObjectName for the Dart SDK's extracted dartdoc content.
 String dartSdkDartdocDataName(String runtimeVersion) {
-  return sdkObjectName('dart/pub-dartdoc-data/$runtimeVersion.json.gz');
+  final prefix = dartSdkDartdocPrefix();
+  return p.join(prefix, '$runtimeVersion.json.gz');
 }

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -10,6 +10,16 @@ import 'utils.dart' show isNewer;
 final String runtimeVersion = '2018.09.11';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
+/// The version which marks the earliest version of the data which we'd like to
+/// keep during various GC processes. Data prior to this version is subject to
+/// delete (unless there is another rule in place to keep it).
+///
+/// Make sure that at least two versions are kept here as the next candidates
+/// when the version switch happens:
+/// - 2018.09.11
+/// - 2018.09.03
+final String gcBeforeRuntimeVersion = '2018.08.27';
+
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '2.1.0-dev.2.0';
 final String toolEnvSdkVersion = '2.0.0';

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -6,6 +6,9 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'utils.dart' show isNewer;
 
+/// The pattern of [runtimeVersion].
+final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
+
 // update this whenever one of the other versions change
 final String runtimeVersion = '2018.09.11';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);

--- a/app/test/dartdoc/handlers_test.dart
+++ b/app/test/dartdoc/handlers_test.dart
@@ -212,4 +212,9 @@ class DartdocBackendMock implements DartdocBackend {
   Future uploadDartSdkDartdocData(File file) {
     throw new UnimplementedError();
   }
+
+  @override
+  Future deleteOldSdkData() {
+    throw new UnimplementedError();
+  }
 }

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -11,6 +11,14 @@ import 'package:yaml/yaml.dart';
 import 'package:pub_dartlang_org/shared/versions.dart';
 
 void main() {
+  test('runtime pattern', () {
+    expect(runtimeVersionPattern.hasMatch(runtimeVersion), isTrue);
+    expect(runtimeVersionPattern.hasMatch('2018.09.13'), isTrue);
+    expect(runtimeVersionPattern.hasMatch('2018 09 13'), isFalse);
+    expect(runtimeVersionPattern.hasMatch('2018'), isFalse);
+    expect(runtimeVersionPattern.hasMatch('x.json'), isFalse);
+  });
+
   test('do not forget to update runtimeVersion when any version changes', () {
     final hash = [
       runtimeVersion,


### PR DESCRIPTION
I'm introducing a new version that tracks the previously deployed runtime versions. The GC process for ScoreCard and SDK data checks the stored data only against this version, and if it is older than this reference, it can be deleted.

It provides us much better control than the rather vague "keep the latest two or the latest successful" rule of the `Analysis` GC (which would become obsolete once the ScoreCard takes over).