### PR TITLE
Move/migrate analysis target status check to scorecard.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -11,6 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../frontend/models.dart';
+import '../scorecard/backend.dart';
 import '../shared/analyzer_memcache.dart';
 import '../shared/analyzer_service.dart';
 import '../shared/task_scheduler.dart' show TaskTargetStatus;
@@ -220,7 +221,7 @@ class AnalysisBackend {
       return new TaskTargetStatus.skip('Insufficient package or version.');
     }
     final pkgStatus =
-        await analysisBackend.getPackageStatus(packageName, packageVersion);
+        await scoreCardBackend.getPackageStatus(packageName, packageVersion);
     if (!pkgStatus.exists) {
       return new TaskTargetStatus.skip('PackageVersion does not exists.');
     }
@@ -350,16 +351,6 @@ class AnalysisBackend {
           '${obsoleteKeys.map((k) => k.id).join(',')}');
       await db.commit(deletes: obsoleteKeys);
     }
-  }
-
-  /// Returns the status of a package and version.
-  Future<PackageStatus> getPackageStatus(String package, String version) async {
-    final packageKey = db.emptyKey.append(Package, id: package);
-    final List list = await db
-        .lookup([packageKey, packageKey.append(PackageVersion, id: version)]);
-    final Package p = list[0];
-    final PackageVersion pv = list[1];
-    return new PackageStatus.fromModels(p, pv);
   }
 }
 

--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -32,7 +32,6 @@ final Logger _logger = new Logger('pub.analyzer.backend');
 
 const Duration _freshThreshold = const Duration(hours: 12);
 const Duration _identicalThreshold = const Duration(days: 7);
-const Duration reanalyzeThreshold = const Duration(days: 30);
 const Duration _regressionThreshold = const Duration(days: 45);
 const Duration _obsoleteThreshold = const Duration(days: 180);
 
@@ -232,70 +231,15 @@ class AnalysisBackend {
       return new TaskTargetStatus.skip('Package is older than two years old.');
     }
 
