### PR TITLE
Upgrade runtime SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,27 @@ jobs:
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="app"
-      dart: 2.1.0-dev.9.2
+      dart: 2.2.0-dev.0.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="app"
-      dart: 2.1.0-dev.9.2
+      dart: 2.2.0-dev.0.0
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="pkg/_popularity"
-      dart: 2.1.0-dev.9.2
+      dart: 2.2.0-dev.0.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="pkg/_popularity"
-      dart: 2.1.0-dev.9.2
+      dart: 2.2.0-dev.0.0
     - stage: smoke_test
       script: ./tool/travis.sh dartfmt dartanalyzer
       env: PKG="pkg/pub_dartdoc"
-      dart: 2.1.0-dev.9.2
+      dart: 2.2.0-dev.0.0
     - stage: unit_test
       script: ./tool/travis.sh test
       env: PKG="pkg/pub_dartdoc"
-      dart: 2.1.0-dev.9.2
+      dart: 2.2.0-dev.0.0
 
 stages:
   - smoke_test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Keep version in-sync with .travis.yml, .mono_repo.yml and app/lib/shared/versions.dart
-FROM google/dart-runtime-base:2.1.0-dev.9.2
+FROM google/dart-runtime-base:2.2.0-dev.0.0
 
 # `apt-mark hold dart` ensures that Dart is not upgraded with the other packages
 #   We want to make sure SDK upgrades are explicit.

--- a/app/.mono_repo.yml
+++ b/app/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.1.0-dev.9.2
+  - 2.2.0-dev.0.0
 
 stages:
   - smoke_test:

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -34,7 +34,7 @@ final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 final String gcBeforeRuntimeVersion = '2018.08.27';
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
-final String runtimeSdkVersion = '2.1.0-dev.9.2';
+final String runtimeSdkVersion = '2.2.0-dev.0.0';
 final String toolEnvSdkVersion = '2.1.0';
 
 // keep in-sync with app/pubspec.yaml

--- a/pkg/pub_dartdoc/.mono_repo.yml
+++ b/pkg/pub_dartdoc/.mono_repo.yml
@@ -1,6 +1,6 @@
 # See https://github.com/dart-lang/mono_repo for details
 dart:
-  - 2.1.0-dev.9.2
+  - 2.2.0-dev.0.0
 
 stages:
   - smoke_test:


### PR DESCRIPTION
Upgrading to `dartdoc 0.25` requires 2.1.0 minimum. It is very likely that at some point we'll need to upgrade to a -dev release, so I'd rather upgrade to the 2.2-dev branch already.