### PR TITLE
Use consistent ?pretty URL parameter to pretty-print JSON responses.

### DIFF
--- a/app/lib/analyzer/handlers.dart
+++ b/app/lib/analyzer/handlers.dart
@@ -57,7 +57,7 @@ Future<shelf.Response> _packageHandler(shelf.Request request) async {
     if (data == null) {
       return notFoundHandler(request);
     }
-    return jsonResponse(data.toJson());
+    return jsonResponse(data.toJson(), pretty: isPrettyJson(request));
   }
 
   return notFoundHandler(request);

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -333,7 +333,7 @@ Future<shelf.Response> _packagesHandlerJson(
     //   - 'pages'
   };
 
-  return jsonResponse(json);
+  return jsonResponse(json, pretty: isPrettyJson(request));
 }
 
 /// Handles /packages - package listing
@@ -449,7 +449,7 @@ Future<shelf.Response> _packageShowHandlerJson(
     'versions':
         versions.map((packageVersion) => packageVersion.version).toList(),
   };
-  return jsonResponse(json);
+  return jsonResponse(json, pretty: isPrettyJson(request));
 }
 
 /// Handles requests for /packages/<package>/versions
@@ -632,23 +632,23 @@ Future<shelf.Response> _apiPackagesHandler(shelf.Request request) async {
         '${request.requestedUri.resolve('/api/packages?page=${page + 1}')}';
   }
 
-  return jsonResponse(json);
+  return jsonResponse(json, pretty: isPrettyJson(request));
 }
 
 /// Handles requests for /api/documentation/<package>
 Future<shelf.Response> _apiDocumentationHandler(shelf.Request request) async {
   final parts = path.split(request.requestedUri.path).skip(1).toList();
   if (parts.length != 3 || parts[2].isEmpty) {
-    return jsonResponse({}, status: 404);
+    return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }
   final String package = parts[2];
   if (redirectDartdocPages.containsKey(package)) {
-    return jsonResponse({}, status: 404);
+    return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }
 
   final versions = await backend.versionsOfPackage(package);
   if (versions.isEmpty) {
-    return jsonResponse({}, status: 404);
+    return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }
 
   versions.sort((a, b) => a.semanticVersion.compareTo(b.semanticVersion));
@@ -679,7 +679,7 @@ Future<shelf.Response> _apiDocumentationHandler(shelf.Request request) async {
     'name': package,
     'latestStableVersion': latestStableVersion,
     'versions': versionsData,
-  });
+  }, pretty: isPrettyJson(request));
 }
 
 /// Handles requests for
@@ -687,7 +687,8 @@ Future<shelf.Response> _apiDocumentationHandler(shelf.Request request) async {
 Future<shelf.Response> _apiPackagesCompactListHandler(
     shelf.Request request) async {
   final packageNames = await nameTracker.getPackageNames();
-  return jsonResponse({'packages': packageNames});
+  return jsonResponse({'packages': packageNames},
+      pretty: isPrettyJson(request));
 }
 
 /// Whether [requestedUri] matches /api/packages/<package>/metrics
@@ -708,15 +709,16 @@ Future<shelf.Response> _apiPackageMetricsHandler(shelf.Request request) async {
   final requestedPath = request.requestedUri.path;
   final parts = requestedPath.split('/');
   if (parts.length != 5) {
-    return jsonResponse({}, status: 404);
+    return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }
   final packageName = parts[3];
   final data = await scoreCardBackend.getScoreCardData(packageName, null,
       onlyCurrent: false);
   if (data == null) {
-    return jsonResponse({}, status: 404);
+    return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }
-  return jsonResponse({'scorecard': data.toJson()});
+  return jsonResponse({'scorecard': data.toJson()},
+      pretty: isPrettyJson(request));
 }
 
 /// Handles requests for /api/history
@@ -744,7 +746,7 @@ Future<shelf.Response> _apiHistoryHandler(shelf.Request request) async {
               'markdown': h.formatMarkdown(),
             })
         .toList(),
-  }, indent: true);
+  }, pretty: true);
 }
 
 /// Handles requests for /flutter/plugins (redirects to /flutter/packages).
@@ -783,7 +785,7 @@ Future<shelf.Response> _apiSearchHandler(shelf.Request request) async {
         request.requestedUri.replace(queryParameters: newParams).toString();
     result['next'] = nextPageUrl;
   }
-  return jsonResponse(result);
+  return jsonResponse(result, pretty: isPrettyJson(request));
 }
 
 /// Extracts the 'page' query parameter from [url].

--- a/app/lib/search/handlers.dart
+++ b/app/lib/search/handlers.dart
@@ -48,7 +48,6 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
     return htmlResponse(searchIndexNotReadyText,
         status: searchIndexNotReadyCode);
   }
-  final bool indent = request.url.queryParameters['indent'] == 'true';
   final Stopwatch sw = new Stopwatch()..start();
   final SearchQuery query = new SearchQuery.fromServiceUrl(request.url);
   final combiner = new SearchResultCombiner(
@@ -61,5 +60,5 @@ Future<shelf.Response> _searchHandler(shelf.Request request) async {
         '${query.toServiceQueryParameters()}');
   }
 
-  return jsonResponse(result.toJson(), indent: indent);
+  return jsonResponse(result.toJson(), pretty: isPrettyJson(request));
 }

--- a/app/lib/shared/notification.dart
+++ b/app/lib/shared/notification.dart
@@ -12,7 +12,7 @@ import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../frontend/models.dart';
-import 'handlers.dart' show jsonResponse;
+import 'handlers.dart';
 import 'task_client.dart';
 
 final Logger _logger = new Logger('pub.notification');
@@ -98,14 +98,14 @@ Future<shelf.Response> notificationHandler(shelf.Request request) async {
       if (data.isValid) {
         _logger.info('Received notification: $data');
         triggerTask(data.package, data.version);
-        return jsonResponse({'success': true});
+        return jsonResponse({'success': true}, pretty: isPrettyJson(request));
       } else {
-        return jsonResponse({'success': false});
+        return jsonResponse({'success': false}, pretty: isPrettyJson(request));
       }
     } catch (e, st) {
       _logger.warning('Error processing notification', e, st);
-      return jsonResponse({'success': false});
+      return jsonResponse({'success': false}, pretty: isPrettyJson(request));
     }
   }
-  return jsonResponse({'success': false});
+  return jsonResponse({'success': false}, pretty: isPrettyJson(request));
 }


### PR DESCRIPTION
I don't think there is a standard for getting some data as indented JSON, but it seems to me that many services use `?pretty` or `?pretty=true` to achieve it.