### PR TITLE
Use runtimeVersion as the key in Job.

### DIFF
--- a/app/lib/job/model.dart
+++ b/app/lib/job/model.dart
@@ -13,6 +13,9 @@ enum JobStatus { none, success, skipped, failed, aborted }
 
 @Kind(name: 'Job', idType: IdType.String)
 class Job extends ExpandoModel {
+  @StringProperty()
+  String runtimeVersion;
+
   @JobServiceProperty()
   JobService service;
 
@@ -35,9 +38,6 @@ class Job extends ExpandoModel {
   DateTime lockedUntil;
 
   // fields for state = available
-
-  @StringProperty()
-  String runtimeVersion;
 
   @IntProperty()
   int priority;

--- a/index.yaml
+++ b/index.yaml
@@ -8,12 +8,14 @@ indexes:
 
 - kind: Job
   properties:
+  - name: runtimeVersion
   - name: service
   - name: state
   - name: priority
 
 - kind: Job
   properties:
+  - name: runtimeVersion
   - name: service
   - name: state
   - name: lockedUntil


### PR DESCRIPTION
- Instead of rewriting the entire thing for `ScoreCard` I figured it would be the best to just adapt `Job` a bit.
- The GC will be done in a subsequent PR.
- Before the next deploy the indexes should be updated, but not cleared (so that the old releases will continue to work too).