### PR TITLE
Increase polling delay for name and dependency trackers.

### DIFF
--- a/app/lib/shared/deps_graph.dart
+++ b/app/lib/shared/deps_graph.dart
@@ -60,7 +60,7 @@ class TransitiveDependencyGraph {
 }
 
 class PackageDependencyBuilder {
-  static const Duration pollingInterval = const Duration(seconds: 10);
+  static const Duration pollingInterval = const Duration(minutes: 1);
   static const String devPrefix = 'dev/';
 
   final DatastoreDB db;

--- a/app/lib/shared/name_tracker.dart
+++ b/app/lib/shared/name_tracker.dart
@@ -10,7 +10,7 @@ import 'package:gcloud/db.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 
 final Logger _logger = new Logger('pub.name_tracker');
-const Duration _pollingInterval = const Duration(seconds: 10);
+const Duration _pollingInterval = const Duration(minutes: 1);
 
 final NameTracker nameTracker = new NameTracker();
 


### PR DESCRIPTION
I think a one-minute window is still acceptable.