### PR TITLE
More strict reserved names

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -328,6 +328,15 @@ class GCloudPackageRepository extends PackageRepository {
             '${version.package} already exists.');
       }
 
+      // reserved package names for the Dart team
+      if (package == null &&
+          matchesReservedPackageName(newVersion.package) &&
+          !newVersion.uploaderEmail.endsWith('@google.com')) {
+        await T.rollback();
+        throw new GenericProcessingException(
+            'Package name ${newVersion.package} is reserved.');
+      }
+
       // If the package does not exist, then we create a new package.
       if (package == null) package = _newPackageFromVersion(db, newVersion);
 

--- a/app/lib/frontend/name_tracker.dart
+++ b/app/lib/frontend/name_tracker.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'package:logging/logging.dart';
 import 'package:gcloud/db.dart';
 
+import '../shared/utils.dart';
+
 import 'models.dart';
 
 final _logger = new Logger('pub.name_tracker');
@@ -28,21 +30,18 @@ class NameTracker {
   /// Add a package name to the tracker.
   void add(String name) {
     _names.add(name);
-    _reducedNames.add(_reduce(name));
+    _reducedNames.add(reducePackageName(name));
   }
 
   /// Whether the package was already added to the tracker.
   bool hasPackage(String name) => _names.contains(name);
 
   /// Whether the [name] has a conflicting package that already exists.
-  bool hasConflict(String name) => _reducedNames.contains(_reduce(name));
+  bool hasConflict(String name) =>
+      _reducedNames.contains(reducePackageName(name));
 
   /// Whether to accept the upload attempt of a given package [name].
   bool accept(String name) => hasPackage(name) || !hasConflict(name);
-
-  String _reduce(String name) =>
-      // we allow only `_` as part of the name.
-      name.replaceAll('_', '').toLowerCase();
 
   int get length => _names.length;
 

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -182,7 +182,7 @@ void validatePackageName(String name) {
     throw new GenericProcessingException(
         'Package name must begin with a letter or underscore.');
   }
-  if (_reservedWords.contains(name.toLowerCase())) {
+  if (_reservedWords.contains(reducePackageName(name))) {
     throw new GenericProcessingException(
         'Package name must not be a reserved word in Dart.');
   }

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -169,6 +169,16 @@ const List<String> _reservedWords = const <String>[
   'with'
 ];
 
+final _reservedPackageNames = <String>[
+  'in_app_purchase',
+  'location_background',
+  'webview_flutter',
+].map(reducePackageName).toList();
+
+/// Whether the [name] is (very similar) to a reserved package name.
+bool matchesReservedPackageName(String name) =>
+    _reservedPackageNames.contains(reducePackageName(name));
+
 /// Sanity checks if the user would upload a package with a modified pub client
 /// that skips these verifications.
 /// TODO: share code to use the same validations as in

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -203,6 +203,11 @@ void validatePackageName(String name) {
   }
 }
 
+/// Removes extra characters from the package name
+String reducePackageName(String name) =>
+    // we allow only `_` as part of the name.
+    name.replaceAll('_', '').toLowerCase();
+
 List<List<T>> _sliceList<T>(List<T> list, int limit) {
   if (list.length <= limit) return [list];
   final int maxPageIndex = (list.length - 1) ~/ limit;

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -77,6 +77,11 @@ void main() {
     test('accept lower-case', () {
       validatePackageName('my_package'); // does not throw
     });
+
+    test('reject reserved words', () {
+      expect(() => validatePackageName('do'), throwsException);
+      expect(() => validatePackageName('d_o'), throwsException);
+    });
   });
 
   group('boundedList', () {


### PR DESCRIPTION
- reserved words with underscores are now rejected (e.g. `return_` or `retur_n`)
- introducing the ability to reserve package names for the Dart team for later publishing, and adding a few not-yet-published Flutter plugins.