### PR TITLE
Refactoring runtime-versioned data files + remove old search snapshots

### DIFF
--- a/app/bin/service/analyzer.dart
+++ b/app/bin/service/analyzer.dart
@@ -25,6 +25,7 @@ import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
+import 'package:pub_dartlang_org/shared/storage.dart';
 
 import 'package:pub_dartlang_org/analyzer/backend.dart';
 import 'package:pub_dartlang_org/analyzer/handlers.dart';

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -25,6 +25,7 @@ import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
+import 'package:pub_dartlang_org/shared/storage.dart';
 
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/dartdoc/dartdoc_runner.dart';

--- a/app/bin/service/dartdoc.dart
+++ b/app/bin/service/dartdoc.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:isolate';
-import 'dart:math' as math;
 
 import 'package:appengine/appengine.dart';
 import 'package:gcloud/db.dart';
@@ -32,7 +31,6 @@ import 'package:pub_dartlang_org/dartdoc/dartdoc_runner.dart';
 import 'package:pub_dartlang_org/dartdoc/handlers.dart';
 
 final Logger logger = new Logger('pub.dartdoc');
-final _random = new math.Random.secure();
 
 Future main() async {
   Future workerSetup() async {
@@ -81,15 +79,7 @@ Future _workerMain(WorkerEntryMessage message) async {
       message.statsSendPort.send(await jobBackend.stats(JobService.dartdoc));
     });
 
-    // Run GC in the next 6 hours (randomized wait to reduce race).
-    new Timer(new Duration(minutes: _random.nextInt(360)), () async {
-      try {
-        await dartdocBackend.deleteOldSdkData();
-      } catch (e, st) {
-        logger.warning('Error while deleting old SDK data.', e, st);
-      }
-    });
-
+    dartdocBackend.scheduleOldDataGC();
     await jobMaintenance.run();
   });
 }

--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -32,6 +32,7 @@ import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/search_client.dart';
 import 'package:pub_dartlang_org/shared/search_memcache.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
+import 'package:pub_dartlang_org/shared/storage.dart';
 
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/handlers.dart';

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -22,6 +22,7 @@ import 'package:pub_dartlang_org/shared/handler_helpers.dart';
 import 'package:pub_dartlang_org/shared/popularity_storage.dart';
 import 'package:pub_dartlang_org/shared/scheduler_stats.dart';
 import 'package:pub_dartlang_org/shared/service_utils.dart';
