### PR TITLE
TaskScheduler: randomization and keeping the updated timestamp

### DIFF
--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -125,10 +125,11 @@ class TaskScheduler {
 class Task {
   final String package;
   final String version;
+  final DateTime updated;
 
-  Task(this.package, this.version);
+  Task(this.package, this.version, this.updated);
 
-  Task.now(this.package, this.version);
+  Task.now(this.package, this.version) : updated = new DateTime.now();
 
   @override
   String toString() => '$package $version';

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -51,7 +51,7 @@ class TaskScheduler {
   List<List<Task>> _queues;
   bool _needsShuffle = false;
 
-  TaskScheduler(this.taskRunner, this.sources, {this.randomize: false}) {
+  TaskScheduler(this.taskRunner, this.sources, {this.randomize = false}) {
     _queues = new List<List<Task>>.generate(sources.length, (i) => <Task>[]);
   }
 

--- a/app/lib/shared/task_scheduler.dart
+++ b/app/lib/shared/task_scheduler.dart
@@ -132,17 +132,6 @@ class Task {
 
   @override
   String toString() => '$package $version';
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Task &&
-          runtimeType == other.runtimeType &&
-          package == other.package &&
-          version == other.version;
-
-  @override
-  int get hashCode => package.hashCode ^ version.hashCode;
 }
 
 class TaskTargetStatus {

--- a/app/lib/shared/task_sources.dart
+++ b/app/lib/shared/task_sources.dart
@@ -99,11 +99,13 @@ class DatastoreHeadTaskSource implements TaskSource {
   }
 
   Task _packageToTask(Package p) =>
-      new Task(p.name, p.latestVersion ?? p.latestDevVersion);
+      new Task(p.name, p.latestVersion ?? p.latestDevVersion, p.updated);
 
-  Task _versionToTask(PackageVersion pv) => new Task(pv.package, pv.version);
+  Task _versionToTask(PackageVersion pv) =>
+      new Task(pv.package, pv.version, pv.created);
 
-  Task _analysisToTask(Analysis a) => new Task(a.packageName, a.packageVersion);
+  Task _analysisToTask(Analysis a) =>
+      new Task(a.packageName, a.packageVersion, a.timestamp);
 }
 
 /// Creates a task when the most recent output requires an update (e.g. too old).
@@ -126,12 +128,12 @@ abstract class DatastoreHistoryTaskSource implements TaskSource {
         await for (Package p in packageQuery.run()) {
           if (await requiresUpdate(p.name, p.latestVersion,
               retryFailed: true)) {
-            yield new Task(p.name, p.latestVersion);
+            yield new Task(p.name, p.latestVersion, p.updated);
           }
 
           if (p.latestVersion != p.latestDevVersion &&
               await requiresUpdate(p.name, p.latestDevVersion)) {
-            yield new Task(p.name, p.latestDevVersion);
+            yield new Task(p.name, p.latestDevVersion, p.updated);
           }
         }
 
@@ -141,7 +143,7 @@ abstract class DatastoreHistoryTaskSource implements TaskSource {
           ..order('-created');
         await for (PackageVersion pv in versionQuery.run()) {
           if (await requiresUpdate(pv.package, pv.version)) {
-            yield new Task(pv.package, pv.version);
+            yield new Task(pv.package, pv.version, pv.created);
           }
         }
       } catch (e, st) {


### PR DESCRIPTION
- The updated timestamp will be used by the task target check method in #1687.
- The randomization reduces race conditions for analyzer and dartdoc, while it is not important for search.