### PR TITLE
Insert whitespace to improve text extraction from Markdown.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -40,7 +40,15 @@ String compactDescription(String text) => _compactText(text, maxLength: 500);
 
 String compactReadme(String text) {
   if (text == null || text.isEmpty) return '';
-  final html = markdownToHtml(text, null);
+  final html = markdownToHtml(text, null)
+      .replaceAll('</li>', '\n</li>')
+      .replaceAll('</p>', '\n</p>')
+      .replaceAll('</ul>', '\n</ul>')
+      .replaceAll('</ol>', '\n</ol>')
+      .replaceAll('</dl>', '\n</dl>')
+      .replaceAll('</dd>', '\n</dd>')
+      .replaceAll('</pre>', '\n</pre>')
+      .replaceAll('</blockquote>', '\n</blockquote>');
   final root = parseFragment(html);
   return _compactText(root.text, maxLength: 5000);
 }

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -7,6 +7,35 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/search/text_utils.dart';
 
 void main() {
+  group('text preparation', () {
+    test('readme text extraction', () {
+      final String input = '''Currently supports the following methods:
+
+- camelize
+- capitalize
+- escape
+- isLowerCase
+- isUpperCase
+- join
+- printable
+- reverse
+- startsWithLowerCase
+- startsWithUpperCase
+- toUnicode
+- underscore
+
+Other useful methods will be added soon...
+''';
+      final text = compactReadme(input);
+      expect(
+          text,
+          'Currently supports the following methods: camelize capitalize escape '
+          'isLowerCase isUpperCase join printable reverse startsWithLowerCase '
+          'startsWithUpperCase toUnicode underscore '
+          'Other useful methods will be added soon...');
+    });
+  });
+
   group('extact phrases', () {
     test('no phrase', () {
       expect(extractExactPhrases(''), isEmpty);


### PR DESCRIPTION
https://github.com/dart-lang/pub-dartlang-dart/issues/1615

The alternative would be to traverse the HTML DOM, but it seem to be simpler to just insert a few characters for HTML Elements that would otherwise render as `display: block`.