### PR TITLE
Restrict the use of AnalysisData.

### DIFF
--- a/app/bin/tools/dump_package_status.dart
+++ b/app/bin/tools/dump_package_status.dart
@@ -51,9 +51,8 @@ Future main(List<String> arguments) async {
         final PackageVersion pv = pvs[0];
         if (pv == null) return;
 
-        final analysisData = await analyzerClient
-            .getAnalysisData(new AnalysisKey(p.name, pv.version));
-        final analysisView = new AnalysisView(analysisData);
+        final analysisView = await analyzerClient
+            .getAnalysisView(new AnalysisKey(p.name, pv.version));
         final dependencies = new Set<String>();
 
         analysisView.directDependencies

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -23,7 +23,7 @@ import 'utils.dart';
 import 'versions.dart';
 
 export 'package:pana/pana.dart' show LicenseFile, PkgDependency, Suggestion;
-export 'analyzer_service.dart';
+export 'analyzer_service.dart' hide AnalysisData;
 
 /// Sets the analyzer client.
 void registerAnalyzerClient(AnalyzerClient client) =>
@@ -49,7 +49,7 @@ class AnalyzerClient {
   }
 
   Future<AnalysisView> getAnalysisView(AnalysisKey key) async {
-    return new AnalysisView(await getAnalysisData(key));
+    return new AnalysisView(await _getAnalysisData(key));
   }
 
   Future<List<AnalysisExtract>> getAnalysisExtracts(
@@ -122,7 +122,7 @@ class AnalyzerClient {
   }
 
   /// Gets the analysis data from the analyzer service via HTTP.
-  Future<AnalysisData> getAnalysisData(AnalysisKey key) async {
+  Future<AnalysisData> _getAnalysisData(AnalysisKey key) async {
     if (key == null) return null;
     final String cachedContent = await analyzerMemcache?.getContent(
         key.package, key.version, panaVersion);

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -16,6 +16,7 @@ import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
+import 'package:pub_dartlang_org/shared/analyzer_service.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_client.dart';
@@ -301,15 +302,11 @@ class AnalyzerClientMock implements AnalyzerClient {
   AnalysisExtract mockAnalysisExtract;
 
   @override
-  Future<AnalysisData> getAnalysisData(AnalysisKey key) async =>
-      mockAnalysisData;
-
-  @override
   Future close() async => null;
 
   @override
   Future<AnalysisView> getAnalysisView(AnalysisKey key) async =>
-      new AnalysisView(await getAnalysisData(key));
+      new AnalysisView(mockAnalysisData);
 
   @override
   Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) =>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -10,6 +10,7 @@ import 'package:pana/pana.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/shared/analyzer_service.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/platform.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';


### PR DESCRIPTION
It is easier to migrate `AnalysisView` if `AnalysisData` is an internal detail.