### PR TITLE
Upgrade dartdoc to 0.23.1

### DIFF
--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -42,7 +42,7 @@ final Version semanticPanaVersion = new Version.parse(panaVersion);
 final String flutterVersion = '0.9.5';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
-final String dartdocVersion = '0.21.1';
+final String dartdocVersion = '0.23.1';
 final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
 
 /// The version of our customization going into the output of the dartdoc static

--- a/app/test/dartdoc/golden/pana_0.12.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.21.1">
+  <meta name="generator" content="made with love by dartdoc 0.23.1">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.12.2/index.html">

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -11,7 +11,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.21.1">
+  <meta name="generator" content="made with love by dartdoc 0.23.1">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="alternate" href="/documentation/pana/latest/">

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
@@ -70,6 +70,7 @@
       <li><a href="pana/ToolEnvironment-class.html">ToolEnvironment</a></li>
       <li><a href="pana/UrlChecker-class.html">UrlChecker</a></li>
     
+    
       <li class="section-title"><a href="pana/pana-library.html#constants">Constants</a></li>
       <li><a href="pana/currentAnalysisOptionsFileName-constant.html">currentAnalysisOptionsFileName</a></li>
       <li><a href="pana/packageVersion-constant.html">packageVersion</a></li>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -80,6 +80,7 @@
       <li><a href="pana/ToolEnvironment-class.html">ToolEnvironment</a></li>
       <li><a href="pana/UrlChecker-class.html">UrlChecker</a></li>
     
+    
       <li class="section-title"><a href="pana/pana-library.html#constants">Constants</a></li>
       <li><a href="pana/currentAnalysisOptionsFileName-constant.html">currentAnalysisOptionsFileName</a></li>
       <li><a href="pana/packageVersion-constant.html">packageVersion</a></li>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
@@ -70,6 +70,7 @@
       <li><a href="pana/ToolEnvironment-class.html">ToolEnvironment</a></li>
       <li><a href="pana/UrlChecker-class.html">UrlChecker</a></li>
     
+    
       <li class="section-title"><a href="pana/pana-library.html#constants">Constants</a></li>
       <li><a href="pana/currentAnalysisOptionsFileName-constant.html">currentAnalysisOptionsFileName</a></li>
       <li><a href="pana/packageVersion-constant.html">packageVersion</a></li>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -80,6 +80,7 @@
       <li><a href="pana/ToolEnvironment-class.html">ToolEnvironment</a></li>
       <li><a href="pana/UrlChecker-class.html">UrlChecker</a></li>
     
+    
       <li class="section-title"><a href="pana/pana-library.html#constants">Constants</a></li>
       <li><a href="pana/currentAnalysisOptionsFileName-constant.html">currentAnalysisOptionsFileName</a></li>
       <li><a href="pana/packageVersion-constant.html">packageVersion</a></li>

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 595611303);
+    expect(hash, 410577049);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.32.6"
+    version: "0.33.0"
   args:
     dependency: transitive
     description:
@@ -126,14 +126,21 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   dartdoc:
     dependency: "direct main"
     description:
       name: dartdoc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.21.1"
+    version: "0.23.1"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.6"
   fixnum:
     dependency: transitive
     description:
@@ -147,7 +154,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4+2"
+    version: "0.1.6"
   glob:
     dependency: transitive
     description:
@@ -190,6 +197,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.7"
   io:
     dependency: transitive
     description:
@@ -231,7 +245,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4+2"
+    version: "0.3.6"
   logging:
     dependency: "direct main"
     description:
@@ -308,7 +322,14 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
   plugin:
     dependency: transitive
     description:
@@ -323,6 +344,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.6"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.5"
   pub_semver:
     dependency: transitive
     description:

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   meta: ^1.1.5
   path: ^1.6.0
   # dartdoc version to be pinned
-  dartdoc: 0.21.1
+  dartdoc: 0.23.1
 
 dev_dependencies:
   build_runner: '^1.0.0'


### PR DESCRIPTION
It seems that we have a few more extra spaces in the output, but it is considered low-priority (in the dartdoc project) to fix those.