### PR TITLE
Upgrade dartdoc to 0.24.1

### DIFF
--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-final String runtimeVersion = '2018.11.05';
+final String runtimeVersion = '2018.11.07';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -44,7 +44,7 @@ final String flutterVersion = '0.10.2';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml
-final String dartdocVersion = '0.23.1';
+final String dartdocVersion = '0.24.1';
 final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
 
 /// The version of our customization going into the output of the dartdoc static

--- a/app/test/dartdoc/golden/pana_0.12.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.23.1">
+  <meta name="generator" content="made with love by dartdoc 0.24.1">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.12.2/index.html">

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.23.1">
+  <meta name="generator" content="made with love by dartdoc 0.24.1">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="alternate" href="/documentation/pana/latest/">

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
@@ -172,7 +172,7 @@
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
-          <div class="features">read-only</div>
+          <div class="features">read-only, override</div>
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
@@ -244,7 +244,7 @@
           </dt>
         <dd>
           Returns a string representation of this object.
-          
+          <div class="features">override</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
@@ -277,7 +277,7 @@
           </dt>
         <dd>
           The equality operator. <a href="pana/LicenseFile/operator_equals.html">[...]</a>
-          
+          <div class="features">override</div>
 </dd>
       </dl>
     </section>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -176,7 +176,7 @@
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
-          <div class="features">read-only</div>
+          <div class="features">read-only, override</div>
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
@@ -248,7 +248,7 @@
           </dt>
         <dd>
           Returns a string representation of this object.
-          
+          <div class="features">override</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
@@ -281,7 +281,7 @@
           </dt>
         <dd>
           The equality operator. <a href="pana/LicenseFile/operator_equals.html">[...]</a>
-          
+          <div class="features">override</div>
 </dd>
       </dl>
     </section>

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 924792102);
+    expect(hash, 994732870);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {

--- a/pkg/pub_dartdoc/lib/pub_data_generator.dart
+++ b/pkg/pub_dartdoc/lib/pub_data_generator.dart
@@ -28,11 +28,15 @@ class PubDataGenerator implements Generator {
         .where((elem) => elem.isPublic)
         .where((elem) => p.isWithin(_inputDirectory, elem.sourceFileName))
         .where((elem) {
-      // remove inherited items from dart:* libraries
-      final inheritedFrom = elem.overriddenElement?.fullyQualifiedName;
-      final fromDartLibs =
-          inheritedFrom != null && inheritedFrom.startsWith('dart:');
-      return !fromDartLibs;
+      if (elem is Inheritable) {
+        // remove inherited items from dart:* libraries
+        final inheritedFrom = elem.overriddenElement?.fullyQualifiedName;
+        final fromDartLibs =
+            inheritedFrom != null && inheritedFrom.startsWith('dart:');
+        return !fromDartLibs;
+      } else {
+        return true;
+      }
     }).toList();
 
     final apiMap = <String, ApiElement>{};
@@ -76,6 +80,10 @@ class PubDataGenerator implements Generator {
 
   @override
   Set<String> get writtenFiles => _writtenFiles;
+
+  // Inherited member, should not show up in pub-data.json
+  @override
+  String toString() => null;
 }
 
 String _trimToNull(String text) {

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: dartdoc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.23.1"
+    version: "0.24.1"
   file:
     dependency: transitive
     description:

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   meta: ^1.1.5
   path: ^1.6.0
   # dartdoc version to be pinned, keep in-sync with app/lib/shared/versions.dart
-  dartdoc: 0.23.1
+  dartdoc: 0.24.1
 
 dev_dependencies:
   build_runner: '^1.0.0'

--- a/pkg/pub_dartdoc/test/self_documenting_test.dart
+++ b/pkg/pub_dartdoc/test/self_documenting_test.dart
@@ -106,7 +106,11 @@ void main() {
       () async {
         final goldenFile = new File('test/self-pub-data.json');
         final dataFile = new File('${tempDir.path}/pub-data.json');
-        final actualMap = json.decode(await dataFile.readAsString());
+        final fileContent = await dataFile.readAsString();
+        final actualMap = json.decode(fileContent);
+
+        // inherited toString() should not show up
+        expect(fileContent.contains('PubDataGenerator.toString'), isFalse);
 
         if (_regenerateGoldens) {
           final content = new JsonEncoder.withIndent('  ').convert(actualMap);


### PR DESCRIPTION
- templates barely changed
- the API that we extended changed a bit
- added a small `toString()` test to make sure we don't emit inherited members from dart:core
