### PR TITLE
Don't force the job processing on datastore head polling.

### DIFF
--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -49,6 +49,7 @@ class JobBackend {
         ],
       ).toString();
 
+  /// Triggers analysis/dartdoc for [package]/[version] if older than [updated].
   Future trigger(JobService service, String package,
       [String version, DateTime updated]) async {
     final pKey = _db.emptyKey.append(Package, id: package);

--- a/app/lib/job/backend.dart
+++ b/app/lib/job/backend.dart
@@ -49,7 +49,8 @@ class JobBackend {
         ],
       ).toString();
 
-  Future trigger(JobService service, String package, [String version]) async {
+  Future trigger(JobService service, String package,
+      [String version, DateTime updated]) async {
     final pKey = _db.emptyKey.append(Package, id: package);
     final pList = await _db.lookup([pKey]);
     final Package p = pList[0];
@@ -69,8 +70,9 @@ class JobBackend {
     }
 
     final isLatestStable = p.latestVersion == version;
+    final shouldProcess = updated == null || updated.isAfter(pv.created);
     await createOrUpdate(
-        service, package, version, isLatestStable, pv.created, true);
+        service, package, version, isLatestStable, pv.created, shouldProcess);
   }
 
   Future createOrUpdate(

--- a/app/lib/job/job.dart
+++ b/app/lib/job/job.dart
@@ -105,7 +105,7 @@ class JobMaintenance {
     await for (Task task in stream) {
       try {
         await jobBackend.trigger(
-            _processor.service, task.package, task.version);
+            _processor.service, task.package, task.version, task.updated);
       } catch (e, st) {
         _logger.info('Head sync failed for $task', e, st);
       }


### PR DESCRIPTION
Fixes #1744

The root cause in the issue was that each `syncDatastoreHead` triggered a new Job processing unconditionally and on their own schedule, overlapping with concurrent processing. Using the task timestamp allows us to easily filter on duplicate updates.