### PR TITLE
Handle empty pub-data.json in search indexing.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -99,7 +99,11 @@ class SearchBackend {
       List<ApiDocPage> apiDocPages;
       if (pubDataContent != null) {
         try {
-          apiDocPages = _apiDocPagesFromPubDataText(pubDataContent);
+          if (pubDataContent.isEmpty) {
+            _logger.info('Got empty pub-data.json for package ${p.name}.');
+          } else {
+            apiDocPages = _apiDocPagesFromPubDataText(pubDataContent);
+          }
         } catch (e, st) {
           _logger.severe('Parsing pub-data.json failed.', e, st);
         }


### PR DESCRIPTION
#1740. I don't think that empty `pub-data.json` is a good sign, we should look into it, but the current log doesn't give a good indication on what packages have it. Either way, at the point of indexing, the empty data file doesn't provide a value, ignoring it is a safe choice.