### PR TITLE
ScoreCard migration: search results.

### DIFF
--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -130,7 +130,7 @@ class TemplateService {
         scoreBoxHtml = _renderSdkScoreBox();
       } else if (!view.isExternal) {
         scoreBoxHtml = _renderScoreBox(overallScore,
-            isSkipped: _isAnalysisSkipped(view.analysisStatus),
+            isSkipped: view.isSkipped,
             isNewPackage: view.isNewPackage,
             package: view.name);
       }

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -244,8 +244,28 @@ class ScoreCardReport extends db.ExpandoModel {
   }
 }
 
+abstract class FlagMixin {
+  List<String> get flags;
+
+  bool get isDiscontinued =>
+      flags != null && flags.contains(PackageFlags.isDiscontinued);
+
+  bool get isLegacy => flags != null && flags.contains(PackageFlags.isLegacy);
+
+  bool get isObsolete =>
+      flags != null && flags.contains(PackageFlags.isObsolete);
+
+  bool get doNotAdvertise =>
+      flags != null && flags.contains(PackageFlags.doNotAdvertise);
+
+  bool get isSkipped => isDiscontinued || isLegacy || isObsolete;
+
+  bool get usesFlutter =>
+      flags != null && flags.contains(PackageFlags.usesFlutter);
+}
+
 @JsonSerializable()
-class ScoreCardData {
+class ScoreCardData extends Object with FlagMixin {
   final String packageName;
   final String packageVersion;
   final String runtimeVersion;
@@ -266,24 +286,25 @@ class ScoreCardData {
   final List<String> platformTags;
 
   /// The flags for the package, version or analysis.
+  @override
   final List<String> flags;
 
   /// The report types that are already done for the ScoreCard.
   final List<String> reportTypes;
 
   ScoreCardData({
-    @required this.packageName,
-    @required this.packageVersion,
-    @required this.runtimeVersion,
-    @required this.updated,
-    @required this.packageCreated,
-    @required this.packageVersionCreated,
-    @required this.healthScore,
-    @required this.maintenanceScore,
-    @required this.popularityScore,
-    @required this.platformTags,
-    @required this.flags,
-    @required this.reportTypes,
+    this.packageName,
+    this.packageVersion,
+    this.runtimeVersion,
+    this.updated,
+    this.packageCreated,
+    this.packageVersionCreated,
+    this.healthScore,
+    this.maintenanceScore,
+    this.popularityScore,
+    this.platformTags,
+    this.flags,
+    this.reportTypes,
   });
 
   factory ScoreCardData.fromJson(Map<String, dynamic> json) =>
@@ -299,16 +320,7 @@ class ScoreCardData {
 
   bool get isNew => new DateTime.now().difference(packageCreated).inDays <= 30;
 
-  bool get isDiscontinued =>
-      flags != null && flags.contains(PackageFlags.isDiscontinued);
-
-  bool get doNotAdvertise =>
-      flags != null && flags.contains(PackageFlags.doNotAdvertise);
-
   bool get isCurrent => runtimeVersion == versions.runtimeVersion;
-
-  bool get usesFlutter =>
-      flags != null && flags.contains(PackageFlags.usesFlutter);
 
   Map<String, dynamic> toJson() {
     final map = _$ScoreCardDataToJson(this);

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -47,11 +47,6 @@ class AnalyzerClient {
     return new AnalysisView(await _getAnalysisData(key));
   }
 
-  Future<List<AnalysisExtract>> getAnalysisExtracts(
-      Iterable<AnalysisKey> keys) {
-    return Future.wait(keys.map(getAnalysisExtract));
-  }
-
   Future<AnalysisExtract> getAnalysisExtract(AnalysisKey key) async {
     if (key == null) return null;
     final cached = _extractCache[key];

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -95,7 +95,7 @@ void main() {
               new PackageView.fromModel(
                   package: testPackage,
                   version: testPackageVersion,
-                  analysis: null)
+                  scoreCard: null)
             ]);
           },
         ));
@@ -126,7 +126,7 @@ void main() {
               new PackageView.fromModel(
                   package: testPackage,
                   version: testPackageVersion,
-                  analysis: null)
+                  scoreCard: null)
             ]);
           },
         ));
