### PR TITLE
New tool: sync_staging.

### DIFF
--- a/app/bin/tools/sync_staging.dart
+++ b/app/bin/tools/sync_staging.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/db.dart';
+import 'package:http/http.dart';
+import 'package:pool/pool.dart';
+
+import 'package:pub_dartlang_org/frontend/models.dart';
+import 'package:pub_dartlang_org/frontend/pub_client.dart';
+import 'package:pub_dartlang_org/frontend/service_utils.dart';
+
+void main() async {
+  await withProdServices(() async {
+    final pubClient = new PubClient(new Client());
+
+    int processIdx = 0;
+    int missingPackages = 0;
+    int missingVersions = 0;
+    final pool = new Pool(4);
+    final futures = <Future>[];
+
+    final packages = await pubClient.listPackages();
+    for (String package in packages) {
+      final data = await pubClient.getPackageData(package);
+
+      final f = pool.withResource(() async {
+        final pkgKey = dbService.emptyKey.append(Package, id: package);
+        final versions = await dbService
+            .query<PackageVersion>(ancestorKey: pkgKey)
+            .run()
+            .toList();
+        final versionsExisting = versions.map((pv) => pv.version).toSet();
+        final versionsToCreate =
+            data.versions.where((v) => !versionsExisting.contains(v));
+
+        final idx = processIdx++;
+        final status = versionsToCreate.isEmpty
+            ? 'OK'
+            : 'missing ${versionsToCreate.length} versions';
+        print('Package [$idx/${packages.length}] $package: $status');
+
+        missingVersions += versionsToCreate.length;
+        if (versionsToCreate.isNotEmpty) {
+          final Package p = (await dbService.lookup([pkgKey])).single;
+          if (p == null) {
+            missingPackages++;
+          }
+          // TODO: update staging Datastore
+        }
+      });
+      futures.add(f);
+    }
+    await Future.wait(futures);
+    await pool.close();
+
+    print(
+        'Total missing: $missingPackages packages $missingVersions versions.');
+    await pubClient.close();
+  });
+}

--- a/app/lib/frontend/pub_client.dart
+++ b/app/lib/frontend/pub_client.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert' as convert;
+
+import 'package:http/http.dart';
+
+/// Client interface for accessing some of pub's public APIs.
+class PubClient {
+  final Client _client;
+  final String _siteRoot;
+
+  PubClient(this._client, {String siteRoot = 'https://pub.dartlang.org'})
+      : _siteRoot = siteRoot;
+
+  /// List the name of packages.
+  Future<List<String>> listPackages() async {
+    final content = await _client.read('$_siteRoot/api/packages?compact=1');
+    final map = convert.json.decode(content) as Map<String, dynamic>;
+    final packages = (map['packages'] as List).cast<String>();
+    return packages;
+  }
+
+  /// Fetch the base package data (versions and uploaders).
+  Future<PackageData> getPackageData(String package) async {
+    final content = await _client.read('$_siteRoot/packages/$package.json');
+    final map = convert.json.decode(content) as Map<String, dynamic>;
+    final uploaders = (map['uploaders'] as List)?.cast<String>();
+    final versions = (map['versions'] as List)?.cast<String>();
+    return new PackageData(uploaders: uploaders, versions: versions);
+  }
+
+  /// Fetch the package version data (created, pubspec).
+  Future<PackageVersionData> getPackageVersionData(
+      String package, String version) async {
+    final pageContent =
+        await _client.read('$_siteRoot/packages/$package/versions/$version');
+    final searchJson = pageContent
+        .split('\n')
+        .firstWhere((s) => s.contains('"@type":"SoftwareSourceCode"'));
+    final searchMap = convert.json.decode(searchJson) as Map<String, dynamic>;
+    final created = DateTime.parse(searchMap['dateModified'] as String);
+    return new PackageVersionData(
+      created: created,
+      pubspec: await _getPubspec(package, version),
+    );
+  }
+
+  Future<Map<String, dynamic>> _getPubspec(
+      String package, String version) async {
+    final content = await _client
+        .read('$_siteRoot/api/packages/$package/versions/$version');
+    final map = convert.json.decode(content) as Map<String, dynamic>;
+    return map['pubspec'] as Map<String, dynamic>;
+  }
+
+  /// Closes the http client.
+  ///
+  /// (kept-it Future-based in case we may need to close streams).
+  Future close() async {
+    _client.close();
+  }
+}
+
+class PackageData {
+  final List<String> uploaders;
+  final List<String> versions;
+
+  PackageData({this.uploaders, this.versions});
+}
+
+class PackageVersionData {
+  final DateTime created;
+  final Map<String, dynamic> pubspec;
+
+  PackageVersionData({this.created, this.pubspec});
+}

