### PR TITLE
Load the latest versioned snapshot.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -283,7 +283,7 @@ class SnapshotStorage {
         .where((name) => name.endsWith(_suffix) && name.length == targetLength)
         .where((name) {
           final match = versions.runtimeVersionPattern
-              .matchAsPrefix(name, _suffix.length);
+              .matchAsPrefix(name, _prefix.length);
           return match != null;
         })
         .where((name) => name.compareTo(_currentPath) <= 0)


### PR DESCRIPTION
As we've deployed one release that uses the versioned snapshot, we can move away form the non-versioned one (no longer reading or writing it). On startup, we'll load the latest versioned snapshot available.
/cc @jonasfj 