### PR TITLE
Calculate dartdoc coverage score and fix scorecard-model fields.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -40,6 +40,10 @@ const _pubDataFileName = 'pub-data.json';
 const _sdkTimeout = const Duration(minutes: 20);
 final Duration _twoYears = const Duration(days: 2 * 365);
 
+// We'll emit a suggestion and apply score penalty only if the coverage is below
+// this value.
+const _coverageEmitThreshold = 0.1;
+
 final _pkgPubDartdocDir =
     Platform.script.resolve('../../pkg/pub_dartdoc').toFilePath();
 
@@ -218,7 +222,7 @@ class DartdocJobProcessor extends JobProcessor {
         coverageScore = documented / total;
       }
 
-      if (coverageScore < 1.0) {
+      if (coverageScore < _coverageEmitThreshold) {
         final level = coverageScore < 0.2
             ? SuggestionLevel.warning
             : SuggestionLevel.hint;

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -124,7 +124,8 @@ class DartdocJobProcessor extends JobProcessor {
     bool hasContent = false;
 
     String reportStatus = ReportStatus.failed;
-    final suggestions = <Suggestion>[];
+    final healthSuggestions = <Suggestion>[];
+    final maintenanceSuggestions = <Suggestion>[];
     try {
       final pkgDir = await downloadPackage(job.packageName, job.packageVersion);
       if (pkgDir == null) {
@@ -197,17 +198,22 @@ class DartdocJobProcessor extends JobProcessor {
       await toolEnvRef.release();
     }
 
-    if (!hasContent) {
-      suggestions.add(getDartdocRunFailedSuggestion());
+    double coverageScore = 0.0;
+    if (hasContent) {
+      // TODO: calculate coverage score and add health suggestions
+    } else {
+      maintenanceSuggestions.add(getDartdocRunFailedSuggestion());
     }
-    // TODO: calculate coverage score
     await scoreCardBackend.updateReport(
         job.packageName,
         job.packageVersion,
         new DartdocReport(
           reportStatus: reportStatus,
-          coverageScore: hasContent ? 1.0 : 0.0,
-          suggestions: suggestions.isEmpty ? null : suggestions,
+          coverageScore: coverageScore,
+          healthSuggestions:
+              healthSuggestions.isEmpty ? null : healthSuggestions,
+          maintenanceSuggestions:
+              maintenanceSuggestions.isEmpty ? null : maintenanceSuggestions,
         ));
     await scoreCardBackend.updateScoreCard(job.packageName, job.packageVersion);
 

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -34,6 +34,7 @@ const statusFilePath = 'status.json';
 const _archiveFilePath = 'package.tar.gz';
 const _buildLogFilePath = 'log.txt';
 const _packageTimeout = const Duration(minutes: 10);
+const _pubDataFileName = 'pub-data.json';
 const _sdkTimeout = const Duration(minutes: 20);
 final Duration _twoYears = const Duration(days: 2 * 365);
 
@@ -73,7 +74,7 @@ class DartdocJobProcessor extends JobProcessor {
         timeout: _sdkTimeout,
       );
 
-      final pubDataFile = new File(p.join(outputDir, 'pub-data.json'));
+      final pubDataFile = new File(p.join(outputDir, _pubDataFileName));
       final hasPubData = await pubDataFile.exists();
       final isOk = pr.exitCode == 0 && hasPubData;
       if (!isOk) {

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -117,15 +117,29 @@ DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
   return DartdocReport(
       reportStatus: json['reportStatus'] as String,
       coverageScore: (json['coverageScore'] as num)?.toDouble(),
-      suggestions: (json['suggestions'] as List)
+      healthSuggestions: (json['healthSuggestions'] as List)
+          ?.map((e) =>
+              e == null ? null : Suggestion.fromJson(e as Map<String, dynamic>))
+          ?.toList(),
+      maintenanceSuggestions: (json['maintenanceSuggestions'] as List)
           ?.map((e) =>
               e == null ? null : Suggestion.fromJson(e as Map<String, dynamic>))
           ?.toList());
 }
 
-Map<String, dynamic> _$DartdocReportToJson(DartdocReport instance) =>
-    <String, dynamic>{
-      'reportStatus': instance.reportStatus,
-      'coverageScore': instance.coverageScore,
-      'suggestions': instance.suggestions
-    };
+Map<String, dynamic> _$DartdocReportToJson(DartdocReport instance) {
+  var val = <String, dynamic>{
+    'reportStatus': instance.reportStatus,
+    'coverageScore': instance.coverageScore,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('healthSuggestions', instance.healthSuggestions);
+  writeNotNull('maintenanceSuggestions', instance.maintenanceSuggestions);
+  return val;
+}


### PR DESCRIPTION
- Dartdoc coverage is part of health score, but broken dartdoc execution is part of maintenance score. They need to be tracked and calculated separately.
- Coverage calculation is simple: documented/total (the number of API elements).