### PR TITLE
Refactor: atomXmlResponse to handlers_atom_feed.dart

### DIFF
--- a/app/lib/frontend/handlers_atom_feed.dart
+++ b/app/lib/frontend/handlers_atom_feed.dart
@@ -10,7 +10,6 @@ import 'package:markdown/markdown.dart' as md;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:uuid/uuid.dart';
 
-import '../shared/handlers.dart';
 import '../shared/urls.dart' show siteRoot;
 
 import 'backend.dart';
@@ -29,6 +28,13 @@ Future<shelf.Response> atomFeedHandler(shelf.Request request) async {
   final feed = feedFromPackageVersions(request.requestedUri, versions);
   return atomXmlResponse(feed.toXmlDocument());
 }
+
+shelf.Response atomXmlResponse(String content, {int status = 200}) =>
+    new shelf.Response(
+      status,
+      body: content,
+      headers: {'content-type': 'application/atom+xml; charset="utf-8"'},
+    );
 
 class FeedEntry {
   final String id;

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -34,13 +34,6 @@ shelf.Response redirectToSearch(String query) {
   return redirectResponse(searchUrl(q: query));
 }
 
-shelf.Response atomXmlResponse(String content, {int status = 200}) =>
-    new shelf.Response(
-      status,
-      body: content,
-      headers: {'content-type': 'application/atom+xml; charset="utf-8"'},
-    );
-
 bool isPrettyJson(shelf.Request request) {
   return request.url.queryParameters.containsKey('pretty');
 }


### PR DESCRIPTION
I think there won't be other atom feed handler that would need to use it in a shared place.