### PR TITLE
Treat missing SDK constraint as legacy package and mark Dart 2 incompatibility.

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -168,6 +168,11 @@ class AnalyzerJobProcessor extends JobProcessor {
   }
 
   bool _isLegacy(Suggestion s) {
+    // Dart 2 SDK treats missing SDK constraints as <2.0.0.
+    if (s.code == SuggestionCode.pubspecSdkConstraintMissing) {
+      return true;
+    }
+
     final isVersionFailed = s.isError &&
         s.code == SuggestionCode.pubspecDependenciesFailedToResolve &&
         s.description != null &&


### PR DESCRIPTION
https://github.com/dart-lang/pub-dartlang-dart/issues/1574