### PR TITLE
Migrate TaskSource: from Analysis instance to ScoreCard.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -102,7 +102,7 @@ Future _main(FrontendEntryMessage message) async {
         new IndexUpdateTaskSource(db.dbService, batchIndexUpdater),
         new DatastoreHeadTaskSource(
           db.dbService,
-          TaskSourceModel.analysis,
+          TaskSourceModel.scorecard,
           sleep: const Duration(minutes: 10),
           skipHistory: true,
         ),


### PR DESCRIPTION
With this change, the search service will scan for changes in ScoreCard, and will update itself when a scorecard gets updated. (also removing the dependency on the `Analysis` object)