+import 'package:pub_dartlang_org/shared/storage.dart';
 import 'package:pub_dartlang_org/shared/task_client.dart';
 import 'package:pub_dartlang_org/shared/task_scheduler.dart';
 import 'package:pub_dartlang_org/shared/task_sources.dart';

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -75,6 +75,7 @@ Future _main(FrontendEntryMessage message) async {
     final Bucket snapshotBucket = await getOrCreateBucket(
         storageService, activeConfiguration.searchSnapshotBucketName);
     registerSnapshotStorage(new SnapshotStorage(snapshotBucket));
+    snapshotStorage.scheduleOldDataGC();
 
     final ReceivePort taskReceivePort = new ReceivePort();
     registerDartSdkIndex(new SimplePackageIndex.sdk(

--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -74,8 +74,7 @@ Future _main(FrontendEntryMessage message) async {
 
     final Bucket snapshotBucket = await getOrCreateBucket(
         storageService, activeConfiguration.searchSnapshotBucketName);
-    registerSnapshotStorage(
-        new SnapshotStorage(storageService, snapshotBucket));
+    registerSnapshotStorage(new SnapshotStorage(snapshotBucket));
 
     final ReceivePort taskReceivePort = new ReceivePort();
     registerDartSdkIndex(new SimplePackageIndex.sdk(

--- a/app/bin/tools/remove_package.dart
+++ b/app/bin/tools/remove_package.dart
@@ -10,7 +10,7 @@ import 'package:gcloud/storage.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import 'package:pub_dartlang_org/shared/configuration.dart';
-import 'package:pub_dartlang_org/shared/service_utils.dart';
+import 'package:pub_dartlang_org/shared/storage.dart';
 
 import 'package:pub_dartlang_org/analyzer/models.dart';
 import 'package:pub_dartlang_org/dartdoc/backend.dart';

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -45,7 +45,7 @@ class DartdocBackend {
 
   DartdocBackend(this._db, this._storage)
       : _sdkStorage = new VersionedDataStorage(
-            _storage, '${storage_path.dartSdkDartdocPrefix()}/', '.json.gz');
+            _storage, '${storage_path.dartSdkDartdocPrefix()}/');
 
   /// Whether the storage bucket has a usable extracted data file.
   /// Only the existence of the file is checked.

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -53,8 +53,10 @@ class DartdocBackend {
   Future<bool> hasValidDartSdkDartdocData() => _sdkStorage.hasCurrentData();
 
   /// Upload the generated dartdoc data file for the Dart SDK to the storage bucket.
-  Future uploadDartSdkDartdocData(File file) =>
-      _sdkStorage.uploadDataFile(file);
+  Future uploadDartSdkDartdocData(File file) async {
+    final map = json.decode(await file.readAsString()) as Map<String, dynamic>;
+    await _sdkStorage.uploadDataAsJsonMap(map);
+  }
 
   /// Read the generated dartdoc data file for the Dart SDK.
   Future<PubDartdocData> getDartSdkDartdocData() async {

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -41,10 +41,10 @@ DartdocBackend get dartdocBackend =>
 class DartdocBackend {
   final DatastoreDB _db;
   final Bucket _storage;
-  final VersionedDataStorage _sdkStorage;
+  final VersionedJsonStorage _sdkStorage;
 
   DartdocBackend(this._db, this._storage)
-      : _sdkStorage = new VersionedDataStorage(
+      : _sdkStorage = new VersionedJsonStorage(
             _storage, '${storage_path.dartSdkDartdocPrefix()}/');
 
   /// Whether the storage bucket has a usable extracted data file.

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -27,7 +27,6 @@ import 'storage_path.dart' as storage_path;
 final Logger _logger = new Logger('pub.dartdoc.backend');
 
 final Duration _contentDeleteThreshold = const Duration(days: 1);
-final Duration _sdkDeleteThreshold = const Duration(days: 182);
 final int _concurrentUploads = 8;
 final int _concurrentDeletes = 8;
 
@@ -63,9 +62,10 @@ class DartdocBackend {
     return new PubDartdocData.fromJson(map);
   }
 
-  /// Deletes the old entries that predate [shared_versions.gcBeforeRuntimeVersion].
-  Future deleteOldSdkData() =>
-      _sdkStorage.deleteOldData(ageThreshold: _sdkDeleteThreshold);
+  /// Schedules the delete of old data files.
+  void scheduleOldDataGC() {
+    _sdkStorage.scheduleOldDataGC();
+  }
 
   /// Returns the latest stable version of a package.
   Future<String> getLatestVersion(String package) async {

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -243,7 +243,7 @@ class SnapshotStorage {
   VersionedDataStorage _snapshots;
 
   SnapshotStorage(Bucket bucket)
-      : _snapshots = new VersionedDataStorage(bucket, 'snapshot/', '.json.gz');
+      : _snapshots = new VersionedDataStorage(bucket, 'snapshot/');
 
   Future<SearchSnapshot> fetch() async {
     final version = await _snapshots.detectLatestVersion();

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -21,7 +21,7 @@ import '../shared/analyzer_client.dart';
 import '../shared/dartdoc_client.dart';
 import '../shared/popularity_storage.dart';
 import '../shared/search_service.dart';
-import '../shared/utils.dart';
+import '../shared/storage.dart';
 import '../shared/versions.dart' as versions;
 
 import 'text_utils.dart';

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -264,6 +264,10 @@ class SnapshotStorage {
   Future store(SearchSnapshot snapshot) async {
     await _snapshots.uploadDataAsJsonMap(snapshot.toJson());
   }
+
+  void scheduleOldDataGC() {
+    _snapshots.scheduleOldDataGC();
+  }
 }
 
 @JsonSerializable()

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -240,10 +240,10 @@ PackageDocument createSdkDocument(PubDartdocData lib) {
 }
 
 class SnapshotStorage {
-  VersionedDataStorage _snapshots;
+  VersionedJsonStorage _snapshots;
 
   SnapshotStorage(Bucket bucket)
-      : _snapshots = new VersionedDataStorage(bucket, 'snapshot/');
+      : _snapshots = new VersionedJsonStorage(bucket, 'snapshot/');
 
   Future<SearchSnapshot> fetch() async {
     final version = await _snapshots.detectLatestVersion();

--- a/app/lib/shared/popularity_storage.dart
+++ b/app/lib/shared/popularity_storage.dart
@@ -11,7 +11,7 @@ import 'package:gcloud/storage.dart';
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:_popularity/popularity.dart';
 
-import '../shared/utils.dart';
+import '../shared/storage.dart';
 
 final Logger _logger = new Logger('pub.popularity');
 final GZipCodec _gzip = new GZipCodec();

--- a/app/lib/shared/service_utils.dart
+++ b/app/lib/shared/service_utils.dart
@@ -7,7 +7,6 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:appengine/appengine.dart';
-import 'package:gcloud/storage.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:pana/pana.dart' show runProc;
@@ -242,11 +241,4 @@ Future initDartdoc(Logger logger) async {
     logger.shout(message);
     throw new Exception(message);
   }
-}
-
-Future<Bucket> getOrCreateBucket(Storage storage, String name) async {
-  if (!await storage.bucketExists(name)) {
-    await storage.createBucket(name);
-  }
-  return storage.bucket(name);
 }

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -68,15 +68,14 @@ Future uploadBytesWithRetry(
     uploadWithRetry(bucket, objectName, bytes.length,
         () => new Stream.fromIterable([bytes]));
 
-/// Utility class to access versioned data file that follows the pattern:
-/// "/path-prefix/runtime-version.ext". The extension must use .gz as the
-/// storage uses transparent gzip on the data stream.
-class VersionedDataStorage {
+/// Utility class to access versioned JSON data that follows the name pattern:
+/// "/path-prefix/runtime-version.json.gz".
+class VersionedJsonStorage {
   final Bucket _bucket;
   final String _prefix;
   final String _extension = '.json.gz';
 
-  VersionedDataStorage(Bucket bucket, String prefix)
+  VersionedJsonStorage(Bucket bucket, String prefix)
       : _bucket = bucket,
         _prefix = prefix {
     assert(prefix.endsWith('/'));

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -89,8 +89,11 @@ class VersionedDataStorage {
     try {
       final info = await _bucket.info(_objectName());
       return info != null;
-    } catch (_) {
-      return false;
+    } catch (e) {
+      if (e is DetailedApiRequestError && e.status == 404) {
+        return false;
+      }
+      rethrow;
     }
   }
 

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:gcloud/storage.dart';
+
+/// Returns a valid `gs://` URI for a given [bucket] + [path] combination.
+String bucketUri(Bucket bucket, String path) =>
+    'gs://${bucket.bucketName}/$path';
+
+Future<Bucket> getOrCreateBucket(Storage storage, String name) async {
+  if (!await storage.bucketExists(name)) {
+    await storage.createBucket(name);
+  }
+  return storage.bucket(name);
+}

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -107,7 +107,8 @@ class VersionedJsonStorage {
   }
 
   /// Gets the content of the data file decoded as JSON Map.
-  Future<Map<String, dynamic>> getContentAsJsonMap([String version]) async {
+  Future<Map<String, dynamic>> getContentAsJsonMap(
+      [String version = versions.runtimeVersion]) async {
     final objectName = _objectName(version);
     final map = await _bucket
         .read(objectName)
@@ -182,10 +183,11 @@ class VersionedJsonStorage {
     });
   }
 
-  String getBucketUri([String version]) =>
+  String getBucketUri([String version = versions.runtimeVersion]) =>
       bucketUri(_bucket, _objectName(version));
 
   String _objectName([String version]) {
-    return '$_prefix${version ?? versions.runtimeVersion}$_extension';
+    assert(version != null);
+    return '$_prefix$version$_extension';
   }
 }

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -3,8 +3,20 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
+import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
+    show DetailedApiRequestError;
 import 'package:gcloud/storage.dart';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+
+import 'utils.dart' show contentType, retryAsync;
+import 'versions.dart' as versions;
+
+final _gzip = new GZipCodec();
+final _logger = new Logger('shared.storage');
 
 /// Returns a valid `gs://` URI for a given [bucket] + [path] combination.
 String bucketUri(Bucket bucket, String path) =>
@@ -15,4 +27,119 @@ Future<Bucket> getOrCreateBucket(Storage storage, String name) async {
     await storage.createBucket(name);
   }
   return storage.bucket(name);
+}
+
+Future deleteFromBucket(Bucket bucket, String objectName) async {
+  try {
+    await bucket.delete(objectName);
+  } on DetailedApiRequestError catch (e) {
+    if (e.status != 404) {
+      rethrow;
+    }
+  }
+}
+
+/// Uploads content from [openStream] to the [bucket] as [objectName].
+Future uploadWithRetry(Bucket bucket, String objectName, int length,
+    Stream<List<int>> openStream()) async {
+  await retryAsync(
+    () async {
+      final sink = bucket.write(objectName,
+          length: length, contentType: contentType(objectName));
+      await sink.addStream(openStream());
+      await sink.close();
+    },
+    description: 'Upload to $objectName',
+    shouldRetryOnError: (e) {
+      if (e is DetailedApiRequestError) {
+        return e.status == 502 || e.status == 503;
+      }
+      return false;
+    },
+    sleep: Duration(seconds: 10),
+  );
+}
+
+/// Uploads content from [bytes] to the [bucket] as [objectName].
+Future uploadBytesWithRetry(
+        Bucket bucket, String objectName, List<int> bytes) =>
+    uploadWithRetry(bucket, objectName, bytes.length,
+        () => new Stream.fromIterable([bytes]));
+
+/// Utility class to access versioned data file that follows the pattern:
+/// "/path-prefix/runtime-version.ext". The extension must use .gz as the
+/// storage uses transparent gzip on the data stream.
+class VersionedDataStorage {
+  final Bucket _bucket;
+  final String _prefix;
+  final String _extension;
+
+  VersionedDataStorage(Bucket bucket, String prefix, String extension)
+      : _bucket = bucket,
+        _prefix = prefix,
+        _extension = extension {
+    assert(extension.endsWith('.gz'));
+  }
+
+  /// Whether the storage bucket has a data file for the current runtime version.
+  /// TODO: decide whether we should re-generate the file after a certain age
+  Future<bool> hasCurrentData() async {
+    try {
+      final info = await _bucket.info(_objectName());
+      return info != null;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Upload the current data file to the storage bucket.
+  Future uploadDataFile(File file) async {
+    final objectName = _objectName();
+    try {
+      // Prevents edge cases like double compression.
+      assert(!file.path.endsWith('.gz'));
+      await uploadWithRetry(_bucket, objectName, file.lengthSync(),
+          () => file.openRead().transform(_gzip.encoder));
+    } catch (e, st) {
+      _logger.warning('Unable to upload data file: $objectName', e, st);
+    }
+  }
+
+  /// Gets the content of the data file decoded as JSON Map.
+  Future<Map<String, dynamic>> getContentAsJsonMap() async {
+    final objectName = _objectName();
+    final map = await _bucket
+        .read(objectName)
+        .transform(_gzip.decoder)
+        .transform(utf8.decoder)
+        .transform(json.decoder)
+        .single;
+    return map as Map<String, dynamic>;
+  }
+
+  /// Deletes the old entries that predate [versions.gcBeforeRuntimeVersion].
+  Future deleteOldData({Duration ageThreshold}) async {
+    await for (BucketEntry entry in _bucket.list(prefix: _prefix)) {
+      if (entry.isDirectory) {
+        continue;
+      }
+      final name = p.basename(entry.name);
+      if (!name.endsWith(_extension)) {
+        continue;
+      }
+      final version = name.substring(0, name.length - _extension.length);
+      final matchesPattern = version.length == 10 &&
+          versions.runtimeVersionPattern.hasMatch(version);
+      if (matchesPattern &&
+          version.compareTo(versions.gcBeforeRuntimeVersion) < 0) {
+        final info = await _bucket.info(entry.name);
+        final age = new DateTime.now().difference(info.updated);
+        if (ageThreshold == null || age > ageThreshold) {
+          await deleteFromBucket(_bucket, entry.name);
+        }
+      }
+    }
+  }
+
+  String _objectName() => '$_prefix${versions.runtimeVersion}$_extension';
 }

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -157,6 +157,10 @@ class VersionedDataStorage {
   }
 
   /// Deletes the old entries that predate [versions.gcBeforeRuntimeVersion].
+  ///
+  /// When [minAgeThreshold] is specified, only older files will be deleted. The
+  /// process assumes that if an old runtimeVersion is still active, it will
+  /// update it periodically, and a cleanup should preserve such files.
   Future deleteOldData({Duration minAgeThreshold}) async {
     await for (BucketEntry entry in _bucket.list(prefix: _prefix)) {
       if (entry.isDirectory) {

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -74,15 +74,12 @@ Future uploadBytesWithRetry(
 class VersionedDataStorage {
   final Bucket _bucket;
   final String _prefix;
-  final String _extension;
+  final String _extension = '.json.gz';
 
-  VersionedDataStorage(Bucket bucket, String prefix, String extension)
+  VersionedDataStorage(Bucket bucket, String prefix)
       : _bucket = bucket,
-        _prefix = prefix,
-        _extension = extension {
+        _prefix = prefix {
     assert(prefix.endsWith('/'));
-    assert(extension.startsWith('.'));
-    assert(extension.endsWith('.gz'));
   }
 
   /// Whether the storage bucket has a data file for the current runtime version.

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -99,19 +99,6 @@ class VersionedDataStorage {
     }
   }
 
-  /// Upload the current data file to the storage bucket.
-  Future uploadDataFile(File file) async {
-    final objectName = _objectName();
-    try {
-      // Prevents edge cases like double compression.
-      assert(!file.path.endsWith('.gz'));
-      await uploadWithRetry(_bucket, objectName, file.lengthSync(),
-          () => file.openRead().transform(_gzip.encoder));
-    } catch (e, st) {
-      _logger.warning('Unable to upload data file: $objectName', e, st);
-    }
-  }
-
   /// Upload the current data to the storage bucket.
   Future uploadDataAsJsonMap(Map<String, dynamic> map) async {
     final objectName = _objectName();

--- a/app/lib/shared/storage.dart
+++ b/app/lib/shared/storage.dart
@@ -80,6 +80,8 @@ class VersionedDataStorage {
       : _bucket = bucket,
         _prefix = prefix,
         _extension = extension {
+    assert(prefix.endsWith('/'));
+    assert(extension.startsWith('.'));
     assert(extension.endsWith('.gz'));
   }
 

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -11,7 +11,6 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:appengine/appengine.dart';
-import 'package:gcloud/storage.dart';
 import 'package:http/http.dart' as http;
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
@@ -321,10 +320,6 @@ Future<http.Response> getUrlWithRetry(http.Client client, String url,
   }
   return result;
 }
-
-/// Returns a valid `gs://` URI for a given [bucket] + [path] combination.
-String bucketUri(Bucket bucket, String path) =>
-    'gs://${bucket.bucketName}/$path';
 
 /// To avoid having the same String values many times in memory we intern them.
 /// https://en.wikipedia.org/wiki/String_interning

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-final String runtimeVersion = '2018.11.12';
+const String runtimeVersion = '2018.11.12';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to

--- a/app/test/frontend/handlers_documentation_test.dart
+++ b/app/test/frontend/handlers_documentation_test.dart
@@ -191,7 +191,7 @@ class DartdocBackendMock implements DartdocBackend {
   }
 
   @override
-  Future deleteOldSdkData() {
+  void scheduleOldDataGC() {
     throw new UnimplementedError();
   }
 


### PR DESCRIPTION
- Fixes #1725.
- refactored most bucket-related utility methods to `shared/storage.dart`
- updated bucket upload with length info
- refactored the runtime-version-based code from dartdoc's sdk data and search's snapshot storages into `VersionedDataStorage`
- old search snapshots are now deleted too