### PR TITLE
Move /documentation handler to frontend/

### DIFF
--- a/app/lib/dartdoc/handlers.dart
+++ b/app/lib/dartdoc/handlers.dart
@@ -3,17 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
-import 'package:http_parser/http_parser.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../shared/handlers.dart';
-import '../shared/packages_overrides.dart';
-import '../shared/urls.dart';
-import '../shared/utils.dart' show contentType;
-
-import 'backend.dart';
 
 /// Handlers for the dartdoc service.
 Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
@@ -38,106 +31,3 @@ Future<shelf.Response> dartdocServiceHandler(shelf.Request request) async {
 
 /// Handler /debug requests
 shelf.Response _debugHandler(shelf.Request request) => debugResponse();
-
-/// Handles requests for:
-///   - /documentation/<package>/<version>
-Future<shelf.Response> documentationHandler(shelf.Request request) async {
-  final docFilePath = parseRequestUri(request.requestedUri);
-  if (docFilePath == null) {
-    return notFoundHandler(request);
-  }
-  if (redirectDartdocPages.containsKey(docFilePath.package)) {
-    return redirectResponse(redirectDartdocPages[docFilePath.package]);
-  }
-  if (docFilePath.package == null || docFilePath.version == null) {
-    return redirectResponse(pkgDocUrl(docFilePath.package, isLatest: true));
-  }
-  if (docFilePath.path == null) {
-    return redirectResponse('${request.requestedUri}/');
-  }
-  final String requestMethod = request.method?.toUpperCase();
-  final entry = await dartdocBackend.getServingEntry(
-      docFilePath.package, docFilePath.version);
-  if (entry == null) {
-    return redirectResponse(pkgVersionsUrl(docFilePath.package));
-  }
-  if (entry.isLatest == true && docFilePath.version != 'latest') {
-    return redirectResponse(pkgDocUrl(docFilePath.package,
-        isLatest: true, relativePath: docFilePath.path));
-  }
-  if (requestMethod == 'HEAD') {
-    if (!entry.hasContent && docFilePath.path.endsWith('.html')) {
-      return notFoundHandler(request);
-    }
-    final info = await dartdocBackend.getFileInfo(entry, docFilePath.path);
-    if (info == null) {
-      return notFoundHandler(request);
-    }
-    // TODO: add content-length header too
-    return htmlResponse('');
-  }
-  if (requestMethod == 'GET') {
-    if (!entry.hasContent && docFilePath.path.endsWith('.html')) {
-      return redirectResponse(pkgVersionsUrl(docFilePath.package));
-    }
-    final info = await dartdocBackend.getFileInfo(entry, docFilePath.path);
-    if (info == null) {
-      return notFoundHandler(request);
-    }
-    if (isNotModified(request, info.lastModified, info.etag)) {
-      return new shelf.Response.notModified();
-    }
-    final stream = dartdocBackend.readContent(entry, docFilePath.path);
-    final headers = {
-      HttpHeaders.contentTypeHeader: contentType(docFilePath.path),
-      HttpHeaders.cacheControlHeader: 'max-age: ${staticShortCache.inSeconds}',
-    };
-    if (info.lastModified != null) {
-      headers[HttpHeaders.lastModifiedHeader] =
-          formatHttpDate(info.lastModified);
-    }
-    if (info.etag != null) {
-      headers[HttpHeaders.etagHeader] = info.etag;
-    }
-    return new shelf.Response(HttpStatus.ok, body: stream, headers: headers);
-  }
-  return notFoundHandler(request);
-}
-
-class DocFilePath {
-  final String package;
-  final String version;
-  final String path;
-
-  DocFilePath(this.package, this.version, this.path);
-}
-
-DocFilePath parseRequestUri(Uri uri) {
-  final int segmentCount = uri.pathSegments.length;
-  if (segmentCount < 2) return null;
-  if (uri.pathSegments[0] != 'documentation') return null;
-
-  final String package = uri.pathSegments[1];
-  if (package.isEmpty) return null;
-  if (segmentCount == 2) {
-    return new DocFilePath(package, null, null);
-  }
-
-  final String version = uri.pathSegments[2];
-  if (version.isEmpty) {
-    return new DocFilePath(package, null, null);
-  }
-  if (segmentCount == 3) {
-    return new DocFilePath(package, version, null);
-  }
-
-  final relativeSegments =
-      uri.pathSegments.skip(3).where((s) => s.isNotEmpty).toList();
-  String path = relativeSegments.join('/');
-  if (path.isEmpty) {
-    path = 'index.html';
-  } else if (path.isNotEmpty && !relativeSegments.last.contains('.')) {
-    path = '$path/index.html';
-  }
-  return new DocFilePath(package, version, path);
-}

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -14,7 +14,6 @@ import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../dartdoc/backend.dart';
-import '../dartdoc/handlers.dart' show documentationHandler;
 import '../history/backend.dart';
 import '../scorecard/backend.dart';
 import '../shared/analyzer_client.dart';
@@ -28,6 +27,7 @@ import '../shared/utils.dart';
 
 import 'atom_feed.dart';
 import 'backend.dart';
+import 'handlers_documentation.dart';
 import 'handlers_redirects.dart';
 import 'models.dart';
 import 'name_tracker.dart';

--- a/app/lib/frontend/handlers_documentation.dart
+++ b/app/lib/frontend/handlers_documentation.dart
@@ -80,6 +80,8 @@ Future<shelf.Response> documentationHandler(shelf.Request request) async {
   return notFoundHandler(request);
 }
 
+/// The parsed structure of the documentation URL.
+/// [package] is always set, [version] or [path] may be missing.
 class DocFilePath {
   final String package;
   final String version;
@@ -88,6 +90,8 @@ class DocFilePath {
   DocFilePath(this.package, this.version, this.path);
 }
 
+/// Parses the /documentation/<package>/<version>/<path with many levels> URL
+/// and returns the parsed structure.
 DocFilePath parseRequestUri(Uri uri) {
   final int segmentCount = uri.pathSegments.length;
   if (segmentCount < 2) return null;

--- a/app/lib/frontend/handlers_documentation.dart
+++ b/app/lib/frontend/handlers_documentation.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http_parser/http_parser.dart';
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../dartdoc/backend.dart';
+
+import '../shared/handlers.dart';
+import '../shared/packages_overrides.dart';
+import '../shared/urls.dart';
+import '../shared/utils.dart' show contentType;
+
+/// Handles requests for:
+///   - /documentation/<package>/<version>
+Future<shelf.Response> documentationHandler(shelf.Request request) async {
+  final docFilePath = parseRequestUri(request.requestedUri);
+  if (docFilePath == null) {
+    return notFoundHandler(request);
+  }
+  if (redirectDartdocPages.containsKey(docFilePath.package)) {
+    return redirectResponse(redirectDartdocPages[docFilePath.package]);
+  }
+  if (docFilePath.package == null || docFilePath.version == null) {
+    return redirectResponse(pkgDocUrl(docFilePath.package, isLatest: true));
+  }
+  if (docFilePath.path == null) {
+    return redirectResponse('${request.requestedUri}/');
+  }
+  final String requestMethod = request.method?.toUpperCase();
+  final entry = await dartdocBackend.getServingEntry(
+      docFilePath.package, docFilePath.version);
+  if (entry == null) {
+    return redirectResponse(pkgVersionsUrl(docFilePath.package));
+  }
+  if (entry.isLatest == true && docFilePath.version != 'latest') {
+    return redirectResponse(pkgDocUrl(docFilePath.package,
+        isLatest: true, relativePath: docFilePath.path));
+  }
+  if (requestMethod == 'HEAD') {
+    if (!entry.hasContent && docFilePath.path.endsWith('.html')) {
+      return notFoundHandler(request);
+    }
+    final info = await dartdocBackend.getFileInfo(entry, docFilePath.path);
+    if (info == null) {
+      return notFoundHandler(request);
+    }
+    // TODO: add content-length header too
+    return htmlResponse('');
+  }
+  if (requestMethod == 'GET') {
+    if (!entry.hasContent && docFilePath.path.endsWith('.html')) {
+      return redirectResponse(pkgVersionsUrl(docFilePath.package));
+    }
+    final info = await dartdocBackend.getFileInfo(entry, docFilePath.path);
+    if (info == null) {
+      return notFoundHandler(request);
+    }
+    if (isNotModified(request, info.lastModified, info.etag)) {
+      return new shelf.Response.notModified();
+    }
+    final stream = dartdocBackend.readContent(entry, docFilePath.path);
+    final headers = {
+      HttpHeaders.contentTypeHeader: contentType(docFilePath.path),
+      HttpHeaders.cacheControlHeader: 'max-age: ${staticShortCache.inSeconds}',
+    };
+    if (info.lastModified != null) {
+      headers[HttpHeaders.lastModifiedHeader] =
+          formatHttpDate(info.lastModified);
+    }
+    if (info.etag != null) {
+      headers[HttpHeaders.etagHeader] = info.etag;
+    }
+    return new shelf.Response(HttpStatus.ok, body: stream, headers: headers);
+  }
+  return notFoundHandler(request);
+}
+
+class DocFilePath {
+  final String package;
+  final String version;
+  final String path;
+
+  DocFilePath(this.package, this.version, this.path);
+}
+
+DocFilePath parseRequestUri(Uri uri) {
+  final int segmentCount = uri.pathSegments.length;
+  if (segmentCount < 2) return null;
+  if (uri.pathSegments[0] != 'documentation') return null;
+
+  final String package = uri.pathSegments[1];
+  if (package.isEmpty) return null;
+  if (segmentCount == 2) {
+    return new DocFilePath(package, null, null);
+  }
+
+  final String version = uri.pathSegments[2];
+  if (version.isEmpty) {
+    return new DocFilePath(package, null, null);
+  }
+  if (segmentCount == 3) {
+    return new DocFilePath(package, version, null);
+  }
+
+  final relativeSegments =
+  uri.pathSegments.skip(3).where((s) => s.isNotEmpty).toList();
+  String path = relativeSegments.join('/');
+  if (path.isEmpty) {
+    path = 'index.html';
+  } else if (path.isNotEmpty && !relativeSegments.last.contains('.')) {
+    path = '$path/index.html';
+  }
+  return new DocFilePath(package, version, path);
+}

--- a/app/lib/frontend/handlers_documentation.dart
+++ b/app/lib/frontend/handlers_documentation.dart
@@ -112,7 +112,7 @@ DocFilePath parseRequestUri(Uri uri) {
   }
 
   final relativeSegments =
-  uri.pathSegments.skip(3).where((s) => s.isNotEmpty).toList();
+      uri.pathSegments.skip(3).where((s) => s.isNotEmpty).toList();
   String path = relativeSegments.join('/');
   if (path.isEmpty) {
     path = 'index.html';

--- a/app/test/frontend/handlers_documentation_test.dart
+++ b/app/test/frontend/handlers_documentation_test.dart
@@ -13,7 +13,7 @@ import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
-import 'package:pub_dartlang_org/dartdoc/handlers.dart';
+import 'package:pub_dartlang_org/frontend/handlers_documentation.dart';
 import 'package:pub_dartlang_org/shared/urls.dart';
 
 import '../shared/handlers_test_utils.dart';
@@ -100,22 +100,6 @@ void main() {
       registerDartdocBackend(new DartdocBackendMock());
       expectRedirectResponse(await issueGet('/documentation/no_pkg/latest/'),
           '/packages/no_pkg/versions');
-    });
-
-    test('dartdocs.org redirect', () async {
-      expectRedirectResponse(
-        await dartdocServiceHandler(new shelf.Request('GET',
-            Uri.parse('https://dartdocs.org/documentation/pkg/latest/'))),
-        'https://pub.dartlang.org/documentation/pkg/latest/',
-      );
-    });
-
-    test('www.dartdocs.org redirect', () async {
-      expectRedirectResponse(
-        await dartdocServiceHandler(new shelf.Request('GET',
-            Uri.parse('https://www.dartdocs.org/documentation/pkg/latest/'))),
-        'https://pub.dartlang.org/documentation/pkg/latest/',
-      );
     });
   });
 }

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -19,10 +19,10 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
 
-import '../dartdoc/handlers_test.dart' show DartdocBackendMock;
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';
 
+import 'handlers_documentation_test.dart' show DartdocBackendMock;
 import 'handlers_test_utils.dart';
 import 'utils.dart';
 


### PR DESCRIPTION
First part of #1756

Most of it is unchanged code, except:
- I've removed the redirect test as they are already tested in `frontend/handlers_test`.
- Added a few lines of documentation notes.
