### PR TITLE
All bucket initalization use getOrCreateBucket

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -85,8 +85,8 @@ Future _workerMain(WorkerEntryMessage message) async {
 }
 
 Future _registerServices() async {
-  final Bucket popularityBucket =
-      storageService.bucket(activeConfiguration.popularityDumpBucketName);
+  final popularityBucket = await getOrCreateBucket(
+      storageService, activeConfiguration.popularityDumpBucketName);
   registerPopularityStorage(
       new PopularityStorage(storageService, popularityBucket));
   await popularityStorage.init();

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -94,8 +94,8 @@ Future _workerMain(WorkerEntryMessage message) async {
 }
 
 Future _registerServices() async {
-  final Bucket popularityBucket =
-      storageService.bucket(activeConfiguration.popularityDumpBucketName);
+  final popularityBucket = await getOrCreateBucket(
+      storageService, activeConfiguration.popularityDumpBucketName);
   registerPopularityStorage(
       new PopularityStorage(storageService, popularityBucket));
   await popularityStorage.init();

--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -62,8 +62,8 @@ Future _main(FrontendEntryMessage message) async {
 }
 
 Future<shelf.Handler> setupServices(Configuration configuration) async {
-  final Bucket popularityBucket =
-      storageService.bucket(configuration.popularityDumpBucketName);
+  final popularityBucket = await getOrCreateBucket(
+      storageService, activeConfiguration.popularityDumpBucketName);
   registerPopularityStorage(
       new PopularityStorage(storageService, popularityBucket));
   await popularityStorage.init();
@@ -95,7 +95,8 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
 
   new NameTrackerUpdater(db.dbService).startNameTrackerUpdates();
 
-  final pkgBucket = storageService.bucket(configuration.packageBucketName);
+  final pkgBucket =
+      await getOrCreateBucket(storageService, configuration.packageBucketName);
   final tarballStorage = new TarballStorage(storageService, pkgBucket, null);
   registerTarballStorage(tarballStorage);
 

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -49,7 +49,7 @@ Future _main(FrontendEntryMessage message) async {
   ));
 
   await withAppEngineServices(() async {
-    final Bucket popularityBucket = await getOrCreateBucket(
+    final popularityBucket = await getOrCreateBucket(
         storageService, activeConfiguration.popularityDumpBucketName);
     registerPopularityStorage(
         new PopularityStorage(storageService, popularityBucket));


### PR DESCRIPTION
This is a follow-up on one of the notes in the architecture overview doc. With this change all of the bucket initialization logic would try to recreate a bucket if it were to be missing.