### PR TITLE
Refactor: redirect handlers

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -103,9 +103,6 @@ const _handlers = const <String, shelf.Handler>{
   '/packages': _packagesHandlerHtml,
   '/flutter': _flutterLandingHandler,
   '/flutter/packages': _flutterPackagesHandlerHtml,
-  '/flutter/plugins': _redirectToFlutterPackages,
-  '/server': _serverLandingHandler,
-  '/server/packages': _serverPackagesHandlerHtml,
   '/web': _webLandingHandler,
   '/web/packages': _webPackagesHandlerHtml,
   '/api/search': _apiSearchHandler,
@@ -145,10 +142,6 @@ Future<shelf.Response> __indexHandler(shelf.Request request) =>
 /// Handles requests for /flutter
 Future<shelf.Response> _flutterLandingHandler(shelf.Request request) =>
     _indexHandler(request, KnownPlatforms.flutter);
-
-/// Handles requests for /server
-shelf.Response _serverLandingHandler(shelf.Request request) =>
-    redirectResponse('/');
 
 /// Handles requests for /web
 Future<shelf.Response> _webLandingHandler(shelf.Request request) =>
@@ -309,16 +302,6 @@ Future<shelf.Response> _packagesHandlerHtml(shelf.Request request) =>
 /// Handles /flutter/packages
 Future<shelf.Response> _flutterPackagesHandlerHtml(shelf.Request request) =>
     _packagesHandlerHtmlCore(request, KnownPlatforms.flutter);
-
-/// Handles /server/packages
-shelf.Response _serverPackagesHandlerHtml(shelf.Request request) {
-  final params = request.requestedUri.queryParameters;
-  final uri = new Uri(
-    path: '/packages',
-    queryParameters: params.isNotEmpty ? params : null,
-  );
-  return redirectResponse(uri.toString());
-}
 
 /// Handles /web/packages
 Future<shelf.Response> _webPackagesHandlerHtml(shelf.Request request) =>
@@ -722,10 +705,6 @@ Future<shelf.Response> _apiHistoryHandler(shelf.Request request) async {
         .toList(),
   }, pretty: true);
 }
