### PR TITLE
Increase search memory limit.

### DIFF
--- a/search.yaml
+++ b/search.yaml
@@ -8,7 +8,7 @@ service: search
 
 resources:
   cpu: 1
-  memory_gb: 3.5
+  memory_gb: 7
 
 #manual_scaling:
 #  instances: 1


### PR DESCRIPTION
Not sure when, or why, but the memory requirement increased, the current search instance requires almost 3G heap memory.