### PR TITLE
Backup / update user-provided Datastore entries.

### DIFF
--- a/app/bin/tools/datastore.dart
+++ b/app/bin/tools/datastore.dart
@@ -52,13 +52,12 @@ class BackupCommand extends Command {
         ? Directory.current
         : new Directory(argResults['backup-directory'] as String);
     await backupDir.create(recursive: true);
-    // current timestamp in YYYYMMDD-HHmmss
+    // current timestamp in YYYY-MM-DD-HH-mm-ss
     final ts = new DateTime.now()
         .toUtc()
         .toIso8601String()
-        .replaceAll('-', '')
         .replaceAll('T', '-')
-        .replaceAll(':', '')
+        .replaceAll(':', '-')
         .split('.')
         .first;
     // output files

--- a/app/bin/tools/datastore.dart
+++ b/app/bin/tools/datastore.dart
@@ -265,6 +265,7 @@ class ArchiveLine {
   Map<String, dynamic> toJson() => _$ArchiveLineToJson(this);
 }
 
+// NOTE: Keep in sync with PackageVersion.
 @JsonSerializable()
 class PackageArchive {
   final String name;
@@ -295,6 +296,7 @@ class PackageArchive {
   Map<String, dynamic> toJson() => _$PackageArchiveToJson(this);
 }
 
+// NOTE: Keep in sync with PackageVersion.
 @JsonSerializable()
 class PackageVersionArchive {
   final String version;

--- a/app/bin/tools/datastore.dart
+++ b/app/bin/tools/datastore.dart
@@ -133,7 +133,7 @@ class UpdateCommand extends Command {
   Future run() async {
     if (activeConfiguration.projectId != 'dartlang-pub-dev') {
       print('\nPROJECT_ID is not dartlang-pub-dev, exiting.\n');
-      exit(-1);
+      exit(1);
     }
 
     final backupDir = argResults['backup-directory'] == null

--- a/app/bin/tools/datastore.dart
+++ b/app/bin/tools/datastore.dart
@@ -1,0 +1,335 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Backup critical (user-provided) data from Datastore.
+
+import 'dart:async';
+import 'dart:convert' as convert;
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:gcloud/db.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
+import 'package:pool/pool.dart';
+
+import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/frontend/model_properties.dart';
+import 'package:pub_dartlang_org/frontend/service_utils.dart';
+import 'package:pub_dartlang_org/shared/configuration.dart';
+
+part 'datastore.g.dart';
+
+/// Usage:
+/// - Create a backup and store it in the current directory:
+///   dart bin/tools/datastore.dart backup
+/// - Update the datastore from the latest backup:
+///   dart bin/tools/datastore.dart update
+Future main(List<String> arguments) async {
+  final runner =
+      new CommandRunner('datastore', 'Datastore backup and restore utility.')
+        ..addCommand(new BackupCommand())
+        ..addCommand(new UpdateCommand());
+  await runner.run(arguments);
+}
+
+/// Backup user-provided data from Datastore.
+class BackupCommand extends Command {
+  @override
+  String get name => 'backup';
+
+  @override
+  String get description => 'Backup user-provided data from Datastore.';
+
+  BackupCommand() {
+    argParser.addOption('backup-directory', help: 'The backup directory.');
+  }
+
+  @override
+  Future run() async {
+    final backupDir = argResults['backup-directory'] == null
+        ? Directory.current
+        : new Directory(argResults['backup-directory'] as String);
+    await backupDir.create(recursive: true);
+    // current timestamp in YYYYMMDD-HHmmss
+    final ts = new DateTime.now()
+        .toUtc()
+        .toIso8601String()
+        .replaceAll('-', '')
+        .replaceAll('T', '-')
+        .replaceAll(':', '')
+        .split('.')
+        .first;
+    // output files
+    final packagesFile = new File('${backupDir.path}/$ts-packages.jsonl');
+
+    await withProdServices(() async {
+      print('Backup packages into ${packagesFile.path}...');
+      int pkgCounter = 0;
+      await for (final p in dbService.query<Package>().run()) {
+        pkgCounter++;
+        if (pkgCounter == 1 || pkgCounter % 20 == 0) {
+          print('Processing #$pkgCounter [${p.name}]...');
+        }
+        final versions = await dbService
+            .query<PackageVersion>(ancestorKey: p.key)
+            .run()
+            .toList();
+
+        final archiveLine = new ArchiveLine(
+          package: new PackageArchive(
+            name: p.name,
+            created: p.created,
+            updated: p.updated,
+            downloads: p.downloads,
+            latestVersion: p.latestVersion,
+            latestDevVersion: p.latestDevVersion,
+            uploaderEmails: p.uploaderEmails,
+            isDiscontinued: p.isDiscontinued,
+            doNotAdvertise: p.doNotAdvertise,
+          ),
+          versions: versions
+              .map((pv) => new PackageVersionArchive(
+                    version: pv.version,
+                    created: pv.created,
+                    pubspecJson: convert.json.encode(pv.pubspec.asJson),
+                    readmeFilename: pv.readmeFilename,
+                    readmeContent: pv.readmeContent,
+                    changelogFilename: pv.changelogFilename,
+                    changelogContent: pv.changelogContent,
+                    exampleFilename: pv.exampleFilename,
+                    exampleContent: pv.exampleContent,
+                    libraries: pv.libraries,
+                    downloads: pv.downloads,
+                    sortOrder: pv.sortOrder,
+                    uploaderEmail: pv.uploaderEmail,
+                  ))
+              .toList(),
+        );
+
+        final line = convert.json.encode(archiveLine.toJson());
+        await packagesFile.writeAsString(line + '\n',
+            mode: FileMode.writeOnlyAppend);
+      }
+      print('$pkgCounter packages backed up in ${packagesFile.path}');
+    });
+  }
+}
+
+/// 'Updates user-provided data from backup.'
+class UpdateCommand extends Command {
+  @override
+  String get name => 'update';
+
+  @override
+  String get description => 'Updates user-provided data from backup.';
+
+  UpdateCommand() {
+    argParser.addOption('backup-directory', help: 'The backup directory.');
+  }
+
+  @override
+  Future run() async {
+    if (activeConfiguration.projectId != 'dartlang-pub-dev') {
+      print('\nPROJECT_ID is not dartlang-pub-dev, exiting.\n');
+      exit(-1);
+    }
+
+    final backupDir = argResults['backup-directory'] == null
+        ? Directory.current
+        : new Directory(argResults['backup-directory'] as String);
+    // input files
+    final backupPrefix = await _detectLatest(backupDir);
+    print('\nFound backup prefix: $backupPrefix\n'
+        'Waiting for 5 seconds before proceeding.\n');
+    await new Future.delayed(const Duration(seconds: 5));
+    final packagesFile = new File('$backupPrefix-packages.jsonl');
+
+    await withProdServices(() async {
+      print('Restoring packages from: $packagesFile');
+      final stream = packagesFile
+          .openRead()
+          .transform(convert.utf8.decoder)
+          .transform(new convert.LineSplitter())
+          .map(convert.json.decode)
+          .cast<Map<String, dynamic>>();
+      int pkgCounter = 0;
+      int pkgUpdateCount = 0;
+      int pkgVersionUpdateCount = 0;
+      await for (final data in stream) {
+        final archiveLine = new ArchiveLine.fromJson(data);
+        final pkgArchive = archiveLine.package;
+        final packageName = pkgArchive.name;
+        final pkgKey = dbService.emptyKey.append(Package, id: packageName);
+        final latestVersionKey =
+            pkgKey.append(PackageVersion, id: pkgArchive.latestVersion);
+        final latestDevVersionKey = pkgArchive.latestDevVersion == null
+            ? null
+            : pkgKey.append(PackageVersion, id: pkgArchive.latestDevVersion);
+
+        pkgCounter++;
+        if (pkgCounter == 1 || pkgCounter % 10 == 0) {
+          print('Processing #$pkgCounter [$packageName]...');
+        }
+
+        await dbService.withTransaction((tx) async {
+          Package p = (await tx.lookup([pkgKey])).single;
+          p ??= new Package();
+          p
+            ..id = pkgArchive.name
+            ..name = pkgArchive.name
+            ..created = pkgArchive.created
+            ..updated = pkgArchive.updated
+            ..downloads = pkgArchive.downloads
+            ..latestVersionKey = latestVersionKey
+            ..latestDevVersionKey = latestDevVersionKey
+            ..uploaderEmails = pkgArchive.uploaderEmails
+            ..isDiscontinued = pkgArchive.isDiscontinued
+            ..doNotAdvertise = pkgArchive.doNotAdvertise;
+          pkgUpdateCount++;
+          tx.queueMutations(inserts: [p]);
+          await tx.commit();
+        });
+
+        final pool = new Pool(4);
+        final futures = <Future>[];
+        for (final versionArchive in archiveLine.versions) {
+          final packageVersion = versionArchive.version;
+          final versionKey = pkgKey.append(PackageVersion, id: packageVersion);
+          Future updateVersion() async {
+            await dbService.withTransaction((tx) async {
+              PackageVersion pv = (await tx.lookup([versionKey])).single;
+              if (pv == null) {
+                pv = new PackageVersion()
+                  ..parentKey = pkgKey
+                  ..id = packageVersion
+                  ..version = packageVersion
+                  ..created = versionArchive.created
+                  ..pubspec = new Pubspec(versionArchive.pubspecJson)
+                  ..readmeFilename = versionArchive.readmeFilename
+                  ..readmeContent = versionArchive.readmeContent
+                  ..changelogFilename = versionArchive.changelogFilename
+                  ..changelogContent = versionArchive.changelogContent
+                  ..exampleFilename = versionArchive.exampleFilename
+                  ..exampleContent = versionArchive.exampleContent
+                  ..libraries = versionArchive.libraries
+                  ..downloads = versionArchive.downloads
+                  ..sortOrder = versionArchive.sortOrder
+                  ..uploaderEmail = versionArchive.uploaderEmail;
+                pkgVersionUpdateCount++;
+                tx.queueMutations(inserts: [pv]);
+                await tx.commit();
+              } else {
+                await tx.rollback();
+              }
+            });
+          }
+
+          pool.withResource(updateVersion);
+        }
+        await Future.wait(futures);
+        await pool.close();
+      }
+      print('$pkgCounter packages processed from ${packagesFile.path}');
+      print('Updated:\n'
+          '  $pkgUpdateCount packages\n'
+          '  $pkgVersionUpdateCount versions.');
+    });
+  }
+
+  Future<String> _detectLatest(Directory backupDir) async {
+    final suffix = '-packages.jsonl';
+    final list = await backupDir
+        .list()
+        .where((fse) => fse is File && fse.path.endsWith(suffix))
+        .map((f) => f.path.substring(0, f.path.length - suffix.length))
+        .toList();
+    list.sort();
+    return list.last;
+  }
+}
+
+@JsonSerializable()
+class ArchiveLine {
+  final PackageArchive package;
+  final List<PackageVersionArchive> versions;
+
+  ArchiveLine({
+    @required this.package,
+    @required this.versions,
+  });
+
+  factory ArchiveLine.fromJson(Map<String, dynamic> json) =>
+      _$ArchiveLineFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ArchiveLineToJson(this);
+}
+
+@JsonSerializable()
+class PackageArchive {
+  final String name;
+  final DateTime created;
+  final DateTime updated;
+  final int downloads;
+  final String latestVersion;
+  final String latestDevVersion;
+  final List<String> uploaderEmails;
+  final bool isDiscontinued;
+  final bool doNotAdvertise;
+
+  PackageArchive({
+    @required this.name,
+    @required this.created,
+    @required this.updated,
+    @required this.downloads,
+    @required this.latestVersion,
+    @required this.latestDevVersion,
+    @required this.uploaderEmails,
+    @required this.isDiscontinued,
+    @required this.doNotAdvertise,
+  });
+
+  factory PackageArchive.fromJson(Map<String, dynamic> json) =>
+      _$PackageArchiveFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PackageArchiveToJson(this);
+}
+
+@JsonSerializable()
+class PackageVersionArchive {
+  final String version;
+  final DateTime created;
+  final String pubspecJson;
+  final String readmeFilename;
+  final String readmeContent;
+  final String changelogFilename;
+  final String changelogContent;
+  final String exampleFilename;
+  final String exampleContent;
+  final List<String> libraries;
+  final int downloads;
+  final int sortOrder;
+  final String uploaderEmail;
+
+  PackageVersionArchive({
+    @required this.version,
+    @required this.created,
+    @required this.pubspecJson,
+    @required this.readmeFilename,
+    @required this.readmeContent,
+    @required this.changelogFilename,
+    @required this.changelogContent,
+    @required this.exampleFilename,
+    @required this.exampleContent,
+    @required this.libraries,
+    @required this.downloads,
+    @required this.sortOrder,
+    @required this.uploaderEmail,
+  });
+
+  factory PackageVersionArchive.fromJson(Map<String, dynamic> json) =>
+      _$PackageVersionArchiveFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PackageVersionArchiveToJson(this);
+}

--- a/app/bin/tools/datastore.dart
+++ b/app/bin/tools/datastore.dart
@@ -24,13 +24,13 @@ part 'datastore.g.dart';
 /// Usage:
 /// - Create a backup and store it in the current directory:
 ///   dart bin/tools/datastore.dart backup
-/// - Update the datastore from the latest backup:
-///   dart bin/tools/datastore.dart update
+/// - Restore the datastore from the latest backup:
+///   dart bin/tools/datastore.dart restore
 Future main(List<String> arguments) async {
   final runner =
       new CommandRunner('datastore', 'Datastore backup and restore utility.')
         ..addCommand(new BackupCommand())
-        ..addCommand(new UpdateCommand());
+        ..addCommand(new RestoreCommand());
   await runner.run(arguments);
 }
 
@@ -116,15 +116,15 @@ class BackupCommand extends Command {
   }
 }
 
-/// 'Updates user-provided data from backup.'
-class UpdateCommand extends Command {
+/// 'Restores user-provided data from backup.'
+class RestoreCommand extends Command {
   @override
-  String get name => 'update';
+  String get name => 'restore';
 
   @override
-  String get description => 'Updates user-provided data from backup.';
+  String get description => 'Restores user-provided data from backup.';
 
-  UpdateCommand() {
+  RestoreCommand() {
     argParser.addOption('packages', help: 'The *-packages.jsonl backup file.');
   }
 
@@ -142,7 +142,7 @@ class UpdateCommand extends Command {
     }
 
     await withProdServices(() async {
-      print('Updating packages from: $packagesFile');
+      print('Restoring packages from: $packagesFile');
       final stream = packagesFile
           .openRead()
           .transform(convert.utf8.decoder)
@@ -227,7 +227,7 @@ class UpdateCommand extends Command {
         await pool.close();
       }
       print('$pkgCounter packages processed from ${packagesFile.path}');
-      print('Updated:\n'
+      print('Restored:\n'
           '  $pkgUpdateCount packages\n'
           '  $pkgVersionUpdateCount versions.');
     });

--- a/app/bin/tools/datastore.g.dart
+++ b/app/bin/tools/datastore.g.dart
@@ -1,0 +1,94 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'datastore.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ArchiveLine _$ArchiveLineFromJson(Map<String, dynamic> json) {
+  return ArchiveLine(
+      package: json['package'] == null
+          ? null
+          : PackageArchive.fromJson(json['package'] as Map<String, dynamic>),
+      versions: (json['versions'] as List)
+          ?.map((e) => e == null
+              ? null
+              : PackageVersionArchive.fromJson(e as Map<String, dynamic>))
+          ?.toList());
+}
+
+Map<String, dynamic> _$ArchiveLineToJson(ArchiveLine instance) =>
+    <String, dynamic>{
+      'package': instance.package,
+      'versions': instance.versions
+    };
+
+PackageArchive _$PackageArchiveFromJson(Map<String, dynamic> json) {
+  return PackageArchive(
+      name: json['name'] as String,
+      created: json['created'] == null
+          ? null
+          : DateTime.parse(json['created'] as String),
+      updated: json['updated'] == null
+          ? null
+          : DateTime.parse(json['updated'] as String),
+      downloads: json['downloads'] as int,
+      latestVersion: json['latestVersion'] as String,
+      latestDevVersion: json['latestDevVersion'] as String,
+      uploaderEmails:
+          (json['uploaderEmails'] as List)?.map((e) => e as String)?.toList(),
+      isDiscontinued: json['isDiscontinued'] as bool,
+      doNotAdvertise: json['doNotAdvertise'] as bool);
+}
+
+Map<String, dynamic> _$PackageArchiveToJson(PackageArchive instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'created': instance.created?.toIso8601String(),
+      'updated': instance.updated?.toIso8601String(),
+      'downloads': instance.downloads,
+      'latestVersion': instance.latestVersion,
+      'latestDevVersion': instance.latestDevVersion,
+      'uploaderEmails': instance.uploaderEmails,
+      'isDiscontinued': instance.isDiscontinued,
+      'doNotAdvertise': instance.doNotAdvertise
+    };
+
+PackageVersionArchive _$PackageVersionArchiveFromJson(
+    Map<String, dynamic> json) {
+  return PackageVersionArchive(
+      version: json['version'] as String,
+      created: json['created'] == null
+          ? null
+          : DateTime.parse(json['created'] as String),
+      pubspecJson: json['pubspecJson'] as String,
+      readmeFilename: json['readmeFilename'] as String,
+      readmeContent: json['readmeContent'] as String,
+      changelogFilename: json['changelogFilename'] as String,
+      changelogContent: json['changelogContent'] as String,
+      exampleFilename: json['exampleFilename'] as String,
+      exampleContent: json['exampleContent'] as String,
+      libraries: (json['libraries'] as List)?.map((e) => e as String)?.toList(),
+      downloads: json['downloads'] as int,
+      sortOrder: json['sortOrder'] as int,
+      uploaderEmail: json['uploaderEmail'] as String);
+}
+
+Map<String, dynamic> _$PackageVersionArchiveToJson(
+        PackageVersionArchive instance) =>
+    <String, dynamic>{
+      'version': instance.version,
+      'created': instance.created?.toIso8601String(),
+      'pubspecJson': instance.pubspecJson,
+      'readmeFilename': instance.readmeFilename,
+      'readmeContent': instance.readmeContent,
+      'changelogFilename': instance.changelogFilename,
+      'changelogContent': instance.changelogContent,
+      'exampleFilename': instance.exampleFilename,
+      'exampleContent': instance.exampleContent,
+      'libraries': instance.libraries,
+      'downloads': instance.downloads,
+      'sortOrder': instance.sortOrder,
+      'uploaderEmail': instance.uploaderEmail
+    };

--- a/app/build.yaml
+++ b/app/build.yaml
@@ -3,6 +3,7 @@
 targets:
   pub_dartlang_org:
     sources:
+      - 'bin/tools/datastore.dart'
       - 'lib/history/models.dart'
       - 'lib/dartdoc/models.dart'
       - 'lib/scorecard/models.dart'

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -28,6 +28,8 @@ export 'model_properties.dart' show FileObject;
 // have db Models for users, but the lowlevel datastore API will store them
 // as expanded properties of type `Entity`.
 // We should move ExpandoModel -> Model once we have highlevel db.User objects.
+//
+// NOTE: Keep in sync with PackageArchive.
 @db.Kind(name: 'Package', idType: db.IdType.String)
 class Package extends db.ExpandoModel {
   @db.StringProperty()
@@ -115,6 +117,8 @@ class Package extends db.ExpandoModel {
 // have db Models for users, but the lowlevel datastore API will store them
 // as expanded properties of type `Entity`.
 // We should move ExpandoModel -> Model once we have highlevel db.User objects.
+//
+// NOTE: Keep in sync with PackageVersionArchive.
 @db.Kind(name: 'PackageVersion', idType: db.IdType.String)
 class PackageVersion extends db.ExpandoModel {
   @db.StringProperty(required: true)


### PR DESCRIPTION
This should help both https://github.com/dart-lang/pub-dartlang-dart/issues/1508 and https://github.com/dart-lang/pub-dartlang-dart/issues/1509

Currently it updates `Package` data, and creates new `PackageVersion` entries (no check for updating the PV entry if the underlying data may have changed).

The script has an extra protection against not writing to other store than staging. I have plans to improve it later (e.g. auto-delete versions that are no longer in prod / extra in staging), but first we shall do a clean refresh of staging with this one.