### PR TITLE
Bugfix: ApiPages index is off by the number of SDK API results.

### DIFF
--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -60,11 +60,14 @@ Future<SearchResultPage> _loadResultForPackages(
         (await batchResults[1]).cast<PackageVersion>();
 
     for (int i = 0; i < versions.length; i++) {
+      final package = packageEntries[i];
+      final apiPages =
+          packageScores.firstWhere((ps) => ps.package == package.name).apiPages;
       final pv = new PackageView.fromModel(
-        package: packageEntries[i],
+        package: package,
         version: versions[i],
         analysis: analysisExtracts[i],
-        apiPages: packageScores[i].apiPages,
+        apiPages: apiPages,
       );
       pubPackages[pv.name] = pv;
     }


### PR DESCRIPTION
- `packageEntries` has the non-hosted packages removed
- `versions` and `analysisExtracts` are derived form `packageEntries`
- `packageScores` must not use the same index, need to use the lookup instead