### PR TITLE
Detect known failure patterns in dartdoc and skip logging.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -306,10 +306,14 @@ class DartdocJobProcessor extends JobProcessor {
     _appendLog(logFileOutput, r.processResult);
 
     if (r.processResult.exitCode != 0) {
-      _logger.warning('Error while running dartdoc for $job.\n'
-          'exitCode: ${r.processResult.exitCode}\n'
+      final mergedOutput = 'exitCode: ${r.processResult.exitCode}\n'
           'stdout: ${r.processResult.stdout}\n'
-          'stderr: ${r.processResult.stderr}\n');
+          'stderr: ${r.processResult.stderr}\n';
+      if (_isKnownFailurePattern(mergedOutput)) {
+        _logger.info('Error while running dartdoc for $job (see log.txt).');
+      } else {
+        _logger.warning('Error while running dartdoc for $job.\n$mergedOutput');
+      }
     }
 
     return r.hasIndexHtml && r.hasIndexJson;
@@ -381,4 +385,14 @@ class DartdocJobProcessor extends JobProcessor {
     await tmpTar.rename(p.join(outputDir, _archiveFilePath));
     _appendLog(logFileOutput, pr);
   }
+}
+
+bool _isKnownFailurePattern(String output) {
+  if (output.contains('Unhandled exception:') &&
+      output.contains('encountered ') &&
+      output.contains(' analysis errors') &&
+      output.contains('Dartdoc.logAnalysisErrors')) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
This should greatly improve https://github.com/dart-lang/pub-dartlang-dart/issues/1347, as most of the warnings I've checked in the dartdoc service are large output blocks of dartdoc failures, and those add up to the larger overall content size.