### PR TITLE
'Report an issue' link

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -405,8 +405,10 @@ class TemplateService {
       version: selectedVersion.version,
       isLatest: selectedVersion.version == package.latestVersion,
     );
-    final repositoryUrl = urls.inferRepositoryUrl(homepageUrl);
-    final issueTrackerUrl = urls.inferIssueTrackerUrl(homepageUrl);
+    final packageLinks = new urls.PackageLinks.infer(
+      homepageUrl: homepageUrl,
+      documentationUrl: documentationUrl,
+    );
 
     final links = <Map<String, dynamic>>[];
     void addLink(
@@ -426,12 +428,15 @@ class TemplateService {
       links.add(<String, dynamic>{'href': href, 'label': label});
     }
 
-    if (repositoryUrl != homepageUrl) {
+    if (packageLinks.repositoryUrl != packageLinks.homepageUrl) {
       addLink(homepageUrl, 'Homepage');
     }
-    addLink(repositoryUrl, 'Repository', detectServiceProvider: true);
-    addLink(issueTrackerUrl, 'Issue Tracker', detectServiceProvider: true);
-    addLink(documentationUrl, 'Documentation');
+    addLink(packageLinks.repositoryUrl, 'Repository',
+        detectServiceProvider: true);
+    addLink(packageLinks.issueTrackerUrl, 'Issue Tracker');
+    addLink(packageLinks.reportIssuesUrl, 'Report an issue',
+        detectServiceProvider: true);
+    addLink(packageLinks.documentationUrl, 'Documentation');
     addLink(dartdocsUrl, 'API Docs');
 
     final values = {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -218,7 +218,8 @@ class PackageLinks {
   }) {
     repositoryUrl ??= inferRepositoryUrl(homepageUrl);
     issueTrackerUrl ??= inferIssueTrackerUrl(repositoryUrl);
-    reportIssuesUrl ??= inferIssueTrackerUrl(issueTrackerUrl, reportNewIssue: true);
+    reportIssuesUrl ??=
+        inferIssueTrackerUrl(issueTrackerUrl, reportNewIssue: true);
     return new PackageLinks(
       homepageUrl: homepageUrl,
       documentationUrl: documentationUrl,

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -120,11 +120,11 @@ String dartSdkMainUrl(String version) {
 }
 
 /// Parses GitHub and GitLab urls, and returns the root of the repository.
-String inferRepositoryUrl(String homepage) {
-  if (homepage == null) {
+String inferRepositoryUrl(String baseUrl) {
+  if (baseUrl == null) {
     return null;
   }
-  final uri = Uri.tryParse(homepage);
+  final uri = Uri.tryParse(baseUrl);
   if (uri == null) {
     return null;
   }
@@ -146,11 +146,11 @@ String inferRepositoryUrl(String homepage) {
 }
 
 /// Parses GitHub and GitLab urls, and returns the issue tracker of the repository.
-String inferIssueTrackerUrl(String homepage) {
-  if (homepage == null) {
+String inferIssueTrackerUrl(String baseUrl, {bool reportNewIssue: false}) {
+  if (baseUrl == null) {
     return null;
   }
-  final uri = Uri.tryParse(homepage);
+  final uri = Uri.tryParse(baseUrl);
   if (uri == null) {
     return null;
   }
@@ -166,6 +166,9 @@ String inferIssueTrackerUrl(String homepage) {
       return null;
     }
     segments.add('issues');
+    if (reportNewIssue) {
+      segments.add('new');
+    }
     final url = new Uri(
       scheme: 'https',
       host: uri.host,
@@ -188,4 +191,40 @@ String inferServiceProviderName(String url) {
     return 'GitLab';
   }
   return null;
+}
+
+/// The URLs provided by the package's pubspec or inferred from the homepage.
+class PackageLinks {
+  final String homepageUrl;
+  final String documentationUrl;
+  final String repositoryUrl;
+  final String issueTrackerUrl;
+  final String reportIssuesUrl;
+
+  PackageLinks({
+    this.homepageUrl,
+    this.documentationUrl,
+    this.repositoryUrl,
+    this.issueTrackerUrl,
+    this.reportIssuesUrl,
+  });
+
+  factory PackageLinks.infer({
+    String homepageUrl,
+    String documentationUrl,
+    String repositoryUrl,
+    String issueTrackerUrl,
+    String reportIssuesUrl,
+  }) {
+    repositoryUrl ??= inferRepositoryUrl(homepageUrl);
+    issueTrackerUrl ??= inferIssueTrackerUrl(repositoryUrl);
+    reportIssuesUrl ??= inferIssueTrackerUrl(issueTrackerUrl, reportNewIssue: true);
+    return new PackageLinks(
+      homepageUrl: homepageUrl,
+      documentationUrl: documentationUrl,
+      repositoryUrl: repositoryUrl,
+      issueTrackerUrl: issueTrackerUrl,
+      reportIssuesUrl: reportIssuesUrl,
+    );
+  }
 }


### PR DESCRIPTION
- https://github.com/dart-lang/pub-dartlang-dart/issues/1522
- the main change is in the initialization of the PackageLinks constructor: homepage -> repository -> issue tracker -> new issue url (vs. the previous everything comes from the homepage). It would allow us to process half-filled pubspec.yaml files.