### PR TITLE
Remove http overhead of the AnalyzerClient.

### DIFF
--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -18,6 +18,7 @@ import 'package:pub_dartlang_org/job/job.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/scorecard/scorecard_memcache.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
+import 'package:pub_dartlang_org/shared/analyzer_memcache.dart';
 import 'package:pub_dartlang_org/shared/configuration.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_memcache.dart';
 import 'package:pub_dartlang_org/shared/handler_helpers.dart';
@@ -101,6 +102,7 @@ Future _registerServices() async {
 
   registerDartdocMemcache(new DartdocMemcache(memcacheService));
 
+  registerAnalyzerMemcache(new AnalyzerMemcache(memcacheService));
   registerAnalysisBackend(new AnalysisBackend(dbService));
   registerAnalyzerClient(new AnalyzerClient());
   final Bucket storageBucket = await getOrCreateBucket(

--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -13,6 +13,7 @@ import 'package:logging/logging.dart';
 import 'package:pub_server/shelf_pubserver.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
+import 'package:pub_dartlang_org/analyzer/backend.dart';
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/history/backend.dart';
 import 'package:pub_dartlang_org/history/models.dart';
@@ -66,6 +67,7 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
   await popularityStorage.init();
 
   registerAnalyzerMemcache(new AnalyzerMemcache(memcacheService));
+  registerAnalysisBackend(new AnalysisBackend(db.dbService));
   final AnalyzerClient analyzerClient = new AnalyzerClient();
   registerAnalyzerClient(analyzerClient);
   registerScopeExitCallback(analyzerClient.close);

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -11,6 +11,7 @@ import 'package:gcloud/service_scope.dart';
 import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 
+import 'package:pub_dartlang_org/analyzer/backend.dart';
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/analyzer_memcache.dart';
@@ -55,6 +56,7 @@ Future _main(FrontendEntryMessage message) async {
     await popularityStorage.init();
 
     registerAnalyzerMemcache(new AnalyzerMemcache(memcacheService));
+    registerAnalysisBackend(new AnalysisBackend(db.dbService));
     final AnalyzerClient analyzerClient = new AnalyzerClient();
     registerAnalyzerClient(analyzerClient);
     registerScopeExitCallback(analyzerClient.close);

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -139,8 +139,8 @@ class AnalyzerClient {
       return data;
     } catch (e, st) {
       _logger.shout('Analysis request failed: $key', e, st);
+      return null;
     }
-    return null;
   }
 
   Future triggerAnalysis(

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -6,20 +6,18 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:gcloud/service_scope.dart' as ss;
-import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:pana/pana.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../analyzer/backend.dart';
 import '../job/backend.dart';
 
 import 'analyzer_memcache.dart';
 import 'analyzer_service.dart';
-import 'configuration.dart';
 import 'memcache.dart' show analyzerDataLocalExpiration;
 import 'platform.dart';
 import 'popularity_storage.dart';
-import 'utils.dart';
 import 'versions.dart';
 
 export 'package:pana/pana.dart' show LicenseFile, PkgDependency, Suggestion;
@@ -40,9 +38,6 @@ final Logger _logger = new Logger('pub.analyzer_client');
 class AnalyzerClient {
   final int _extractCacheSize = 10000;
   final Map<AnalysisKey, AnalysisExtract> _extractCache = {};
-  final http.Client _client = new http.Client();
-  String get _analyzerServiceHttpHostPort =>
-      activeConfiguration.analyzerServicePrefix;
 
   Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) {
     return Future.wait(keys.map(getAnalysisView));
@@ -134,20 +129,16 @@ class AnalyzerClient {
         _logger.severe('Unable to parse analysis data for $key', e, st);
       }
     }
-    final String uri =
-        '$_analyzerServiceHttpHostPort/packages/${key.package}/${key.version}?panaVersion=$panaVersion';
     try {
-      final http.Response rs = await getUrlWithRetry(_client, uri);
-      if (rs.statusCode == 200) {
-        final String content = rs.body;
-        final AnalysisData data = new AnalysisData.fromJson(
-            json.decode(content) as Map<String, dynamic>);
+      final data = await analysisBackend.getAnalysis(key.package,
+          version: key.version, panaVersion: panaVersion);
+      if (data != null) {
         await analyzerMemcache?.setContent(
-            key.package, key.version, panaVersion, content);
-        return data;
+            key.package, key.version, panaVersion, json.encode(data.toJson()));
       }
+      return data;
     } catch (e, st) {
-      _logger.shout('Analysis request failed on $uri', e, st);
+      _logger.shout('Analysis request failed: $key', e, st);
     }
     return null;
   }
@@ -165,7 +156,7 @@ class AnalyzerClient {
   }
 
   Future close() async {
-    _client.close();
+    // no-op
   }
 }
 


### PR DESCRIPTION
Related to #1521 and #1539. As we no longer want to tie our content-serving frontend to the service's frontend, data access is using the *Backend service objects.