### PR TITLE
Ignore too long words.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -70,7 +70,9 @@ Map<String, double> tokenize(String originalText) {
   final tokens = <String, double>{};
 
   for (String word in splitForIndexing(originalText)) {
-    if (word.length > _maxWordLength) word = word.substring(0, _maxWordLength);
+    if (word.length > _maxWordLength) {
+      continue;
+    }
 
     final String normalizedWord = normalizeBeforeIndexing(word);
     if (normalizedWord.isEmpty) continue;


### PR DESCRIPTION
As https://github.com/dart-lang/pub-dartlang-dart/pull/1627 fixes the text extraction issues, the rest of the long words can be ignored, because our primary focus is API and English documentation.
Fixes https://github.com/dart-lang/pub-dartlang-dart/issues/1615