-    // Does package have any analysis?
-    final Key packageKey = db.emptyKey.append(PackageAnalysis, id: packageName);
-    final PackageAnalysis packageAnalysis =
-        (await db.lookup([packageKey])).single;
-    if (packageAnalysis == null) {
-      return new TaskTargetStatus.ok();
-    }
-
-    // Does package have newer version than latest analyzed version?
-    final semanticVersion = new Version.parse(packageVersion);
-    if (isNewer(packageAnalysis.latestSemanticVersion, semanticVersion)) {
-      return new TaskTargetStatus.ok();
-    }
-
-    // Does package have analysis for the current version?
-    final Key versionKey =
-        packageKey.append(PackageVersionAnalysis, id: packageVersion);
-    final PackageVersionAnalysis versionAnalysis =
-        (await db.lookup([versionKey])).single;
-    if (versionAnalysis == null) {
-      return new TaskTargetStatus.ok();
-    }
-
-    // Is current analysis version newer?
-    if (isNewer(
-        versionAnalysis.semanticRuntimeVersion, semanticRuntimeVersion)) {
-      // TODO: skip re-analysis of non-Flutter packages if only the flutterVersion changed
-      return new TaskTargetStatus.ok();
-    }
-
-    // Is current analysis version obsolete?
-    if (isNewer(
-        semanticRuntimeVersion, versionAnalysis.semanticRuntimeVersion)) {
-      // check if there is any analysis with this runtime version
-      final query = db.query<Analysis>(ancestorKey: versionKey)
-        ..filter('runtimeVersion =', runtimeVersion)
-        ..limit(1);
-      if (await query.run().isEmpty) {
-        return new TaskTargetStatus.ok();
-      } else {
-        return new TaskTargetStatus.skip('Newer analysis instance detected.');
-      }
-    }
-
-    if (versionAnalysis.panaVersion != panaVersion ||
-        versionAnalysis.flutterVersion != flutterVersion) {
-      _logger.warning('Versions should be matching: '
-          '${versionAnalysis.panaVersion} - $panaVersion and '
-          '${versionAnalysis.flutterVersion} - $flutterVersion');
-    }
-
-    // Is it due to re-analyze?
-    final DateTime now = new DateTime.now().toUtc();
-    final Duration analysisAge =
-        now.difference(versionAnalysis.analysisTimestamp);
-    if (analysisAge > reanalyzeThreshold) {
-      return new TaskTargetStatus.ok();
-    }
-
-    // Is it a newer analysis than the trigger timestamp?
-    if (versionAnalysis.analysisTimestamp.isAfter(updated) &&
-        versionAnalysis.analysisStatus == AnalysisStatus.success) {
+    final hasReport = await scoreCardBackend.hasReport(
+      packageName,
+      packageVersion,
+      ReportType.pana,
+      updatedAfter: updated,
+    );
+    if (hasReport) {
       return new TaskTargetStatus.skip(
-          'Previous analysis completed after task\'s trigger timestamp.');
+          'PackageVersion has up-to-date analysis.');
     }
 
     return new TaskTargetStatus.ok();

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -34,11 +34,13 @@ class AnalyzerJobProcessor extends JobProcessor {
       : super(service: JobService.analyzer, lockDuration: lockDuration);
 
   @override
-  Future<bool> shouldProcess(
-      String package, String version, DateTime updated) async {
-    final status =
-        await analysisBackend.checkTargetStatus(package, version, updated);
-    return !status.shouldSkip;
+  Future<bool> shouldProcess(String package, String version, DateTime updated) {
+    return scoreCardBackend.shouldUpdateReport(
+      package,
+      version,
+      ReportType.pana,
+      updatedAfter: updated,
+    );
   }
 
   @override

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -43,7 +43,7 @@ class AnalyzerJobProcessor extends JobProcessor {
 
   @override
   Future<JobStatus> process(Job job) async {
-    final packageStatus = await analysisBackend.getPackageStatus(
+    final packageStatus = await scoreCardBackend.getPackageStatus(
         job.packageName, job.packageVersion);
     if (!packageStatus.exists) {
       _logger.info('Package does not exist: $job.');

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -17,7 +17,6 @@ import 'package:pub_semver/pub_semver.dart';
 import '../frontend/models.dart' show Package, PackageVersion;
 
 import '../shared/dartdoc_memcache.dart';
-import '../shared/task_scheduler.dart' show TaskTargetStatus;
 import '../shared/utils.dart' show contentType;
 import '../shared/versions.dart' as shared_versions;
 
@@ -189,18 +188,6 @@ class DartdocBackend {
     await _storage.delete(entry.inProgressObjectName);
 
     await dartdocMemcache?.invalidate(entry.packageName, entry.packageVersion);
-  }
-
-  Future<TaskTargetStatus> checkTargetStatus(String package, String version,
-      DateTime updated, bool retryFailed) async {
-    final entry = await getLatestEntry(package, version);
-    if (entry == null) {
-      return new TaskTargetStatus.ok();
-    }
-    if (updated != null && updated.isAfter(entry.timestamp)) {
-      return new TaskTargetStatus.ok();
-    }
-    return entry.checkTargetStatus(retryFailed: retryFailed);
   }
 
   Future<bool> isLegacy(String package, String version) async {

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -97,11 +97,16 @@ class DartdocJobProcessor extends JobProcessor {
   }
 
   @override
-  Future<bool> shouldProcess(
-      String package, String version, DateTime updated) async {
-    final status =
-        await dartdocBackend.checkTargetStatus(package, version, updated, true);
-    return !status.shouldSkip;
+  Future<bool> shouldProcess(String package, String version, DateTime updated) {
+    return scoreCardBackend.shouldUpdateReport(
+      package,
+      version,
+      ReportType.dartdoc,
+      updatedAfter: updated,
+      includeDiscontinued: true,
+      includeObsolete: true,
+      successThreshold: const Duration(days: 90),
+    );
   }
 
   @override

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -14,7 +14,6 @@ import 'package:pana/src/utils.dart' show runProc;
 import 'package:path/path.dart' as p;
 import 'package:uuid/uuid.dart';
 
-import '../analyzer/backend.dart';
 import '../job/backend.dart';
 import '../job/job.dart';
 import '../scorecard/backend.dart';
@@ -216,7 +215,7 @@ class DartdocJobProcessor extends JobProcessor {
     await dartdocBackend.removeObsolete(job.packageName, job.packageVersion);
 
     // Trigger analyzer job to pick up the new dartdoc results.
-    final pkgStatus = await analysisBackend.getPackageStatus(
+    final pkgStatus = await scoreCardBackend.getPackageStatus(
         job.packageName, job.packageVersion);
     if (pkgStatus.exists &&
         !pkgStatus.isDiscontinued &&

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -257,4 +257,14 @@ class ScoreCardBackend {
       deletes.clear();
     }
   }
+
+  /// Returns the status of a package and version.
+  Future<PackageStatus> getPackageStatus(String package, String version) async {
+    final packageKey = _db.emptyKey.append(Package, id: package);
+    final List list = await _db
+        .lookup([packageKey, packageKey.append(PackageVersion, id: version)]);
+    final Package p = list[0];
+    final PackageVersion pv = list[1];
+    return new PackageStatus.fromModels(p, pv);
+  }
 }

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -272,15 +272,23 @@ class ScoreCardBackend {
     String packageName,
     String packageVersion,
     String reportType, {
-    Duration successThreshold: const Duration(days: 30),
-    Duration failureThreshold: const Duration(days: 1),
+    bool includeDiscontinued = false,
+    bool includeObsolete = false,
+    Duration successThreshold = const Duration(days: 30),
+    Duration failureThreshold = const Duration(days: 1),
     DateTime updatedAfter,
   }) async {
     if (packageName == null || packageVersion == null) {
       return false;
     }
     final pkgStatus = await getPackageStatus(packageName, packageVersion);
-    if (!pkgStatus.exists || pkgStatus.isDiscontinued || pkgStatus.isObsolete) {
+    if (!pkgStatus.exists) {
+      return false;
+    }
+    if (!includeDiscontinued && pkgStatus.isDiscontinued) {
+      return false;
+    }
+    if (!includeObsolete && pkgStatus.isObsolete) {
       return false;
     }
 

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -144,16 +144,3 @@ class Task {
   @override
   int get hashCode => package.hashCode ^ version.hashCode;
 }
-
-class TaskTargetStatus {
-  final bool shouldSkip;
-  final String reason;
-
-  TaskTargetStatus(this.shouldSkip, this.reason);
-
-  TaskTargetStatus.ok()
-      : shouldSkip = false,
-        reason = null;
-
-  TaskTargetStatus.skip(this.reason) : shouldSkip = true;
-}

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -166,11 +166,6 @@ class MockAnalysisBackend implements AnalysisBackend {
   Future deleteObsoleteAnalysis(String package, String version) {
     throw new UnimplementedError();
   }
-
-  @override
-  Future<PackageStatus> getPackageStatus(String package, String version) {
-    throw new UnimplementedError();
-  }
 }
 
 final Analysis testAnalysis = new Analysis()

--- a/app/test/analyzer/handlers_test.dart
+++ b/app/test/analyzer/handlers_test.dart
@@ -10,8 +10,6 @@ import 'package:gcloud/db.dart';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/shared/analyzer_service.dart';
-import 'package:pub_dartlang_org/shared/task_scheduler.dart'
-    show TaskTargetStatus;
 
 import 'package:pub_dartlang_org/analyzer/backend.dart';
 import 'package:pub_dartlang_org/analyzer/models.dart';
@@ -154,12 +152,6 @@ class MockAnalysisBackend implements AnalysisBackend {
   @override
   Future<BackendAnalysisStatus> storeAnalysis(Analysis analysis) async {
     return _storeAnalysisSync(analysis);
-  }
-
-  @override
-  Future<TaskTargetStatus> checkTargetStatus(
-      String packageName, String packageVersion, DateTime updated) {
-    throw new UnimplementedError();
   }
 
   @override

--- a/app/test/dartdoc/handlers_test.dart
+++ b/app/test/dartdoc/handlers_test.dart
@@ -9,7 +9,6 @@ import 'dart:io';
 
 import 'package:pub_dartlang_org/dartdoc/models.dart';
 import 'package:pub_dartlang_org/dartdoc/pub_dartdoc_data.dart';
-import 'package:pub_dartlang_org/shared/task_scheduler.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
@@ -126,12 +125,6 @@ class DartdocBackendMock implements DartdocBackend {
   final Map<String, String> latestVersions;
 
   DartdocBackendMock({this.entries, this.latestVersions});
-
-  @override
-  Future<TaskTargetStatus> checkTargetStatus(
-      String package, String version, DateTime updated, bool retryFailed) {
-    throw new UnimplementedError();
-  }
 
   @override
   Future<FileInfo> getFileInfo(DartdocEntry entry, String relativePath) {


### PR DESCRIPTION
As the ScoreCard model will have a separate entry for all of the analysis reports in each new release, the logic to decide whether to analyze something becomes much simpler. We are already storing the scorecard reports in parallel to the "live" records, and this is the first step for relying on that data.