### PR TITLE
Remove inlined scripts from core template outputs.

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -124,6 +124,7 @@ class StaticUrls {
 
   Map<String, String> get assets {
     return _assets ??= {
+      'gtag_js': _getCacheableStaticUrl('/js/gtag.js'),
       'script_dart_js': _getCacheableStaticUrl('/js/script.dart.js'),
       'github_markdown_css': _getCacheableStaticUrl('/css/github-markdown.css'),
       'style_css': _getCacheableStaticUrl('/css/style.css'),

--- a/app/test/frontend/golden/authorized_page.html
+++ b/app/test/frontend/golden/authorized_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -90,6 +85,6 @@
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/error_page.html
+++ b/app/test/frontend/golden/error_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -105,6 +100,6 @@
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/flutter_landing_page.html
+++ b/app/test/frontend/golden/flutter_landing_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/golden/index_page.html
+++ b/app/test/frontend/golden/index_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/golden/pkg_index_page.html
+++ b/app/test/frontend/golden/pkg_index_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -368,6 +363,6 @@ import 'package:foobar_pkg/foolib.dart';
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -318,6 +313,6 @@ import 'package:foobar_pkg/foolib.dart';
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -322,6 +317,6 @@ import 'package:foobar_pkg/foolib.dart';
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -335,6 +330,6 @@ import 'package:foobar_pkg/foolib.dart';
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -322,6 +317,6 @@ import 'package:foobar_pkg/foolib.dart';
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -370,6 +365,6 @@ import 'package:foobar_pkg/foolib.dart';
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/pkg_versions_page.html
+++ b/app/test/frontend/golden/pkg_versions_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -152,6 +147,6 @@
   <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue</a>
 </footer>
 <script src="/static/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="/static/highlight/init.js"></script>
 </body>
 </html>

--- a/app/test/frontend/golden/search_page.html
+++ b/app/test/frontend/golden/search_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/golden/search_supported_qualifier.html
+++ b/app/test/frontend/golden/search_supported_qualifier.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/golden/search_unsupported_qualifier.html
+++ b/app/test/frontend/golden/search_unsupported_qualifier.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/golden/web_landing_page.html
+++ b/app/test/frontend/golden/web_landing_page.html
@@ -2,12 +2,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app/test/frontend/static_files_test.dart
+++ b/app/test/frontend/static_files_test.dart
@@ -46,7 +46,7 @@ Future main() async {
       for (String path in mockStaticFiles) {
         final file = staticFileCache.getFile('/static/$path');
         expect(file, isNotNull);
-        expect(file.bytes.length, greaterThan(1000));
+        expect(file.bytes.length, greaterThan(10));
         expect(file.etag.contains('mocked_hash'), isFalse);
       }
     });

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -11,6 +11,7 @@ import 'package:pub_dartlang_org/frontend/model_properties.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 
 const mockStaticFiles = const <String>[
+  'js/gtag.js',
   'js/script.dart.js',
   'css/github-markdown.css',
   'css/style.css',

--- a/app/views/layout.mustache
+++ b/app/views/layout.mustache
@@ -5,12 +5,7 @@
 <html lang="en-us">
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="{{{static_assets.gtag_js}}}"></script>
   <meta charset="utf-8" />
   <meta http-equiv="x-ua-compatible" content="ie=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -133,7 +128,7 @@
 </footer>
 {{#include_highlight}}
 <script src="{{{static_assets_dir}}}/highlight/highlight.pack.js"></script>
-<script>hljs.initHighlightingOnLoad();</script>
+<script src="{{{static_assets_dir}}}/highlight/init.js"></script>
 {{/include_highlight}}
 {{#schema_org_searchaction_json}}
 <script type="application/ld+json">

--- a/static/highlight/init.js
+++ b/static/highlight/init.js
@@ -1,0 +1,1 @@
+hljs.initHighlightingOnLoad();

--- a/static/js/gtag.js
+++ b/static/js/gtag.js
@@ -1,0 +1,4 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'UA-26406144-13');


### PR DESCRIPTION
part of #1691

I've added tests that make sure we don't have inline scripts (except for the search index metadata JSONs), and also we don't use any JS action attributes (`on*`, eg. `onclick`).
