### PR TITLE
Upgrade Flutter SDK to 0.11.3

### DIFF
--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-final String runtimeVersion = '2018.11.09';
+final String runtimeVersion = '2018.11.12';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -25,7 +25,7 @@ final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 ///
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens:
-/// - 2018.11.09
+/// - 2018.11.12
 /// - 2018.10.23
 /// - 2018.10.01
 /// - 2018.09.17
@@ -41,7 +41,7 @@ final String toolEnvSdkVersion = '2.0.0';
 final String panaVersion = '0.12.6';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
-final String flutterVersion = '0.10.2';
+final String flutterVersion = '0.11.3';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 955976478);
+    expect(hash, 494091656);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {


### PR DESCRIPTION
This contains a fix for https://github.com/flutter/flutter/issues/23098, which was a soft-blocker for using the ScoreCard pana report on the analysis tab.