### PR TITLE
Keep and use weights of derived tokens during scoring.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -608,11 +608,10 @@ class TokenMatch {
 }
 
 class TokenIndex {
-  final Map<String, String> _textHashes = <String, String>{};
-  final Map<String, Map<String, double>> _inverseIds =
-      <String, Map<String, double>>{};
-  final Map<String, Set<String>> _inverseNgrams = <String, Set<String>>{};
-  final Map<String, double> _docSizes = <String, double>{};
+  final _textHashes = <String, String>{};
+  final _inverseIds = <String, Map<String, double>>{};
+  final _inverseNgrams = <String, Set<String>>{};
+  final _docSizes = <String, double>{};
   final int _minLength;
 
   TokenIndex({int minLength: 0}) : _minLength = minLength;
@@ -637,7 +636,7 @@ class TokenIndex {
     for (String token in tokens.keys) {
       final Map<String, double> weights =
           _inverseIds.putIfAbsent(token, () => <String, double>{});
-      weights[id] = math.max((weights[id] ?? 0.0), tokens[token]);
+      weights[id] = math.max(weights[id] ?? 0.0, tokens[token]);
       _inverseNgrams.putIfAbsent(token, () => _ngrams(token, _minLength));
     }
     // Document size is a highly scaled-down proxy of the length.

--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -609,7 +609,8 @@ class TokenMatch {
 
 class TokenIndex {
   final Map<String, String> _textHashes = <String, String>{};
-  final Map<String, Set<String>> _inverseIds = <String, Set<String>>{};
+  final Map<String, Map<String, double>> _inverseIds =
+      <String, Map<String, double>>{};
   final Map<String, Set<String>> _inverseNgrams = <String, Set<String>>{};
   final Map<String, double> _docSizes = <String, double>{};
   final int _minLength;
@@ -634,8 +635,9 @@ class TokenIndex {
       remove(id);
     }
     for (String token in tokens.keys) {
-      final Set<String> set = _inverseIds.putIfAbsent(token, () => new Set());
-      set.add(id);
+      final Map<String, double> weights =
+          _inverseIds.putIfAbsent(token, () => <String, double>{});
+      weights[id] = math.max((weights[id] ?? 0.0), tokens[token]);
       _inverseNgrams.putIfAbsent(token, () => _ngrams(token, _minLength));
     }
     // Document size is a highly scaled-down proxy of the length.
@@ -648,9 +650,9 @@ class TokenIndex {
     _textHashes.remove(id);
     _docSizes.remove(id);
     final List<String> removeKeys = [];
-    _inverseIds.forEach((String key, Set<String> set) {
-      set.remove(id);
-      if (set.isEmpty) removeKeys.add(key);
+    _inverseIds.forEach((String key, Map<String, double> weights) {
+      weights.remove(id);
+      if (weights.isEmpty) removeKeys.add(key);
     });
     removeKeys.forEach(_inverseIds.remove);
     removeKeys.forEach(_inverseNgrams.remove);
@@ -710,9 +712,11 @@ class TokenIndex {
     final queryWeight = tokenMatch.maxWeight;
     final Map<String, double> docScores = <String, double>{};
     for (String token in tokenMatch.tokens) {
-      for (String id in _inverseIds[token]) {
+      final docWeights = _inverseIds[token];
+      for (String id in docWeights.keys) {
         final double prevValue = docScores[id] ?? 0.0;
-        docScores[id] = math.max(prevValue, tokenMatch[token]);
+        final double currentValue = tokenMatch[token] * docWeights[id];
+        docScores[id] = math.max(prevValue, currentValue);
       }
     }
 

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -83,7 +83,7 @@ void main() {
         'packages': [
           {
             'package': 'other_with_api',
-            'score': closeTo(0.935, 0.001), // find serveWebPages
+            'score': closeTo(0.360, 0.001), // find serveWebPages
             'apiPages': [
               {'title': null, 'path': 'serve.html'},
             ],
@@ -103,7 +103,7 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.885, 0.001), // find WebPageGenerator
+            'score': closeTo(0.133, 0.001), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],
@@ -122,14 +122,14 @@ void main() {
         'packages': [
           {
             'package': 'foo',
-            'score': closeTo(0.887, 0.001), // find WebPageGenerator
+            'score': closeTo(0.236, 0.001), // find WebPageGenerator
             'apiPages': [
               {'title': null, 'path': 'generator.html'},
             ],
           },
           {
             'package': 'other_with_api',
-            'score': closeTo(0.355, 0.001), // find serveWebPages
+            'score': closeTo(0.032, 0.001), // find serveWebPages
             'apiPages': [
               {'title': null, 'path': 'serve.html'},
             ],

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -39,13 +39,13 @@ void main() {
         ..add('queue_lower', queueText.toLowerCase())
         ..add('unmodifiable', 'CustomUnmodifiableMapBase');
       expect(index.search('queue'), {
-        'queue': closeTo(0.98, 0.01),
+        'queue': closeTo(0.29, 0.01),
       });
       expect(index.search('unmodifiab'), {
-        'unmodifiable': closeTo(0.98, 0.01),
+        'unmodifiable': closeTo(0.47, 0.01),
       });
       expect(index.search('unmodifiable'), {
-        'unmodifiable': closeTo(0.98, 0.01),
+        'unmodifiable': closeTo(0.47, 0.01),
       });
     });
 


### PR DESCRIPTION
- Fixes https://github.com/dart-lang/pub-dartlang-dart/issues/1606
- Increases memory use only by 3% (I'm surprised on this)
- Doesn't effect ranking of original tokens, only derived ones.