### PR TITLE
Reduce the details of dartdoc logging.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -458,6 +458,9 @@ bool _isKnownFailurePattern(String output) {
   return false;
 }
 
+/// Merges the stdout and stderr of [ProcessResult] into a single String, which
+/// can be used in log messages. For long output, set [compressStdout] to true,
+/// keeping only the beginning and the end of stdout.
 String _mergeOutput(ProcessResult pr, {bool compressStdout = false}) {
   String stdout = pr.stdout.toString();
   if (compressStdout) {

--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -458,7 +458,7 @@ bool _isKnownFailurePattern(String output) {
   return false;
 }
 
-String _mergeOutput(ProcessResult pr, {bool compressStdout: false}) {
+String _mergeOutput(ProcessResult pr, {bool compressStdout = false}) {
   String stdout = pr.stdout.toString();
   if (compressStdout) {
     final list = stdout.split('\n');


### PR DESCRIPTION
Improves #1347.

With the updated staging environment I've noticed that Flutter-package seem to have a large amount warnings in the logs. The dartdoc process seems to complete, files are generated, but there is one or more warning or error message with a non-zero error code. That triggered the `logger.warning` with sometimes 1000s of lines in the log message, but otherwise the output was OK.
