### PR TITLE
Use ScoreCardData for score box and score bars.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -469,8 +469,9 @@ Future<shelf.Response> _packageVersionHandlerHtml(
     final Stopwatch serviceSw = new Stopwatch()..start();
     final analysisKey =
         new AnalysisKey(selectedVersion.package, selectedVersion.version);
-    final AnalysisExtract analysisExtract =
-        await analyzerClient.getAnalysisExtract(analysisKey);
+    final card = await scoreCardBackend.getScoreCardData(
+        analysisKey.package, analysisKey.version,
+        onlyCurrent: true);
     final AnalysisView analysisView =
         await analyzerClient.getAnalysisView(analysisKey);
     _packageAnalysisLatencyTracker.add(serviceSw.elapsed);
@@ -490,7 +491,7 @@ Future<shelf.Response> _packageVersionHandlerHtml(
         latestStable,
         latestDev,
         versions.length,
-        analysisExtract,
+        card,
         analysisView);
     _packageDoneLatencyTracker.add(serviceSw.elapsed);
 

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -88,7 +88,7 @@
       <li class="tab " data-name="-installing-tab-">Installing</li>
       <li class="tab" data-name="-versions-tab-">Versions</li>
       <li class="tab" data-name="-analysis-tab-">
-        <div class="score-box"><span class="number -missing" title="No analysis for this version.">--</span></div>
+        <div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div>
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
@@ -251,12 +251,12 @@ import 'package:foobar_pkg/foolib.dart';
     </td>
     <td>
 <div class="score-percent-row">
-    <div class="score-percent" style="left: 0%;">--</div>
+    <div class="score-percent" style="left: 0%;">0</div>
 </div>
 
 <div class="score-progress-row">
     <div class="score-progress-frame">
-        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
+        <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
     </div>
 </div>
 </td>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -89,7 +89,7 @@
       <li class="tab " data-name="-installing-tab-">Installing</li>
       <li class="tab" data-name="-versions-tab-">Versions</li>
       <li class="tab" data-name="-analysis-tab-">
-        <div class="score-box"><span class="number -missing" title="No analysis for this version.">--</span></div>
+        <div class="score-box"><span class="number -rotten" title="Analysis and more details.">0</span></div>
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
@@ -252,12 +252,12 @@ import 'package:foobar_pkg/foolib.dart';
     </td>
     <td>
 <div class="score-percent-row">
-    <div class="score-percent" style="left: 0%;">--</div>
+    <div class="score-percent" style="left: 0%;">0</div>
 </div>
 
 <div class="score-progress-row">
     <div class="score-progress-frame">
-        <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
+        <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
     </div>
 </div>
 </td>

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -13,6 +13,7 @@ import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
+import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_service.dart';
@@ -185,6 +186,7 @@ void main() {
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
         registerDartdocClient(new DartdocClientMock());
+        registerScoreCardBackend(new ScoreCardBackendMock());
         await expectHtmlResponse(await issueGet('/packages/foobar_pkg'));
       });
 
@@ -235,6 +237,7 @@ void main() {
         registerBackend(backend);
         registerAnalyzerClient(new AnalyzerClientMock());
         registerDartdocClient(new DartdocClientMock());
+        registerScoreCardBackend(new ScoreCardBackendMock());
         await expectHtmlResponse(
             await issueGet('/packages/foobar_pkg/versions/0.1.1+5'));
       });

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -16,6 +16,7 @@ import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
+import 'package:pub_dartlang_org/scorecard/models.dart';
 import 'package:pub_dartlang_org/shared/analyzer_service.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
@@ -237,7 +238,7 @@ class TemplateMock implements TemplateService {
       PackageVersion latestStableVersion,
       PackageVersion latestDevVersion,
       int totalNumberOfVersions,
-      AnalysisExtract extract,
+      ScoreCardData card,
       AnalysisView analysis) {
     return _response;
   }

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -7,6 +7,7 @@ library pub_dartlang_org.frontend.handlers_test;
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:pub_dartlang_org/analyzer/backend.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
@@ -16,6 +17,7 @@ import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/frontend/templates.dart';
+import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/scorecard/models.dart';
 import 'package:pub_dartlang_org/shared/analyzer_service.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
