### PR TITLE
Fix ScoreCard's maintenanceScore value.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -234,8 +234,9 @@ class AnalyzerJobProcessor extends JobProcessor {
           panaRuntimeInfo: summary?.runtimeInfo,
           reportStatus: reportStatus,
           healthScore: summary?.health?.healthScore ?? 0.0,
-          maintenanceScore:
-              summary == null ? 0.0 : getMaintenanceScore(summary.maintenance),
+          maintenanceScore: summary == null
+              ? 0.0
+              : (getMaintenanceScore(summary.maintenance) / 100.0),
           platformTags: indexDartPlatform(summary?.platform),
           platformReason: summary?.platform?.reason,
           pkgDependencies: summary?.pkgResolution?.dependencies,


### PR DESCRIPTION
`getMaintenanceScore` reports it in the `0.0-100.0` range, while everything else is stored and handled in the `0.0-1.0` range.