--- a/app/lib/frontend/pub_client.dart
+++ b/app/lib/frontend/pub_client.dart
@@ -5,19 +5,19 @@
 import 'dart:async';
 import 'dart:convert' as convert;
 
-import 'package:http/http.dart';
+import 'package:http/http.dart' as http;
 
 /// Client interface for accessing some of pub's public APIs.
 class PubClient {
-  final Client _client;
+  final http.Client _httpClient;
   final String _siteRoot;
 
-  PubClient(this._client, {String siteRoot = 'https://pub.dartlang.org'})
+  PubClient(this._httpClient, {String siteRoot = 'https://pub.dartlang.org'})
       : _siteRoot = siteRoot;
 
   /// List the name of packages.
   Future<List<String>> listPackages() async {
-    final content = await _client.read('$_siteRoot/api/packages?compact=1');
+    final content = await _httpClient.read('$_siteRoot/api/packages?compact=1');
     final map = convert.json.decode(content) as Map<String, dynamic>;
     final packages = (map['packages'] as List).cast<String>();
     return packages;
@@ -25,7 +25,7 @@ class PubClient {
 
   /// Fetch the base package data (versions and uploaders).
   Future<PackageData> getPackageData(String package) async {
-    final content = await _client.read('$_siteRoot/packages/$package.json');
+    final content = await _httpClient.read('$_siteRoot/packages/$package.json');
     final map = convert.json.decode(content) as Map<String, dynamic>;
     final uploaders = (map['uploaders'] as List)?.cast<String>();
     final versions = (map['versions'] as List)?.cast<String>();
@@ -35,8 +35,8 @@ class PubClient {
   /// Fetch the package version data (created, pubspec).
   Future<PackageVersionData> getPackageVersionData(
       String package, String version) async {
-    final pageContent =
-        await _client.read('$_siteRoot/packages/$package/versions/$version');
+    final pageContent = await _httpClient
+        .read('$_siteRoot/packages/$package/versions/$version');
     final searchJson = pageContent
         .split('\n')
         .firstWhere((s) => s.contains('"@type":"SoftwareSourceCode"'));
@@ -50,7 +50,7 @@ class PubClient {
 
   Future<Map<String, dynamic>> _getPubspec(
       String package, String version) async {
-    final content = await _client
+    final content = await _httpClient
         .read('$_siteRoot/api/packages/$package/versions/$version');
     final map = convert.json.decode(content) as Map<String, dynamic>;
     return map['pubspec'] as Map<String, dynamic>;
@@ -60,7 +60,7 @@ class PubClient {
   ///
   /// (kept-it Future-based in case we may need to close streams).
   Future close() async {
-    _client.close();
+    _httpClient.close();
   }
 }
 


### PR DESCRIPTION
At this point this is only a read-only scanner that will give use the number of packages and versions that are missing from staging, and it can be a validation of the backup/restore process. Because there is an ongoing restore-from-backup on staging, making the updates is not important to implement right away, but I wanted to submit the code. Later on we can finish the missing pieces for the updates. (#1509)