-
-/// Handles requests for /flutter/plugins (redirects to /flutter/packages).
-shelf.Response _redirectToFlutterPackages(shelf.Request request) =>
-    redirectResponse('/flutter/packages');
 
 Future<shelf.Response> _formattedNotFoundHandler(shelf.Request request) async {
   final packages = await _topPackages();

--- a/app/lib/frontend/handlers_redirects.dart
+++ b/app/lib/frontend/handlers_redirects.dart
@@ -4,6 +4,41 @@
 
 library pub_dartlang_org.handlers_redirects;
 
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../shared/handlers.dart';
+import '../shared/urls.dart' as urls;
+
+/// Checks [request] whether it can handle it via redirect.
+/// Returns null when there is no redirect.
+shelf.Response tryHandleRedirects(shelf.Request request) {
+  final host = request.requestedUri.host;
+  if (host == 'www.dartdocs.org' || host == 'dartdocs.org') {
+    return redirectResponse(
+        request.requestedUri.replace(host: 'pub.dartlang.org').toString());
+  }
+
+  final path = request.requestedUri.path;
+  if (path == '/search') {
+    return redirectResponse(
+        request.requestedUri.replace(path: urls.searchUrl()).toString());
+  }
+  if (path.startsWith('/doc')) {
+    return _docRedirectHandler(request);
+  }
+  return null;
+}
+
+/// Handles requests for /doc
+shelf.Response _docRedirectHandler(shelf.Request request) {
+  final pubDocUrl = 'https://www.dartlang.org/tools/pub/';
+  final dartlangDotOrgPath = redirectPaths[request.requestedUri.path];
+  if (dartlangDotOrgPath != null) {
+    return redirectResponse('$pubDocUrl$dartlangDotOrgPath');
+  }
+  return redirectResponse(pubDocUrl);
+}
+
 const Map<String, String> redirectPaths = const <String, String>{
   // /doc/ goes to "Getting started".
   '/doc': 'get-started.html',

--- a/app/test/frontend/handlers_redirects_test.dart
+++ b/app/test/frontend/handlers_redirects_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library pub_dartlang_org.handlers_test;
+
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:pub_dartlang_org/frontend/handlers_redirects.dart';
+import 'package:pub_dartlang_org/frontend/templates.dart';
+
+import '../shared/handlers_test_utils.dart';
+import '../shared/utils.dart';
+
+import 'handlers_test_utils.dart';
+
+void tScopedTest(String name, Future func()) {
+  scopedTest(name, () {
+    registerTemplateService(new TemplateMock());
+    return func();
+  });
+}
+
+void main() {
+  group('redirects', () {
+    test('dartdocs.org redirect', () async {
+      expectRedirectResponse(
+        await issueGetUri(
+            Uri.parse('https://dartdocs.org/documentation/pkg/latest/')),
+        'https://pub.dartlang.org/documentation/pkg/latest/',
+      );
+    });
+
+    test('www.dartdocs.org redirect', () async {
+      expectRedirectResponse(
+        await issueGetUri(
+            Uri.parse('https://www.dartdocs.org/documentation/pkg/latest/')),
+        'https://pub.dartlang.org/documentation/pkg/latest/',
+      );
+    });
+
+    tScopedTest('/doc', () async {
+      for (var path in redirectPaths.keys) {
+        final redirectUrl =
+            'https://www.dartlang.org/tools/pub/${redirectPaths[path]}';
+        expectRedirectResponse(await issueGet(path), redirectUrl);
+      }
+    });
+
+    tScopedTest('/search?q=foobar', () async {
+      expectRedirectResponse(await issueGet('/search?q=foobar'),
+          'https://pub.dartlang.org/packages?q=foobar');
+    });
+
+    tScopedTest('/search?q=foobar&page=2', () async {
+      expectRedirectResponse(await issueGet('/search?q=foobar&page=2'),
+          'https://pub.dartlang.org/packages?q=foobar&page=2');
+    });
+  });
+}

--- a/app/test/frontend/handlers_redirects_test.dart
+++ b/app/test/frontend/handlers_redirects_test.dart
@@ -49,6 +49,11 @@ void main() {
       }
     });
 
+    tScopedTest('/flutter/plugins', () async {
+      expectRedirectResponse(
+          await issueGet('/flutter/plugins'), '/flutter/packages');
+    });
+
     tScopedTest('/search?q=foobar', () async {
       expectRedirectResponse(await issueGet('/search?q=foobar'),
           'https://pub.dartlang.org/packages?q=foobar');
@@ -57,6 +62,19 @@ void main() {
     tScopedTest('/search?q=foobar&page=2', () async {
       expectRedirectResponse(await issueGet('/search?q=foobar&page=2'),
           'https://pub.dartlang.org/packages?q=foobar&page=2');
+    });
+
+    tScopedTest('/server', () async {
+      expectRedirectResponse(await issueGet('/server'), '/');
+    });
+
+    tScopedTest('/server/packages with parameters', () async {
+      expectRedirectResponse(
+          await issueGet('/server/packages?sort=top'), '/packages?sort=top');
+    });
+
+    tScopedTest('/server/packages', () async {
+      expectRedirectResponse(await issueGet('/server/packages'), '/packages');
     });
   });
 }

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -9,9 +9,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
-import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
-import 'package:pub_dartlang_org/frontend/handlers_redirects.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
@@ -22,7 +20,6 @@ import 'package:pub_dartlang_org/shared/search_service.dart';
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';
 
-import 'handlers_documentation_test.dart' show DartdocBackendMock;
 import 'handlers_test_utils.dart';
 import 'utils.dart';
 