@@ -346,5 +348,53 @@ class DartdocClientMock implements DartdocClient {
       String package, String version, String relativePath,
       {Duration timeout}) async {
     return null;
+  }
+}
+
+class ScoreCardBackendMock implements ScoreCardBackend {
+  @override
+  Future<ScoreCardData> getScoreCardData(
+      String packageName, String packageVersion,
+      {bool onlyCurrent}) {
+    return null;
+  }
+
+  @override
+  Future<PackageStatus> getPackageStatus(String package, String version) {
+    throw new UnimplementedError();
+  }
+
+  @override
+  Future deleteOldEntries() {
+    throw new UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, ReportData>> loadReports(
+      String packageName, String packageVersion,
+      {List<String> reportTypes}) {
+    throw new UnimplementedError();
+  }
+
+  @override
+  Future<bool> shouldUpdateReport(
+      String packageName, String packageVersion, String reportType,
+      {bool includeDiscontinued = false,
+      bool includeObsolete = false,
+      Duration successThreshold = const Duration(days: 30),
+      Duration failureThreshold = const Duration(days: 1),
+      DateTime updatedAfter}) {
+    throw new UnimplementedError();
+  }
+
+  @override
+  Future updateReport(
+      String packageName, String packageVersion, ReportData data) {
+    throw new UnimplementedError();
+  }
+
+  @override
+  Future updateScoreCard(String packageName, String packageVersion) {
+    throw new UnimplementedError();
   }
 }

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -122,7 +122,7 @@ void main() {
           testPackageVersion,
           devPackageVersion,
           1,
-          new AnalysisExtract(analysisStatus: AnalysisStatus.success),
+          new ScoreCardData(reportTypes: ['pana']),
           new MockAnalysisView()
             ..analysisStatus = AnalysisStatus.success
             ..timestamp = new DateTime(2018, 02, 05)
@@ -160,7 +160,7 @@ void main() {
           testPackageVersion,
           devPackageVersion,
           1,
-          new AnalysisExtract(analysisStatus: AnalysisStatus.success),
+          new ScoreCardData(reportTypes: ['pana']),
           new MockAnalysisView()
             ..analysisStatus = AnalysisStatus.success
             ..timestamp = new DateTime(2018, 02, 05)
@@ -198,11 +198,11 @@ void main() {
           flutterPackageVersion,
           flutterPackageVersion,
           1,
-          new AnalysisExtract(
-            health: 0.99,
-            maintenance: 0.99,
-            popularity: 0.3,
-            platforms: ['flutter'],
+          new ScoreCardData(
+            healthScore: 0.99,
+            maintenanceScore: 0.99,
+            popularityScore: 0.3,
+            platformTags: ['flutter'],
           ),
           new MockAnalysisView()
             ..analysisStatus = AnalysisStatus.success
@@ -221,7 +221,7 @@ void main() {
           testPackageVersion,
           testPackageVersion,
           1,
-          new AnalysisExtract(analysisStatus: AnalysisStatus.outdated),
+          new ScoreCardData(flags: [PackageFlags.isObsolete]),
           new MockAnalysisView(
             analysisStatus: AnalysisStatus.outdated,
             timestamp: new DateTime(2018, 02, 05),
@@ -240,7 +240,7 @@ void main() {
           testPackageVersion,
           testPackageVersion,
           1,
-          new AnalysisExtract(analysisStatus: AnalysisStatus.discontinued),
+          new ScoreCardData(flags: [PackageFlags.isDiscontinued]),
           new MockAnalysisView(
             analysisStatus: AnalysisStatus.discontinued,
             timestamp: new DateTime(2018, 02, 05),
@@ -273,8 +273,10 @@ void main() {
           testPackageVersion,
           testPackageVersion,
           1,
-          new AnalysisExtract(
-              analysisStatus: AnalysisStatus.legacy, popularity: 0.5),
+          new ScoreCardData(
+            popularityScore: 0.5,
+            flags: [PackageFlags.isLegacy],
+          ),
           analysisView);
 
       expectGoldenFile(html, 'pkg_show_page_legacy.html');
@@ -291,10 +293,12 @@ void main() {
           await new File('$goldenDir/analysis_tab_http.json').readAsString();
       final view = new AnalysisView(new AnalysisData.fromJson(
           json.decode(content) as Map<String, dynamic>));
-      final extract = new AnalysisExtract(
-          health: view.health, maintenance: 0.9, popularity: 0.23);
+      final card = new ScoreCardData(
+          healthScore: view.health,
+          maintenanceScore: 0.9,
+          popularityScore: 0.23);
       final String html = templates.renderAnalysisTab(
-          'http', '>=1.23.0-dev.0.0 <2.0.0', extract, view);
+          'http', '>=1.23.0-dev.0.0 <2.0.0', card, view);
       expectGoldenFile(html, 'analysis_tab_http.html', isFragment: true);
     });
 
@@ -302,10 +306,10 @@ void main() {
       final String html = templates.renderAnalysisTab(
           'pkg_foo',
           '>=1.25.0-dev.9.0 <2.0.0',
-          new AnalysisExtract(
-            health: 0.90234,
-            maintenance: 0.8932343,
-            popularity: 0.2323232,
+          new ScoreCardData(
+            healthScore: 0.90234,
+            maintenanceScore: 0.8932343,
+            popularityScore: 0.2323232,
           ),
           new MockAnalysisView(
             analysisStatus: AnalysisStatus.failure,
@@ -347,7 +351,7 @@ void main() {
       final String html = templates.renderAnalysisTab(
           'pkg_foo',
           null,
-          null,
+          new ScoreCardData(),
           new AnalysisView(new AnalysisData(
             analysis: 1,
             packageName: 'foo',
@@ -367,7 +371,7 @@ void main() {
       final String html = templates.renderAnalysisTab(
           'pkg_foo',
           null,
-          null,
+          new ScoreCardData(flags: [PackageFlags.isObsolete]),
           new AnalysisView(new AnalysisData(
             analysis: 1,
             packageName: 'foo',


### PR DESCRIPTION
Part of the ScoreCard migration:
- removed more use of `AnalysisStatus`
- also fixing score rendering consistency:
  - popularity should be always rendered, and with that, we should always render an overall score (even with legacy or too old packages)
  - removed popup label on the circle: "No analysis for this version." (we provide suggestions and other info, there is no need to discourage clicks)
  - the health and maintenance score on legacy packages should be `--` rather than `0`
