### PR TITLE
Add scheduler stats back to search service's debug data.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -101,6 +101,11 @@ Future _main(FrontendEntryMessage message) async {
       ],
     );
     scheduler.run();
+
+    new Timer.periodic(const Duration(minutes: 5), (_) {
+      updateLatestStats(scheduler.stats());
+    });
+
     await runHandler(_logger, searchServiceHandler);
   });
 }


### PR DESCRIPTION
It was probably "lost" with the isolate refactoring.