@@ -378,76 +375,8 @@ void main() {
         expectRedirectResponse(await issueGet('/server/packages'), '/packages');
       });
 
-      tScopedTest('/doc', () async {
-        for (var path in redirectPaths.keys) {
-          final redirectUrl =
-              'https://www.dartlang.org/tools/pub/${redirectPaths[path]}';
-          expectRedirectResponse(await issueGet(path), redirectUrl);
-        }
-      });
-
       tScopedTest('/authorized', () async {
         await expectHtmlResponse(await issueGet('/authorized'));
-      });
-
-      tScopedTest('/search?q=foobar', () async {
-        expectRedirectResponse(await issueGet('/search?q=foobar'),
-            'https://pub.dartlang.org/packages?q=foobar');
-      });
-
-      tScopedTest('/search?q=foobar&page=2', () async {
-        expectRedirectResponse(await issueGet('/search?q=foobar&page=2'),
-            'https://pub.dartlang.org/packages?q=foobar&page=2');
-      });
-    });
-
-    group('/documentation', () {
-      test('/documentation/flutter redirect', () async {
-        expectRedirectResponse(
-          await issueGet('/documentation/flutter'),
-          'https://docs.flutter.io/',
-        );
-      });
-
-      test('/documentation/flutter/version redirect', () async {
-        expectRedirectResponse(
-          await issueGet('/documentation/flutter/version'),
-          'https://docs.flutter.io/',
-        );
-      });
-
-      test('/documentation/foo/bar redirect', () async {
-        expectRedirectResponse(
-          await issueGet('/documentation/foor/bar'),
-          'https://pub.dartlang.org/documentation/foor/bar/',
-        );
-      });
-
-      scopedTest('trailing slash redirect', () async {
-        expectRedirectResponse(
-            await issueGet('/documentation/foo'), '/documentation/foo/latest/');
-      });
-
-      scopedTest('/documentation/no_pkg redirect', () async {
-        registerDartdocBackend(new DartdocBackendMock());
-        expectRedirectResponse(await issueGet('/documentation/no_pkg/latest/'),
-            '/packages/no_pkg/versions');
-      });
-
-      test('dartdocs.org redirect', () async {
-        expectRedirectResponse(
-          await issueGetUri(
-              Uri.parse('https://dartdocs.org/documentation/pkg/latest/')),
-          'https://pub.dartlang.org/documentation/pkg/latest/',
-        );
-      });
-
-      test('www.dartdocs.org redirect', () async {
-        expectRedirectResponse(
-          await issueGetUri(
-              Uri.parse('https://www.dartdocs.org/documentation/pkg/latest/')),
-          'https://pub.dartlang.org/documentation/pkg/latest/',
-        );
       });
     });
 

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -297,11 +297,6 @@ void main() {
         await expectHtmlResponse(await issueGet('/flutter'));
       });
 
-      tScopedTest('/flutter/plugins', () async {
-        expectRedirectResponse(
-            await issueGet('/flutter/plugins'), '/flutter/packages');
-      });
-
       tScopedTest('/flutter/packages', () async {
         registerSearchService(new SearchServiceMock(
           (SearchQuery query) {
@@ -360,19 +355,6 @@ void main() {
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
         await expectHtmlResponse(await issueGet('/flutter/packages?page=2'));
-      });
-
-      tScopedTest('/server', () async {
-        expectRedirectResponse(await issueGet('/server'), '/');
-      });
-
-      tScopedTest('/server/packages with parameters', () async {
-        expectRedirectResponse(
-            await issueGet('/server/packages?sort=top'), '/packages?sort=top');
-      });
-
-      tScopedTest('/server/packages', () async {
-        expectRedirectResponse(await issueGet('/server/packages'), '/packages');
       });
 
       tScopedTest('/authorized', () async {


### PR DESCRIPTION
- part of #1756
- no change in logic
- removed a few redundant redirect tests that were already tested in handlers_documentation (they were introduced when we were serving both on `dartdoc` service and `default`).