### PR TITLE
Refactor atom feed handler.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -25,8 +25,8 @@ import '../shared/search_service.dart';
 import '../shared/urls.dart' as urls;
 import '../shared/utils.dart';
 
-import 'atom_feed.dart';
 import 'backend.dart';
+import 'handlers_atom_feed.dart';
 import 'handlers_documentation.dart';
 import 'handlers_redirects.dart';
 import 'models.dart';
@@ -121,7 +121,7 @@ const _handlers = const <String, shelf.Handler>{
   '/api/search': _apiSearchHandler,
   '/api/history': _apiHistoryHandler, // experimental, do not rely on it
   '/debug': _debugHandler,
-  '/feed.atom': _atomFeedHandler,
+  '/feed.atom': atomFeedHandler,
   '/sitemap.txt': _siteMapHandler,
   '/authorized': _authorizedHandler,
   '/packages.json': _packagesHandler,
@@ -208,20 +208,6 @@ Future<List<PackageView>> _topPackages(
 /// Handles requests for /help
 Future<shelf.Response> _helpPageHandler(shelf.Request request) async {
   return htmlResponse(templateService.renderHelpPage());
-}
-
-/// Handles requests for /feed.atom
-Future<shelf.Response> _atomFeedHandler(shelf.Request request) async {
-  final int pageSize = 10;
-
-  // The python version had paging support, but there was no point to it, since
-  // the "next page" link was never returned to the caller.
-  final int page = 1;
-
-  final versions = await backend.latestPackageVersions(
-      offset: pageSize * (page - 1), limit: pageSize);
-  final feed = feedFromPackageVersions(request.requestedUri, versions);
-  return atomXmlResponse(feed.toXmlDocument());
 }
 
 Future<shelf.Response> _siteMapHandler(shelf.Request request) async {

--- a/app/lib/frontend/handlers_atom_feed.dart
+++ b/app/lib/frontend/handlers_atom_feed.dart
@@ -7,10 +7,28 @@ library pub_dartlang_org.atom_feed;
 import 'dart:convert';
 
 import 'package:markdown/markdown.dart' as md;
+import 'package:shelf/shelf.dart' as shelf;
 import 'package:uuid/uuid.dart';
 
+import '../shared/handlers.dart';
 import '../shared/urls.dart' show siteRoot;
+
+import 'backend.dart';
 import 'models.dart';
+
+/// Handles requests for /feed.atom
+Future<shelf.Response> atomFeedHandler(shelf.Request request) async {
+  final int pageSize = 10;
+
+  // The python version had paging support, but there was no point to it, since
+  // the "next page" link was never returned to the caller.
+  final int page = 1;
+
+  final versions = await backend.latestPackageVersions(
+      offset: pageSize * (page - 1), limit: pageSize);
+  final feed = feedFromPackageVersions(request.requestedUri, versions);
+  return atomXmlResponse(feed.toXmlDocument());
+}
 
 class FeedEntry {
   final String id;

--- a/app/test/frontend/handlers_atom_feed_test.dart
+++ b/app/test/frontend/handlers_atom_feed_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library pub_dartlang_org.handlers_test;
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/frontend/backend.dart';
+import 'package:pub_dartlang_org/frontend/templates.dart';
+
+import '../shared/utils.dart';
+
+import 'handlers_test_utils.dart';
+import 'utils.dart';
+
+void tScopedTest(String name, Future func()) {
+  scopedTest(name, () {
+    registerTemplateService(new TemplateMock());
+    return func();
+  });
+}
+
+void main() {
+  final pageSize = 10;
+
+  group('feeds', () {
+    tScopedTest('/feed.atom', () async {
+      final backend =
+          new BackendMock(latestPackageVersionsFun: ({offset, limit}) {
+        expect(offset, 0);
+        expect(limit, pageSize);
+        return [testPackageVersion];
+      });
+      registerBackend(backend);
+      await expectAtomXmlResponse(await issueGet('/feed.atom'), regexp: '''
+<\\?xml version="1.0" encoding="UTF-8"\\?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+        <id>https://pub.dartlang.org/feed.atom</id>
+        <title>Pub Packages for Dart</title>
+        <updated>(.*)</updated>
+        <author>
+          <name>Dart Team</name>
+        </author>
+        <link href="https://pub.dartlang.org/" rel="alternate" />
+        <link href="https://pub.dartlang.org/feed.atom" rel="self" />
+        <generator version="0.1.0">Pub Feed Generator</generator>
+        <subtitle>Last Updated Packages</subtitle>
+(\\s*)
+        <entry>
+          <id>urn:uuid:d4fe7eb8-fc0e-5515-a5e5-5868b339d660</id>
+          <title>v0.1.1\\+5 of foobar_pkg</title>
+          <updated>${testPackageVersion.created.toIso8601String()}</updated>
+          <author><name>Hans Juergen &lt;hans@juergen.com&gt;</name></author>
+          <content type="html">&lt;h1&gt;Test Package&lt;&#47;h1&gt;
+&lt;p&gt;This is a readme file.&lt;&#47;p&gt;
+&lt;pre&gt;&lt;code class=&quot;language-dart&quot;&gt;void main\\(\\) {
+}
+&lt;&#47;code&gt;&lt;&#47;pre&gt;
+</content>
+          <link href="https://pub.dartlang.org/packages/foobar_pkg"
+                rel="alternate"
+                title="foobar_pkg" />
+        </entry>
+(\\s*)
+</feed>
+''');
+    });
+  });
+}

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -399,48 +399,6 @@ void main() {
         expectRedirectResponse(await issueGet('/search?q=foobar&page=2'),
             'https://pub.dartlang.org/packages?q=foobar&page=2');
       });
-
-      tScopedTest('/feed.atom', () async {
-        final backend =
-            new BackendMock(latestPackageVersionsFun: ({offset, limit}) {
-          expect(offset, 0);
-          expect(limit, pageSize);
-          return [testPackageVersion];
-        });
-        registerBackend(backend);
-        await expectAtomXmlResponse(await issueGet('/feed.atom'), regexp: '''
-<\\?xml version="1.0" encoding="UTF-8"\\?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-        <id>https://pub.dartlang.org/feed.atom</id>
-        <title>Pub Packages for Dart</title>
-        <updated>(.*)</updated>
-        <author>
-          <name>Dart Team</name>
-        </author>
-        <link href="https://pub.dartlang.org/" rel="alternate" />
-        <link href="https://pub.dartlang.org/feed.atom" rel="self" />
-        <generator version="0.1.0">Pub Feed Generator</generator>
-        <subtitle>Last Updated Packages</subtitle>
-(\\s*)
-        <entry>
-          <id>urn:uuid:d4fe7eb8-fc0e-5515-a5e5-5868b339d660</id>
-          <title>v0.1.1\\+5 of foobar_pkg</title>
-          <updated>${testPackageVersion.created.toIso8601String()}</updated>
-          <author><name>Hans Juergen &lt;hans@juergen.com&gt;</name></author>
-          <content type="html">&lt;h1&gt;Test Package&lt;&#47;h1&gt;
-&lt;p&gt;This is a readme file.&lt;&#47;p&gt;
-&lt;pre&gt;&lt;code class=&quot;language-dart&quot;&gt;void main\\(\\) {
-}
-&lt;&#47;code&gt;&lt;&#47;pre&gt;
-</content>
-          <link href="https://pub.dartlang.org/packages/foobar_pkg"
-                rel="alternate"
-                title="foobar_pkg" />
-        </entry>
-(\\s*)
-</feed>
-''');
-      });
     });
 
     group('/documentation', () {


### PR DESCRIPTION
Part of #1756

I've considered to put it under the umbrella of bots (e.g. `robots.txt`, `sitemap.txt`), but the target audience differs: those are for search engines, while the atom feed is for developers (using feed readers). 