### PR TITLE
Fixing SDK analysis missmatch for Flutter packages.

### DIFF
--- a/app/lib/analyzer/backend.dart
+++ b/app/lib/analyzer/backend.dart
@@ -269,6 +269,7 @@ class PackageStatus {
   final bool isDiscontinued;
   final bool isObsolete;
   final bool isLegacy;
+  final bool usesFlutter;
 
   PackageStatus({
     this.exists,
@@ -278,6 +279,7 @@ class PackageStatus {
     this.isDiscontinued = false,
     this.isObsolete = false,
     this.isLegacy = false,
+    this.usesFlutter = false,
   });
 
   factory PackageStatus.fromModels(Package p, PackageVersion pv) {
@@ -297,6 +299,7 @@ class PackageStatus {
       isDiscontinued: p.isDiscontinued ?? false,
       isObsolete: isObsolete,
       isLegacy: pv.pubspec.supportsOnlyLegacySdk,
+      usesFlutter: pv.pubspec.usesFlutter,
     );
   }
 }

--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -99,8 +99,11 @@ class AnalyzerJobProcessor extends JobProcessor {
       final toolEnvRef = await getOrCreateToolEnvRef();
       try {
         tempDir = await Directory.systemTemp.createTemp('pana');
+        final toolEnv = packageStatus.usesFlutter
+            ? toolEnvRef.flutterEnv
+            : toolEnvRef.toolEnv;
         final PackageAnalyzer analyzer =
-            new PackageAnalyzer(toolEnvRef.toolEnv, urlChecker: _urlChecker);
+            new PackageAnalyzer(toolEnv, urlChecker: _urlChecker);
         final isInternal = internalPackageNames.contains(job.packageName);
         return await analyzer.inspectPackage(
           job.packageName,

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:pana/pana.dart';
+import 'package:path/path.dart' as p;
 
 import 'configuration.dart';
 
@@ -30,10 +31,11 @@ Completer _ongoing;
 class ToolEnvRef {
   final Directory _pubCacheDir;
   final ToolEnvironment toolEnv;
+  final ToolEnvironment flutterEnv;
   int _started = 0;
   int _active = 0;
 
-  ToolEnvRef(this._pubCacheDir, this.toolEnv);
+  ToolEnvRef(this._pubCacheDir, this.toolEnv, this.flutterEnv);
 
   void _aquire() {
     _started++;
@@ -78,7 +80,15 @@ Future<ToolEnvRef> getOrCreateToolEnvRef() async {
       flutterSdkDir: envConfig.flutterSdkDir,
       pubCacheDir: resolvedDirName,
     );
-    _current = new ToolEnvRef(cacheDir, toolEnv);
+    ToolEnvironment flutterEnv = toolEnv;
+    if (envConfig.flutterSdkDir != null) {
+      flutterEnv = await ToolEnvironment.create(
+        dartSdkDir: p.join(envConfig.flutterSdkDir, 'bin', 'cache', 'dart-sdk'),
+        flutterSdkDir: envConfig.flutterSdkDir,
+        pubCacheDir: resolvedDirName,
+      );
+    }
+    _current = new ToolEnvRef(cacheDir, toolEnv, flutterEnv);
     result = _current;
     result._aquire();
     _ongoing.complete();

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-final String runtimeVersion = '2018.10.23';
+final String runtimeVersion = '2018.10.26';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -25,6 +25,7 @@ final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 ///
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens:
+/// - 2018.10.23
 /// - 2018.10.01
 /// - 2018.09.17
 /// - 2018.09.11

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 371784039);
+    expect(hash, 1047099113);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {


### PR DESCRIPTION
Handles https://github.com/dart-lang/pub-dartlang-dart/issues/1728

This is a short-term workaround:
  - We create a second tool environment instance with the Flutter SDK's internal Dart SDK. It can use the same pub cache directory and the same caching lifecycle, but it is configured to use that SDK.
  - PackageStatus exposes the usesFlutter flag too, and we can use it to decide which tool environment to use.
  - Updating the runtimeVersion in order to remove the guesswork from which packages need to be re-analyzed, but if you want to do a quick patch-release for analyzer only, we can do that too. (In that case we'll need to trigger re-analysis of the packages, but should not be hard to provide such a list.)

Longer term solution would be to put this in `pana`: tracking on https://github.com/dart-lang/pana/issues/431 and then removing the duplicate environment we are adding here.

Started a deployment on staging. /cc @jonasfj 