### PR TITLE
 Infer repository and issue tracker URL from homepage.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -409,7 +409,6 @@ class TemplateService {
     );
     final repositoryUrl = urls.inferRepositoryUrl(homepageUrl);
     final issueTrackerUrl = urls.inferIssueTrackerUrl(homepageUrl);
-    final repositoryIsHomepage = repositoryUrl == homepageUrl;
 
     final links = <Map<String, dynamic>>[];
     void addLink(String href, String label) {
@@ -417,12 +416,10 @@ class TemplateService {
       links.add(<String, dynamic>{'href': href, 'label': label});
     }
 
-    if (repositoryIsHomepage) {
-      addLink(repositoryUrl, 'Repository');
-    } else {
+    if (repositoryUrl != homepageUrl) {
       addLink(homepageUrl, isGitHubHomepage ? 'Homepage (GitHub)' : 'Homepage');
-      addLink(repositoryUrl, 'Repository');
     }
+    addLink(repositoryUrl, 'Repository');
     addLink(issueTrackerUrl, 'Issue Tracker');
     addLink(documentationUrl, 'Documentation');
     addLink(dartdocsUrl, 'API Docs');

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -400,8 +400,6 @@ class TemplateService {
             documentationUrl.startsWith('http://pub.dartlang.org/'))) {
       documentationUrl = null;
     }
-    final isGitHubHomepage =
-        homepageUrl != null && homepageUrl.startsWith('https://github.com/');
     final dartdocsUrl = urls.pkgDocUrl(
       package.name,
       version: selectedVersion.version,
@@ -411,16 +409,28 @@ class TemplateService {
     final issueTrackerUrl = urls.inferIssueTrackerUrl(homepageUrl);
 
     final links = <Map<String, dynamic>>[];
-    void addLink(String href, String label) {
-      if (href == null || href.isEmpty) return;
+    void addLink(
+      String href,
+      String label, {
+      bool detectServiceProvider: false,
+    }) {
+      if (href == null || href.isEmpty) {
+        return;
+      }
+      if (detectServiceProvider) {
+        final providerName = urls.inferServiceProviderName(href);
+        if (providerName != null) {
+          label += ' ($providerName)';
+        }
+      }
       links.add(<String, dynamic>{'href': href, 'label': label});
     }
 
     if (repositoryUrl != homepageUrl) {
-      addLink(homepageUrl, isGitHubHomepage ? 'Homepage (GitHub)' : 'Homepage');
+      addLink(homepageUrl, 'Homepage');
     }
-    addLink(repositoryUrl, 'Repository');
-    addLink(issueTrackerUrl, 'Issue Tracker');
+    addLink(repositoryUrl, 'Repository', detectServiceProvider: true);
+    addLink(issueTrackerUrl, 'Issue Tracker', detectServiceProvider: true);
     addLink(documentationUrl, 'Documentation');
     addLink(dartdocsUrl, 'API Docs');
 

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -404,6 +404,22 @@ class TemplateService {
     }
     final isGitHubHomepage = selectedVersion.homepage != null &&
         selectedVersion.homepage.startsWith('https://github.com/');
+    final dartdocsUrl = urls.pkgDocUrl(
+      package.name,
+      version: selectedVersion.version,
+      isLatest: selectedVersion.version == package.latestVersion,
+    );
+
+    final links = <Map<String, dynamic>>[];
+    void addLink(String href, String label) {
+      if (href == null || href.isEmpty) return;
+      links.add(<String, dynamic>{'href': href, 'label': label});
+    }
+
+    addLink(selectedVersion.homepage,
+        isGitHubHomepage ? 'Homepage (GitHub)' : 'Homepage');
+    addLink(documentationUrl, 'Documentation');
+    addLink(dartdocsUrl, 'API Docs');
 
     final values = {
       'package': {
@@ -425,14 +441,7 @@ class TemplateService {
         // TODO: make this 'Authors' if PackageVersion.authors is a list?!
         'authors_title': 'Author',
         'authors_html': _getAuthorsHtml(selectedVersion.pubspec.authors),
-        'homepage_label': isGitHubHomepage ? 'Homepage (GitHub)' : 'Homepage',
-        'homepage': selectedVersion.homepage,
-        'documentation': documentationUrl,
-        'dartdocs_url': urls.pkgDocUrl(
-          package.name,
-          version: selectedVersion.version,
-          isLatest: selectedVersion.version == package.latestVersion,
-        ),
+        'links': links,
         // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
         'uploaders_title': 'Uploader',
         'uploaders_html': _getAuthorsHtml(package.uploaderEmails),

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -336,26 +336,24 @@ class TemplateService {
       bool isFlutterPackage) {
     String readmeFilename;
     String renderedReadme;
+    final homepageUrl = selectedVersion.homepage;
     if (selectedVersion.readme != null) {
       readmeFilename = selectedVersion.readme.filename;
-      renderedReadme =
-          _renderFile(selectedVersion.readme, selectedVersion.homepage);
+      renderedReadme = _renderFile(selectedVersion.readme, homepageUrl);
     }
 
     String changelogFilename;
     String renderedChangelog;
     if (selectedVersion.changelog != null) {
       changelogFilename = selectedVersion.changelog.filename;
-      renderedChangelog =
-          _renderFile(selectedVersion.changelog, selectedVersion.homepage);
+      renderedChangelog = _renderFile(selectedVersion.changelog, homepageUrl);
     }
 
     String exampleFilename;
     String renderedExample;
     if (selectedVersion.example != null) {
       exampleFilename = selectedVersion.example.filename;
-      renderedExample =
-          _renderFile(selectedVersion.example, selectedVersion.homepage);
+      renderedExample = _renderFile(selectedVersion.example, homepageUrl);
       if (renderedExample != null) {
         renderedExample = '<p style="font-family: monospace">'
             '<b>${_htmlEscaper.convert(exampleFilename)}</b>'
@@ -402,13 +400,16 @@ class TemplateService {
             documentationUrl.startsWith('http://pub.dartlang.org/'))) {
       documentationUrl = null;
     }
-    final isGitHubHomepage = selectedVersion.homepage != null &&
-        selectedVersion.homepage.startsWith('https://github.com/');
+    final isGitHubHomepage =
+        homepageUrl != null && homepageUrl.startsWith('https://github.com/');
     final dartdocsUrl = urls.pkgDocUrl(
       package.name,
       version: selectedVersion.version,
       isLatest: selectedVersion.version == package.latestVersion,
     );
+    final repositoryUrl = urls.inferRepositoryUrl(homepageUrl);
+    final issueTrackerUrl = urls.inferIssueTrackerUrl(homepageUrl);
+    final repositoryIsHomepage = repositoryUrl == homepageUrl;
 
     final links = <Map<String, dynamic>>[];
     void addLink(String href, String label) {
@@ -416,8 +417,13 @@ class TemplateService {
       links.add(<String, dynamic>{'href': href, 'label': label});
     }
 
-    addLink(selectedVersion.homepage,
-        isGitHubHomepage ? 'Homepage (GitHub)' : 'Homepage');
+    if (repositoryIsHomepage) {
+      addLink(repositoryUrl, 'Repository');
+    } else {
+      addLink(homepageUrl, isGitHubHomepage ? 'Homepage (GitHub)' : 'Homepage');
+      addLink(repositoryUrl, 'Repository');
+    }
+    addLink(issueTrackerUrl, 'Issue Tracker');
     addLink(documentationUrl, 'Documentation');
     addLink(dartdocsUrl, 'API Docs');
 
@@ -446,8 +452,7 @@ class TemplateService {
         'uploaders_title': 'Uploader',
         'uploaders_html': _getAuthorsHtml(package.uploaderEmails),
         'short_created': selectedVersion.shortCreated,
-        'license_html':
-            _renderLicenses(selectedVersion.homepage, analysis?.licenses),
+        'license_html': _renderLicenses(homepageUrl, analysis?.licenses),
         'score_box_html': _renderScoreBox(analysisStatus, extract?.overallScore,
             isNewPackage: package.isNewPackage()),
         'dependencies_html': _renderDependencyList(analysis),

--- a/app/lib/shared/packages_overrides.dart
+++ b/app/lib/shared/packages_overrides.dart
@@ -40,3 +40,15 @@ const redirectPackagePages = const <String, String>{
 const redirectDartdocPages = const <String, String>{
   'flutter': 'https://docs.flutter.io/',
 };
+
+const _issueTrackerUrlOverrides = const <String, String>{
+  'https://github.com/flutter/plugins/issues':
+      'https://github.com/flutter/flutter/issues',
+};
+
+String overrideIssueTrackerUrl(String url) {
+  if (url == null) {
+    return null;
+  }
+  return _issueTrackerUrlOverrides[url] ?? url;
+}

--- a/app/lib/shared/packages_overrides.dart
+++ b/app/lib/shared/packages_overrides.dart
@@ -41,6 +41,7 @@ const redirectDartdocPages = const <String, String>{
   'flutter': 'https://docs.flutter.io/',
 };
 
+// TODO: remove this after all of the flutter plugins have a proper issue tracker entry in their pubspec.yaml
 const _issueTrackerUrlOverrides = const <String, String>{
   'https://github.com/flutter/plugins/issues':
       'https://github.com/flutter/flutter/issues',

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -167,7 +167,7 @@ String inferIssueTrackerUrl(String homepage) {
     }
     segments.add('issues');
     final url = new Uri(
-      scheme: uri.scheme,
+      scheme: 'https',
       host: uri.host,
       pathSegments: segments,
     ).toString();

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -4,6 +4,8 @@
 
 import 'package:path/path.dart' as p;
 
+import 'packages_overrides.dart';
+
 const pubHostedDomain = 'pub.dartlang.org';
 
 const siteRoot = 'https://$pubHostedDomain';
@@ -115,4 +117,53 @@ String dartSdkMainUrl(String version) {
   final channel = isDev ? 'dev' : 'stable';
   final url = p.join(_apiDartlangOrg, channel, version);
   return '$url/';
+}
+
+String inferRepositoryUrl(String homepage) {
+  if (homepage == null) {
+    return null;
+  }
+  final uri = Uri.tryParse(homepage);
+  if (uri == null) {
+    return null;
+  }
+  if (uri.scheme != 'http' && uri.scheme != 'https') {
+    return null;
+  }
+  if (uri.host == 'github.com' || uri.host == 'gitlab.com') {
+    final segments = uri.pathSegments.take(2).toList();
+    if (segments.length != 2) {
+      return null;
+    }
+    return new Uri(scheme: uri.scheme, host: uri.host, pathSegments: segments)
+        .toString();
+  }
+  return null;
+}
+
+String inferIssueTrackerUrl(String homepage) {
+  if (homepage == null) {
+    return null;
+  }
+  final uri = Uri.tryParse(homepage);
+  if (uri == null) {
+    return null;
+  }
+  if (uri.scheme != 'http' && uri.scheme != 'https') {
+    return null;
+  }
+  if (uri.host == 'github.com' || uri.host == 'gitlab.com') {
+    final segments = uri.pathSegments.take(2).toList();
+    if (segments.length != 2) {
+      return null;
+    }
+    segments.add('issues');
+    final url = new Uri(
+      scheme: uri.scheme,
+      host: uri.host,
+      pathSegments: segments,
+    ).toString();
+    return overrideIssueTrackerUrl(url);
+  }
+  return null;
 }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -119,6 +119,7 @@ String dartSdkMainUrl(String version) {
   return '$url/';
 }
 
+/// Parses GitHub and GitLab urls, and returns the root of the repository.
 String inferRepositoryUrl(String homepage) {
   if (homepage == null) {
     return null;
@@ -141,6 +142,7 @@ String inferRepositoryUrl(String homepage) {
   return null;
 }
 
+/// Parses GitHub and GitLab urls, and returns the issue tracker of the repository.
 String inferIssueTrackerUrl(String homepage) {
   if (homepage == null) {
     return null;
@@ -164,6 +166,20 @@ String inferIssueTrackerUrl(String homepage) {
       pathSegments: segments,
     ).toString();
     return overrideIssueTrackerUrl(url);
+  }
+  return null;
+}
+
+/// Infer the hosting/service provider for a given URL.
+String inferServiceProviderName(String url) {
+  if (url == null) {
+    return null;
+  }
+  if (url.startsWith('https://github.com/')) {
+    return 'GitHub';
+  }
+  if (url.startsWith('https://gitlab.com/')) {
+    return 'GitLab';
   }
   return null;
 }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -131,6 +131,9 @@ String inferRepositoryUrl(String homepage) {
   if (uri.scheme != 'http' && uri.scheme != 'https') {
     return null;
   }
+  if (uri.hasPort) {
+    return null;
+  }
   if (uri.host == 'github.com' || uri.host == 'gitlab.com') {
     final segments = uri.pathSegments.take(2).toList();
     if (segments.length != 2) {
@@ -152,6 +155,9 @@ String inferIssueTrackerUrl(String homepage) {
     return null;
   }
   if (uri.scheme != 'http' && uri.scheme != 'https') {
+    return null;
+  }
+  if (uri.hasPort) {
     return null;
   }
   if (uri.host == 'github.com' || uri.host == 'gitlab.com') {

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -333,8 +333,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
       <p>
           <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
-          
-          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a>
+          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a><br/>
       </p>
 
     <h3 class="title">Author</h3>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -287,8 +287,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
       <p>
           <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
-          
-          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a>
+          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a><br/>
       </p>
 
     <h3 class="title">Author</h3>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -291,8 +291,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
       <p>
           <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
-          
-          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a>
+          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a><br/>
       </p>
 
     <h3 class="title">Author</h3>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -304,8 +304,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
       <p>
           <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
-          
-          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a>
+          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a><br/>
       </p>
 
     <h3 class="title">Author</h3>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -291,8 +291,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
       <p>
           <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
-          
-          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a>
+          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a><br/>
       </p>
 
     <h3 class="title">Author</h3>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -335,8 +335,7 @@ import 'package:foobar_pkg/foolib.dart';
       <p>my package description</p>
       <p>
           <a class="link" href="http://hans.juergen.com">Homepage</a><br/>
-          
-          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a>
+          <a class="link" href="/documentation/foobar_pkg/latest/">API Docs</a><br/>
       </p>
 
     <h3 class="title">Author</h3>

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -118,6 +118,7 @@ void main() {
       expect(inferIssueTrackerUrl(''), isNull);
       expect(inferIssueTrackerUrl('abc 123'), isNull);
       expect(inferIssueTrackerUrl('ftp://github.com/a/b/c'), isNull);
+      expect(inferIssueTrackerUrl('package:foo/foo.dart'), isNull);
     });
 
     test('unknown domain', () {

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -80,4 +80,68 @@ void main() {
       expect(dartSdkMainUrl('2.0.0'), 'https://api.dartlang.org/stable/2.0.0/');
     });
   });
+
+  group('Infer repository URL', () {
+    test('empty or bad input', () {
+      expect(inferRepositoryUrl(null), isNull);
+      expect(inferRepositoryUrl(''), isNull);
+      expect(inferRepositoryUrl('abc 123'), isNull);
+      expect(inferRepositoryUrl('ftp://github.com/a/b/c'), isNull);
+    });
+
+    test('unknown domain', () {
+      expect(inferRepositoryUrl('https://example.com/'), isNull);
+      expect(inferRepositoryUrl('https://example.com/a'), isNull);
+      expect(inferRepositoryUrl('https://example.com/a/b'), isNull);
+    });
+
+    test('github', () {
+      final repo = 'https://github.com/user/repo';
+      expect(inferRepositoryUrl(repo), repo);
+      expect(inferRepositoryUrl('$repo/'), repo);
+      expect(inferRepositoryUrl('$repo/a'), repo);
+      expect(inferRepositoryUrl('$repo/a/b/c'), repo);
+    });
+
+    test('gitlab', () {
+      final repo = 'https://gitlab.com/user/repo';
+      expect(inferRepositoryUrl(repo), repo);
+      expect(inferRepositoryUrl('$repo/'), repo);
+      expect(inferRepositoryUrl('$repo/a'), repo);
+      expect(inferRepositoryUrl('$repo/a/b/c'), repo);
+    });
+  });
+
+  group('Infer issue tracker URL', () {
+    test('empty or bad input', () {
+      expect(inferIssueTrackerUrl(null), isNull);
+      expect(inferIssueTrackerUrl(''), isNull);
+      expect(inferIssueTrackerUrl('abc 123'), isNull);
+      expect(inferIssueTrackerUrl('ftp://github.com/a/b/c'), isNull);
+    });
+
+    test('unknown domain', () {
+      expect(inferIssueTrackerUrl('https://example.com/'), isNull);
+      expect(inferIssueTrackerUrl('https://example.com/a'), isNull);
+      expect(inferIssueTrackerUrl('https://example.com/a/b'), isNull);
+    });
+
+    test('github', () {
+      final repo = 'https://github.com/user/repo';
+      final tracker = '$repo/issues';
+      expect(inferIssueTrackerUrl(repo), tracker);
+      expect(inferIssueTrackerUrl('$repo/'), tracker);
+      expect(inferIssueTrackerUrl('$repo/a'), tracker);
+      expect(inferIssueTrackerUrl('$repo/a/b/c'), tracker);
+    });
+
+    test('gitlab', () {
+      final repo = 'https://gitlab.com/user/repo';
+      final tracker = '$repo/issues';
+      expect(inferIssueTrackerUrl(repo), tracker);
+      expect(inferIssueTrackerUrl('$repo/'), tracker);
+      expect(inferIssueTrackerUrl('$repo/a'), tracker);
+      expect(inferIssueTrackerUrl('$repo/a/b/c'), tracker);
+    });
+  });
 }

--- a/app/views/pkg/show.mustache
+++ b/app/views/pkg/show.mustache
@@ -72,9 +72,9 @@
     {{#package.description}}
       <p>{{package.description}}</p>
       <p>
-          {{#package.homepage}}<a class="link" href="{{& package.homepage}}">{{package.homepage_label}}</a><br/>{{/package.homepage}}
-          {{#package.documentation}}<a class="link" href="{{& package.documentation}}">Documentation</a><br/>{{/package.documentation}}
-          <a class="link" href="{{& package.dartdocs_url}}">API Docs</a>
+      {{#package.links}}
+          <a class="link" href="{{& href}}">{{label}}</a><br/>
+      {{/package.links}}
       </p>
     {{/package.description}}
 


### PR DESCRIPTION
https://github.com/dart-lang/pub-dartlang-dart/issues/1522

The current PR does not check the `pubspec.yaml` properties yet, but infers it only from the homepage. If the homepage and the repository url is the same, only the repository label will be displayed.

There is also a special case for flutter plugin packages: when they are coming from the flutter team, the homepage, the repository url, the issue tracker will be all different, and the issue tracker is on a different repository.