### PR TITLE
Refactoring TaskScheduler

### DIFF
--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -77,10 +77,6 @@ class BatchIndexUpdater implements TaskRunner {
   }
 
   @override
-  Future<TaskTargetStatus> checkTargetStatus(Task task) async =>
-      new TaskTargetStatus.ok();
-
-  @override
   Future<bool> runTask(Task task) async {
     while (_ongoingBatchUpdate != null) {
       await _ongoingBatchUpdate;

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -77,7 +77,7 @@ class BatchIndexUpdater implements TaskRunner {
   }
 
   @override
-  Future<bool> runTask(Task task) async {
+  Future runTask(Task task) async {
     while (_ongoingBatchUpdate != null) {
       await _ongoingBatchUpdate;
     }
@@ -89,8 +89,6 @@ class BatchIndexUpdater implements TaskRunner {
     } else {
       await _updateBatch();
     }
-    // no race here
-    return false;
   }
 
   Future _updateBatch() async {

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -13,11 +13,8 @@ import 'utils.dart';
 final Logger _logger = new Logger('pub.scheduler');
 
 /// Interface for task execution.
+// ignore: one_member_abstracts
 abstract class TaskRunner {
-  /// Whether the scheduler should skip the task, e.g. because it has been
-  /// completed recently.
-  Future<TaskTargetStatus> checkTargetStatus(Task task);
-
   /// Run the task.
   /// Returns whether a race was detected while the run completed.
   Future<bool> runTask(Task task);
@@ -54,15 +51,7 @@ class TaskScheduler {
     Future runTask(Task task) async {
       final Stopwatch sw = new Stopwatch()..start();
       try {
-        TaskTargetStatus status;
         if (redirectPackagePages.containsKey(task.package)) {
-          status = new TaskTargetStatus.skip('Package is redirected from pub.');
-        }
-        status ??= await taskRunner.checkTargetStatus(task);
-        if (status.shouldSkip) {
-          _logger.info('Skipping scheduled task: $task: ${status.reason}.');
-          _statusTracker.add('skip');
-          _allLatencyTracker.add(sw.elapsedMilliseconds);
           return;
         }
         final bool raceDetected = await taskRunner.runTask(task);

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -16,8 +16,7 @@ final Logger _logger = new Logger('pub.scheduler');
 // ignore: one_member_abstracts
 abstract class TaskRunner {
   /// Run the task.
-  /// Returns whether a race was detected while the run completed.
-  Future<bool> runTask(Task task);
+  Future runTask(Task task);
 }
 
 // ignore: one_member_abstracts
@@ -54,8 +53,8 @@ class TaskScheduler {
         if (redirectPackagePages.containsKey(task.package)) {
           return;
         }
-        final bool raceDetected = await taskRunner.runTask(task);
-        _statusTracker.add(raceDetected ? 'race' : 'normal');
+        await taskRunner.runTask(task);
+        _statusTracker.add('normal');
       } catch (e, st) {
         _logger.severe('Error processing task: $task', e, st);
         _statusTracker.add('error');

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -116,11 +116,10 @@ class TaskScheduler {
 class Task {
   final String package;
   final String version;
-  final DateTime updated;
 
-  Task(this.package, this.version, this.updated);
+  Task(this.package, this.version);
 
-  Task.now(this.package, this.version) : updated = new DateTime.now().toUtc();
+  Task.now(this.package, this.version);
 
   @override
   String toString() => '$package $version';
@@ -131,11 +130,10 @@ class Task {
       other is Task &&
           runtimeType == other.runtimeType &&
           package == other.package &&
-          version == other.version &&
-          updated == other.updated;
+          version == other.version;
 
   @override
-  int get hashCode => package.hashCode ^ version.hashCode ^ updated.hashCode;
+  int get hashCode => package.hashCode ^ version.hashCode;
 }
 
 class TaskTargetStatus {

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -83,16 +83,12 @@ class TaskScheduler {
       );
     }
 
-    for (;;) {
+    while (liveSubscriptions > 0) {
       final task = _pickFirstTask();
 
       if (task == null) {
-        if (liveSubscriptions == 0) {
-          break;
-        } else {
-          await new Future.delayed(const Duration(seconds: 5));
-          continue;
-        }
+        await new Future.delayed(const Duration(seconds: 5));
+        continue;
       }
 
       await runTask(task);

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -22,6 +22,7 @@ abstract class TaskRunner {
 // ignore: one_member_abstracts
 abstract class TaskSource {
   /// Returns a stream of currently available tasks at the time of the call.
+  /// Some task sources (e.g. Datastore-polling sources) may never close.
   Stream<Task> startStreaming();
 }
 
@@ -35,7 +36,13 @@ class ManualTriggerTaskSource implements TaskSource {
   Stream<Task> startStreaming() => _taskReceivePort;
 }
 
-/// Schedules and executes package analysis.
+/// Schedules and executes tasks.
+///
+/// The execution of the tasks are prioritized in the order of the task sources:
+/// the ones from a lower-index source will be selected earlier than the ones
+/// from a high-index source.
+///
+/// Some task sources (e.g. Datastore-polling sources) may never close.
 class TaskScheduler {
   final TaskRunner taskRunner;
   final List<TaskSource> sources;

--- a/app/lib/shared/task_sources.dart
+++ b/app/lib/shared/task_sources.dart
@@ -99,13 +99,11 @@ class DatastoreHeadTaskSource implements TaskSource {
   }
 
   Task _packageToTask(Package p) =>
-      new Task(p.name, p.latestVersion ?? p.latestDevVersion, p.updated);
+      new Task(p.name, p.latestVersion ?? p.latestDevVersion);
 
-  Task _versionToTask(PackageVersion pv) =>
-      new Task(pv.package, pv.version, pv.created);
+  Task _versionToTask(PackageVersion pv) => new Task(pv.package, pv.version);
 
-  Task _analysisToTask(Analysis a) =>
-      new Task(a.packageName, a.packageVersion, a.timestamp);
+  Task _analysisToTask(Analysis a) => new Task(a.packageName, a.packageVersion);
 }
 
 /// Creates a task when the most recent output requires an update (e.g. too old).
@@ -128,12 +126,12 @@ abstract class DatastoreHistoryTaskSource implements TaskSource {
         await for (Package p in packageQuery.run()) {
           if (await requiresUpdate(p.name, p.latestVersion,
               retryFailed: true)) {
-            yield new Task(p.name, p.latestVersion, p.updated);
+            yield new Task(p.name, p.latestVersion);
           }
 
           if (p.latestVersion != p.latestDevVersion &&
               await requiresUpdate(p.name, p.latestDevVersion)) {
-            yield new Task(p.name, p.latestDevVersion, p.updated);
+            yield new Task(p.name, p.latestDevVersion);
           }
         }
 
@@ -143,7 +141,7 @@ abstract class DatastoreHistoryTaskSource implements TaskSource {
           ..order('-created');
         await for (PackageVersion pv in versionQuery.run()) {
           if (await requiresUpdate(pv.package, pv.version)) {
-            yield new Task(pv.package, pv.version, pv.created);
+            yield new Task(pv.package, pv.version);
           }
         }
       } catch (e, st) {


### PR DESCRIPTION
Right now it is used only for `search`, but I'm planning to extend this for the non-Job-based scheduling and race-prevention.

- removed some of the historical clutter
- re-added proper priority queues