@@ -156,7 +156,7 @@ void main() {
               new PackageView.fromModel(
                   package: testPackage,
                   version: testPackageVersion,
-                  analysis: null)
+                  scoreCard: null)
             ]);
           },
         ));
@@ -316,7 +316,7 @@ void main() {
               new PackageView.fromModel(
                   package: testPackage,
                   version: testPackageVersion,
-                  analysis: null)
+                  scoreCard: null)
             ]);
           },
         ));
@@ -346,7 +346,7 @@ void main() {
               new PackageView.fromModel(
                   package: testPackage,
                   version: testPackageVersion,
-                  analysis: null)
+                  scoreCard: null)
             ]);
           },
         ));

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -317,11 +317,6 @@ class AnalyzerClientMock implements AnalyzerClient {
       mockAnalysisExtract;
 
   @override
-  Future<List<AnalysisExtract>> getAnalysisExtracts(
-          Iterable<AnalysisKey> keys) =>
-      Future.wait(keys.map(getAnalysisExtract));
-
-  @override
   Future triggerAnalysis(
       String package, String version, Set<String> dependentPackages) async {}
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -10,6 +10,7 @@ import 'package:pana/pana.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/scorecard/models.dart';
 import 'package:pub_dartlang_org/shared/analyzer_service.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/platform.dart';
@@ -69,9 +70,9 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new AnalysisExtract(
-            analysisStatus: AnalysisStatus.success,
-            platforms: ['web'],
+          scoreCard: new ScoreCardData(
+            platformTags: ['web'],
+            reportTypes: ['pana'],
           ),
         ),
       ]);
@@ -84,9 +85,9 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new AnalysisExtract(
-            analysisStatus: AnalysisStatus.success,
-            platforms: ['flutter'],
+          scoreCard: new ScoreCardData(
+            platformTags: ['flutter'],
+            reportTypes: ['pana'],
           ),
         ),
       ]);
@@ -100,9 +101,9 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new AnalysisExtract(
-            analysisStatus: AnalysisStatus.success,
-            platforms: ['web'],
+          scoreCard: new ScoreCardData(
+            platformTags: ['web'],
+            reportTypes: ['pana'],
           ),
         ),
       ]);
@@ -387,14 +388,14 @@ void main() {
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
-          analysis: new AnalysisExtract(),
+          scoreCard: new ScoreCardData(),
         ),
         new PackageView.fromModel(
           package: testPackage,
           version: flutterPackageVersion,
-          analysis: new AnalysisExtract(
-            analysisStatus: AnalysisStatus.success,
-            platforms: ['flutter'],
+          scoreCard: new ScoreCardData(
+            platformTags: ['flutter'],
+            reportTypes: ['pana'],
           ),
         ),
       ], new PageLinks.empty(), null);
@@ -409,7 +410,7 @@ void main() {
           new PackageView.fromModel(
             package: testPackage,
             version: testPackageVersion,
-            analysis: new AnalysisExtract(),
+            scoreCard: new ScoreCardData(),
             apiPages: [
               new ApiPageRef(path: 'some/some-library.html'),
               new ApiPageRef(title: 'Class X', path: 'some/x-class.html'),
@@ -418,9 +419,9 @@ void main() {
           new PackageView.fromModel(
             package: testPackage,
             version: flutterPackageVersion,
-            analysis: new AnalysisExtract(
-              analysisStatus: AnalysisStatus.success,
-              platforms: ['flutter'],
+            scoreCard: new ScoreCardData(
+              platformTags: ['flutter'],
+              reportTypes: ['pana'],
             ),
           ),
         ],
@@ -484,8 +485,8 @@ void main() {
           version: '1.0.2',
           ellipsizedDescription:
               'Some popular package that is shown on the error page.',
-          analysisStatus: AnalysisStatus.success,
           platforms: KnownPlatforms.all,
+          isAwaiting: false,
         ),
       ]);
       expectGoldenFile(html, 'error_page.html');


### PR DESCRIPTION
This is the first half of the ScoreCard migration: search results display the platform tags and the package's overall scores. The data came from `AnalysisExtract` (and if not from cache, it came from `AnalysisView`), but should come from `ScoreCard(Data)`.

(The second part will be the analysis tab migration.)