### PR TITLE
Upgrade pana to 0.12.6

### DIFF
--- a/app/lib/analyzer/pana_runner.dart
+++ b/app/lib/analyzer/pana_runner.dart
@@ -99,11 +99,8 @@ class AnalyzerJobProcessor extends JobProcessor {
       final toolEnvRef = await getOrCreateToolEnvRef();
       try {
         tempDir = await Directory.systemTemp.createTemp('pana');
-        final toolEnv = packageStatus.usesFlutter
-            ? toolEnvRef.flutterEnv
-            : toolEnvRef.toolEnv;
         final PackageAnalyzer analyzer =
-            new PackageAnalyzer(toolEnv, urlChecker: _urlChecker);
+            new PackageAnalyzer(toolEnvRef.toolEnv, urlChecker: _urlChecker);
         final isInternal = internalPackageNames.contains(job.packageName);
         return await analyzer.inspectPackage(
           job.packageName,

--- a/app/lib/dartdoc/pub_dartdoc_data.g.dart
+++ b/app/lib/dartdoc/pub_dartdoc_data.g.dart
@@ -28,7 +28,7 @@ ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
-  var val = <String, dynamic>{
+  final val = <String, dynamic>{
     'name': instance.name,
     'kind': instance.kind,
   };

--- a/app/lib/history/models.g.dart
+++ b/app/lib/history/models.g.dart
@@ -27,7 +27,7 @@ UploaderChanged _$UploaderChangedFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$UploaderChangedToJson(UploaderChanged instance) {
-  var val = <String, dynamic>{};
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -88,7 +88,7 @@ PanaReport _$PanaReportFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$PanaReportToJson(PanaReport instance) {
-  var val = <String, dynamic>{
+  final val = <String, dynamic>{
     'timestamp': instance.timestamp?.toIso8601String(),
     'panaRuntimeInfo': instance.panaRuntimeInfo,
     'reportStatus': instance.reportStatus,
@@ -128,7 +128,7 @@ DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$DartdocReportToJson(DartdocReport instance) {
-  var val = <String, dynamic>{
+  final val = <String, dynamic>{
     'reportStatus': instance.reportStatus,
     'coverageScore': instance.coverageScore,
   };

--- a/app/lib/shared/search_service.g.dart
+++ b/app/lib/shared/search_service.g.dart
@@ -106,7 +106,7 @@ PackageScore _$PackageScoreFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$PackageScoreToJson(PackageScore instance) {
-  var val = <String, dynamic>{
+  final val = <String, dynamic>{
     'package': instance.package,
   };
 
@@ -132,7 +132,7 @@ ApiPageRef _$ApiPageRefFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$ApiPageRefToJson(ApiPageRef instance) {
-  var val = <String, dynamic>{
+  final val = <String, dynamic>{
     'title': instance.title,
     'path': instance.path,
   };

--- a/app/lib/shared/tool_env.dart
+++ b/app/lib/shared/tool_env.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:pana/pana.dart';
-import 'package:path/path.dart' as p;
 
 import 'configuration.dart';
 
@@ -31,11 +30,10 @@ Completer _ongoing;
 class ToolEnvRef {
   final Directory _pubCacheDir;
   final ToolEnvironment toolEnv;
-  final ToolEnvironment flutterEnv;
   int _started = 0;
   int _active = 0;
 
-  ToolEnvRef(this._pubCacheDir, this.toolEnv, this.flutterEnv);
+  ToolEnvRef(this._pubCacheDir, this.toolEnv);
 
   void _aquire() {
     _started++;
@@ -80,15 +78,7 @@ Future<ToolEnvRef> getOrCreateToolEnvRef() async {
       flutterSdkDir: envConfig.flutterSdkDir,
       pubCacheDir: resolvedDirName,
     );
-    ToolEnvironment flutterEnv = toolEnv;
-    if (envConfig.flutterSdkDir != null) {
-      flutterEnv = await ToolEnvironment.create(
-        dartSdkDir: p.join(envConfig.flutterSdkDir, 'bin', 'cache', 'dart-sdk'),
-        flutterSdkDir: envConfig.flutterSdkDir,
-        pubCacheDir: resolvedDirName,
-      );
-    }
-    _current = new ToolEnvRef(cacheDir, toolEnv, flutterEnv);
+    _current = new ToolEnvRef(cacheDir, toolEnv);
     result = _current;
     result._aquire();
     _ongoing.complete();

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-final String runtimeVersion = '2018.11.07';
+final String runtimeVersion = '2018.11.09';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -25,6 +25,7 @@ final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 ///
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens:
+/// - 2018.11.09
 /// - 2018.10.23
 /// - 2018.10.01
 /// - 2018.09.17
@@ -37,7 +38,7 @@ final String runtimeSdkVersion = '2.1.0-dev.5.0';
 final String toolEnvSdkVersion = '2.0.0';
 
 // keep in-sync with app/pubspec.yaml
-final String panaVersion = '0.12.5';
+final String panaVersion = '0.12.6';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
 final String flutterVersion = '0.10.2';

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.32.6"
+    version: "0.33.3"
   appengine:
     dependency: "direct main"
     description:
@@ -70,7 +70,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1+3"
+    version: "0.3.1+4"
   build_resolvers:
     dependency: transitive
     description:
@@ -91,7 +91,7 @@ packages:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   built_collection:
     dependency: transitive
     description:
@@ -168,7 +168,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   fixnum:
     dependency: transitive
     description:
@@ -182,7 +182,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4+2"
+    version: "0.1.6+3"
   gcloud:
     dependency: "direct main"
     description:
@@ -294,7 +294,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -308,14 +308,14 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "2.0.0"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4+2"
+    version: "0.3.6+3"
   logging:
     dependency: "direct main"
     description:
@@ -399,7 +399,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   path:
     dependency: "direct main"
     description:
@@ -455,7 +455,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+2"
+    version: "0.1.2+3"
   quiver:
     dependency: transitive
     description:
@@ -567,7 +567,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.1+1"
   typed_data:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   http: '>=0.11.0 <0.12.0'
   http_parser: '>=3.1.1 <4.0.0'
   intl: '>=0.13.0 <0.16.0'
-  json_annotation: '^1.1.0'
+  json_annotation: '^2.0.0'
   logging: '>=0.9.3 <1.0.0'
   markdown: '>=2.0.0 <2.1.0'
   memcache: '^0.3.0'
@@ -34,13 +34,13 @@ dependencies:
   yaml: '^2.1.12'
   # pana version to be pinned
   # keep in-sync with app/lib/shared/versions.dart
-  pana: '0.12.5'
+  pana: '0.12.6'
   # 3rd-party packages with pinned versions
   archive: '2.0.3'
   uuid: '1.0.3'
 
 dev_dependencies:
   build_runner: '^1.0.0'
-  json_serializable: '^1.5.1'
+  json_serializable: '^2.0.0'
   source_gen: '^0.9.0'
   test: ^1.2.0

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 994732870);
+    expect(hash, 955976478);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {

--- a/pkg/_popularity/pubspec.yaml
+++ b/pkg/_popularity/pubspec.yaml
@@ -5,9 +5,9 @@ environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  json_annotation: ^1.1.0
+  json_annotation: ^2.0.0
 
 dev_dependencies:
   build_runner: ^1.0.0
-  json_serializable: ^1.5.1
+  json_serializable: ^2.0.0
   test: ^1.3.0

--- a/pkg/pub_dartdoc/lib/pub_dartdoc_data.g.dart
+++ b/pkg/pub_dartdoc/lib/pub_dartdoc_data.g.dart
@@ -28,7 +28,7 @@ ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
-  var val = <String, dynamic>{
+  final val = <String, dynamic>{
     'name': instance.name,
     'kind': instance.kind,
   };

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1+3"
+    version: "0.3.1+4"
   build_resolvers:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   built_collection:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -238,7 +238,7 @@ packages:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "2.0.0"
   kernel:
     dependency: transitive
     description:
@@ -364,7 +364,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+2"
+    version: "0.1.2+3"
   quiver:
     dependency: transitive
     description:
@@ -483,7 +483,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.1+1"
   typed_data:
     dependency: transitive
     description:

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -4,7 +4,7 @@ description: The customized dartdoc for pub.dartlang.org.
 environment:
   sdk: ">=2.0.0 <3.0.0"
 dependencies:
-  json_annotation: '^1.1.0'
+  json_annotation: '^2.0.0'
   logging: '>=0.9.3 <1.0.0'
   meta: ^1.1.5
   path: ^1.6.0
@@ -13,6 +13,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: '^1.0.0'
-  json_serializable: '^1.5.1'
+  json_serializable: '^2.0.0'
   source_gen: '^0.9.0'
   test: '^1.3.0'


### PR DESCRIPTION
- upgrade to pana required to upgrade the `json_annotation` and `json_serializable` packages
- upgrade of the later triggered change in the generated code (no change in the behaviour)
- I've also removed the extra flutter environment we needed to have, it is now handled by pana internally