### PR TITLE
Load the previous ScoreCard reports when the current one is missing.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -471,7 +471,7 @@ Future<shelf.Response> _packageVersionHandlerHtml(
         new AnalysisKey(selectedVersion.package, selectedVersion.version);
     final card = await scoreCardBackend.getScoreCardData(
         analysisKey.package, analysisKey.version,
-        onlyCurrent: true);
+        onlyCurrent: false);
     final AnalysisView analysisView =
         await analyzerClient.getAnalysisView(analysisKey);
     _packageAnalysisLatencyTracker.add(serviceSw.elapsed);
@@ -671,8 +671,11 @@ Future<shelf.Response> _apiPackageMetricsHandler(shelf.Request request) async {
     'scorecard': data.toJson(),
   };
   if (request.requestedUri.queryParameters.containsKey('reports')) {
-    final reports =
-        await scoreCardBackend.loadReports(packageName, data.packageVersion);
+    final reports = await scoreCardBackend.loadReports(
+      packageName,
+      data.packageVersion,
+      runtimeVersion: data.runtimeVersion,
+    );
     result['reports'] =
         reports.map((k, report) => new MapEntry(k, report.toJson()));
   }

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -129,10 +129,14 @@ class ScoreCardBackend {
 
   /// Load and deserialize the reports for the given package and version.
   Future<Map<String, ReportData>> loadReports(
-      String packageName, String packageVersion,
-      {List<String> reportTypes}) async {
+    String packageName,
+    String packageVersion, {
+    List<String> reportTypes,
+    String runtimeVersion,
+  }) async {
     reportTypes ??= [ReportType.pana, ReportType.dartdoc];
-    final key = scoreCardKey(packageName, packageVersion);
+    final key = scoreCardKey(packageName, packageVersion,
+        runtimeVersion: runtimeVersion);
 
     final list = await _db.lookup(reportTypes
         .map((type) => key.append(ScoreCardReport, id: type))

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -37,9 +37,12 @@ class AnalyzerClient {
 
   Future<AnalysisView> getAnalysisView(AnalysisKey key) async {
     final card = await scoreCardBackend
-        .getScoreCardData(key.package, key.version, onlyCurrent: true);
-    final reports =
-        await scoreCardBackend.loadReports(key.package, key.version);
+        .getScoreCardData(key.package, key.version, onlyCurrent: false);
+    final reports = await scoreCardBackend.loadReports(
+      key.package,
+      key.version,
+      runtimeVersion: card.runtimeVersion,
+    );
     final PanaReport panaReport = reports[ReportType.pana];
     final DartdocReport dartdocReport = reports[ReportType.dartdoc];
     return new AnalysisView._(card, panaReport, dartdocReport);

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -367,7 +367,7 @@ class ScoreCardBackendMock implements ScoreCardBackend {
   @override
   Future<Map<String, ReportData>> loadReports(
       String packageName, String packageVersion,
-      {List<String> reportTypes}) {
+      {List<String> reportTypes, String runtimeVersion}) {
     throw new UnimplementedError();
   }
 


### PR DESCRIPTION
I thought that strict load is useful, but it prevents us to quickly roll out a new release, a fallback by default seems to better.