### PR TITLE
Help page section: Overall score

### DIFF
--- a/app/views/help.mustache
+++ b/app/views/help.mustache
@@ -106,6 +106,16 @@ linter:
     publishing, run <a href="https://pub.dartlang.org/packages/pana">pana</a> manually.
   </p>
 
+  <h3 id="overall-score">Overall score</h3>
+  <p>
+    The overall score is a weighted average of the individual scores:
+  </p>
+  <ul>
+      <li>50% popularity,</li>
+      <li>30% code health,</li>
+      <li>20% maintenance.</li>
+  </ul>
+
 
   <h2 id="ranking">Ranking</h2>
   <p>


### PR DESCRIPTION
I've realized that we link to the `#overall-score` anchor, but we don't have content for it.