### PR TITLE
Fix /doc redirect.

### DIFF
--- a/app/lib/frontend/handlers_redirects.dart
+++ b/app/lib/frontend/handlers_redirects.dart
@@ -32,7 +32,7 @@ shelf.Response tryHandleRedirects(shelf.Request request) {
   if (handler != null) {
     return handler(request);
   }
-  if (path.startsWith('/doc')) {
+  if (path == '/doc' || path.startsWith('/doc/')) {
     return _docRedirectHandler(request);
   }
   return null;

--- a/app/test/frontend/handlers_redirects_test.dart
+++ b/app/test/frontend/handlers_redirects_test.dart
@@ -49,6 +49,12 @@ void main() {
       }
     });
 
+    // making sure /doc does not catches /documentation request
+    tScopedTest('/documentation', () async {
+      expectRedirectResponse(await issueGet('/documentation/pana/'),
+          '/documentation/pana/latest/');
+    });
+
     tScopedTest('/flutter/plugins', () async {
       expectRedirectResponse(
           await issueGet('/flutter/plugins'), '/flutter/packages');


### PR DESCRIPTION
After the handler refactor of redirects, the `/doc` handler got precedence over `/documentation`. I've also added a test to catch this next time.