### PR TITLE
Prefer current runtime over future runtimes in dartdoc serving.

### DIFF
--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -187,7 +187,18 @@ class DartdocBackend {
       if (hasServing) {
         completedList.removeWhere((entry) => !entry.isServing);
       }
-      completedList.sort((a, b) => -a.timestamp.compareTo(b.timestamp));
+      completedList.sort((a, b) {
+        // content goes first
+        if (a.hasContent && !b.hasContent) return -1;
+        if (!a.hasContent && b.hasContent) return 1;
+        // next release goes to the back of the list
+        final rva = a.runtimeVersion.compareTo(shared_versions.runtimeVersion);
+        final rvb = b.runtimeVersion.compareTo(shared_versions.runtimeVersion);
+        if (rva > 0 && rvb <= 0) return 1;
+        if (rva <= 0 && rvb > 1) return -1;
+        // otherwise compare by timestamp descending
+        return -a.timestamp.compareTo(b.timestamp);
+      });
       return completedList.firstWhere((entry) => entry.hasContent,
           orElse: () => completedList.first);
     }

--- a/app/lib/dartdoc/backend.dart
+++ b/app/lib/dartdoc/backend.dart
@@ -178,29 +178,20 @@ class DartdocBackend {
     }
 
     Future<DartdocEntry> loadVersion(String v) async {
-      final List<DartdocEntry> completedList =
+      final List<DartdocEntry> entries =
           await _listEntries(storage_path.entryPrefix(package, v));
-      if (completedList.isEmpty) return null;
-      final hasServing =
-          completedList.any((entry) => entry.isServing && entry.hasContent);
-      // don't remove non-serving entries if they are the only ones with content
-      if (hasServing) {
-        completedList.removeWhere((entry) => !entry.isServing);
+      // utility to remove anything not matching pred, unless that is everything
+      void retainIfAny(bool pred(DartdocEntry entry)) {
+        if (entries.any(pred)) {
+          entries.retainWhere(pred);
+        }
       }
-      completedList.sort((a, b) {
-        // content goes first
-        if (a.hasContent && !b.hasContent) return -1;
-        if (!a.hasContent && b.hasContent) return 1;
-        // next release goes to the back of the list
-        final rva = a.runtimeVersion.compareTo(shared_versions.runtimeVersion);
-        final rvb = b.runtimeVersion.compareTo(shared_versions.runtimeVersion);
-        if (rva > 0 && rvb <= 0) return 1;
-        if (rva <= 0 && rvb > 1) return -1;
-        // otherwise compare by timestamp descending
-        return -a.timestamp.compareTo(b.timestamp);
-      });
-      return completedList.firstWhere((entry) => entry.hasContent,
-          orElse: () => completedList.first);
+
+      retainIfAny((e) => e.isServing && e.hasContent);
+      retainIfAny((e) => e.hasContent);
+      retainIfAny((e) => e.runtimeVersion == shared_versions.runtimeVersion);
+      entries.sort((a, b) => -a.timestamp.compareTo(b.timestamp));
+      return entries.isEmpty ? null : entries.first;
     }
 
     DartdocEntry entry;

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -19,13 +19,9 @@ part 'models.g.dart';
 /// Describes the details of a dartdoc-generated content.
 @JsonSerializable()
 class DartdocEntry {
-  /// Unique identifier of the entry, generated via a random UUID.
+  /// Random uuid for lookup in storage bucket, see [storage_path].
   final String uuid;
-
-  /// The package name.
   final String packageName;
-
-  /// The package version.
   final String packageVersion;
 
   /// Whether the [packageVersion] is the latest stable version of the package

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -16,23 +16,58 @@ import 'storage_path.dart' as storage_path;
 
 part 'models.g.dart';
 
+/// Describes the details of a dartdoc-generated content.
 @JsonSerializable()
 class DartdocEntry {
+  /// Unique identifier of the entry, generated via a random UUID.
   final String uuid;
+
+  /// The package name.
   final String packageName;
+
+  /// The package version.
   final String packageVersion;
+
+  /// Whether the [packageVersion] is the latest stable version of the package
+  /// (at the time of the entry being created, but may be updated later).
   final bool isLatest;
+
+  /// Whether the package version is too old. This is never set if the version
+  /// is the latest stable version of the package..
   final bool isObsolete;
+
+  /// Whether the package version uses Flutter.
   final bool usesFlutter;
+
+  /// The pub site runtime version of the runtime that generated the content.
   final String runtimeVersion;
+
+  /// The SDK version that was used to fetch dependencies.
   final String sdkVersion;
+
+  /// The version of `package:dartdoc` that generated the content.
   final String dartdocVersion;
+
+  /// The version of Flutter that was used to fetch dependencies.
   final String flutterVersion;
+
+  /// The version of pub site customization over the dartdoc-generated HTML.
+  /// See [versions.customizationVersion].
   final String customizationVersion;
+
+  /// When the content was generated.
   final DateTime timestamp;
+
+  /// Whether the dependencies were resolved successfully.
   final bool depsResolved;
+
+  /// Whether the dartdoc process produced valid content.
   final bool hasContent;
+
+  /// The size of the compressed archive file.
   final int archiveSize;
+
+  /// The size of all the individual files, uncompressed.
   final int totalSize;
 
   DartdocEntry({
@@ -91,6 +126,8 @@ class DartdocEntry {
 
   Map<String, dynamic> toJson() => _$DartdocEntryToJson(this);
 
+  /// Whether the version should be serving with (e.g. it is not a known
+  /// coordinated upgrade of the templates and styles).
   bool get isServing => versions.shouldServeDartdoc(runtimeVersion);
 
   /// The path of the status while the upload is in progress


### PR DESCRIPTION
This is to address the consistency issue: when there is a new release and the dartdoc content is generated, we shouldn't immediately expose it (before the traffic was migrated). With this change we'll serve only if the new release generated content while the old one did not.