### PR TITLE
Remove inline-scripts from dartdoc customization.

### DIFF
--- a/app/lib/dartdoc/customization.dart
+++ b/app/lib/dartdoc/customization.dart
@@ -136,13 +136,8 @@ class DartdocCustomizer {
       ..text = '';
     head.insertBefore(gtagScript, firstChild);
     head.insertBefore(new Text('\n  '), firstChild);
-    final gtagInit = new Element.tag('script');
-    gtagInit
-        .append(new Text('''\n\n    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  '''));
+    final gtagInit = new Element.tag('script')
+      ..attributes['src'] = '$siteRoot/static/js/gtag.js';
     head.insertBefore(gtagInit, firstChild);
   }
 

--- a/app/test/dartdoc/customization_test.dart
+++ b/app/test/dartdoc/customization_test.dart
@@ -10,6 +10,8 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/dartdoc/customization.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 
+import '../shared/html_validation.dart';
+
 const String goldenDir = 'test/dartdoc/golden';
 
 final _regenerateGoldens = false;
@@ -20,6 +22,7 @@ void main() {
       // Making sure it is valid HTML
       final htmlParser = new HtmlParser(content, strict: true);
       final doc = htmlParser.parse();
+      validateHtml(doc);
 
       // Matching logo URLs with static files settings.
       // If this fails, update the hard-coded customization URL to match it.

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -1,13 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="https://pub.dartlang.org/static/js/gtag.js"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -1,13 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="https://pub.dartlang.org/static/js/gtag.js"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
@@ -1,13 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="https://pub.dartlang.org/static/js/gtag.js"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
@@ -1,13 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="https://pub.dartlang.org/static/js/gtag.js"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -1,13 +1,7 @@
 <!DOCTYPE html><html lang="en"><head>
   <meta name="robots" content="noindex">
   <script async="async" src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
-  <script>
-
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'UA-26406144-13');
-  </script>
+  <script src="https://pub.dartlang.org/static/js/gtag.js"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:pana/pana.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -19,6 +18,7 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
 
+import '../shared/html_validation.dart';
 import 'utils.dart';
 
 const String goldenDir = 'test/frontend/golden';
@@ -48,46 +48,12 @@ void main() {
       // Making sure it is valid HTML
       final htmlParser = new HtmlParser(content, strict: true);
 
-      List<Element> elements;
-      List<Element> links;
-      List<Element> scripts;
       if (isFragment) {
         final root = htmlParser.parseFragment();
-        elements = root.querySelectorAll('*');
-        links = root.querySelectorAll('a');
-        scripts = root.querySelectorAll('script');
+        validateHtml(root);
       } else {
         final root = htmlParser.parse();
-        elements = root.querySelectorAll('*');
-        links = root.querySelectorAll('a');
-        scripts = root.querySelectorAll('script');
-      }
-
-      // No inline JS attribute
-      for (Element elem in elements) {
-        expect(
-            elem.attributes.keys
-                .where((name) => name.toString().startsWith('on'))
-                .toList(),
-            []);
-      }
-
-      // All <a target="_blank"> links should have rel="noopener"
-      for (Element elem in links) {
-        if (elem.attributes['target'] == '_blank') {
-          expect(elem.attributes['rel'], contains('noopener'));
-        }
-      }
-
-      // No inline script tag.
-      for (Element elem in scripts) {
-        if (elem.attributes['type'] == 'application/ld+json') {
-          expect(elem.attributes.length, 1);
-          expect(json.decode(elem.text), isNotNull);
-        } else {
-          expect(elem.attributes['src'], isNotEmpty);
-          expect(elem.text.trim(), isEmpty);
-        }
+        validateHtml(root);
       }
 
       if (_regenerateGoldens) {

--- a/app/test/shared/html_validation.dart
+++ b/app/test/shared/html_validation.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:html/dom.dart';
+import 'package:test/test.dart';
+
+void validateHtml(root) {
+  List<Element> elements;
+  List<Element> links;
+  List<Element> scripts;
+
+  if (root is DocumentFragment) {
+    elements = root.querySelectorAll('*');
+    links = root.querySelectorAll('a');
+    scripts = root.querySelectorAll('script');
+  } else if (root is Document) {
+    elements = root.querySelectorAll('*');
+    links = root.querySelectorAll('a');
+    scripts = root.querySelectorAll('script');
+  } else {
+    throw new ArgumentError('Unknown html element type: $root');
+  }
+
+  // No inline JS attribute
+  for (Element elem in elements) {
+    expect(
+        elem.attributes.keys
+            .where((name) => name.toString().startsWith('on'))
+            .toList(),
+        []);
+  }
+
+  // All <a target="_blank"> links should have rel="noopener"
+  for (Element elem in links) {
+    if (elem.attributes['target'] == '_blank') {
+      expect(elem.attributes['rel'], contains('noopener'));
+    }
+  }
+
+  // No inline script tag.
+  for (Element elem in scripts) {
+    if (elem.attributes['type'] == 'application/ld+json') {
+      expect(elem.attributes.length, 1);
+      expect(json.decode(elem.text), isNotNull);
+    } else {
+      expect(elem.attributes['src'], isNotEmpty);
+      expect(elem.text.trim(), isEmpty);
+    }
+  }
+}


### PR DESCRIPTION
Part of #1691

I've moved the html validation test to shared, the same thing is applied on both frontend and dartdoc output.