### PR TITLE
Use lookup candidates in search.

### DIFF
--- a/app/lib/search/index_simple.dart
+++ b/app/lib/search/index_simple.dart
@@ -503,6 +503,7 @@ class _TextResults {
   _TextResults(this.pkgScore, this.topApiPages);
 }
 
+/// Represents an evaluated score as an {id: score} map.
 class Score {
   final Map<String, double> _values;
 
@@ -547,6 +548,9 @@ class Score {
     return new Score(result);
   }
 
+  /// Remove insignificant values below a certain threshold:
+  /// - [fraction] of the maximum value
+  /// - [minValue] as an absolute minimum filter
   Score removeLowValues({double fraction, double minValue}) {
     assert(minValue != null || fraction != null);
     double threshold = minValue;
@@ -567,6 +571,7 @@ class Score {
     return new Score(result);
   }
 
+  /// Keeps the scores only for values in [keys].
   Score project(Iterable<String> keys) {
     final result = <String, double>{};
     for (String key in keys) {
@@ -577,6 +582,7 @@ class Score {
     return new Score(result);
   }
 
+  /// Transfer the score values with [f].
   Score map(double f(String key, double value)) {
     final result = <String, double>{};
     for (String key in _values.keys) {
@@ -586,6 +592,7 @@ class Score {
   }
 }
 
+/// The weighted tokens used for the final search.
 class TokenMatch {
   final Map<String, double> _tokenWeights = <String, double>{};
   double _maxWeight;
@@ -605,10 +612,18 @@ class TokenMatch {
   Map<String, double> get tokenWeights => new Map.unmodifiable(_tokenWeights);
 }
 
+/// Stores a token -> documentId inverted index with weights.
 class TokenIndex {
+  /// {id: hash} map to detect if a document update or removal is a no-op.
   final _textHashes = <String, String>{};
+
+  /// Maps token Strings to a weighted map of document ids.
   final _inverseIds = <String, Map<String, double>>{};
-  final _inverseNgrams = <String, Set<String>>{};
+
+  /// Maps lookup candidates to their original token form.
+  final _lookupCandidates = <String, Set<String>>{};
+
+  /// {id: size} map to store a value representative to the document length
   final _docSizes = <String, double>{};
   final int _minLength;
 
@@ -634,8 +649,15 @@ class TokenIndex {
     for (String token in tokens.keys) {
       final Map<String, double> weights =
           _inverseIds.putIfAbsent(token, () => <String, double>{});
+      // on the first insert of an entry, we populate the similarity candidates
+      if (weights.isEmpty) {
+        for (String reduced in deriveLookupCandidates(token)) {
+          _lookupCandidates
+              .putIfAbsent(reduced, () => new Set<String>())
+              .add(token);
+        }
+      }
       weights[id] = math.max(weights[id] ?? 0.0, tokens[token]);
-      _inverseNgrams.putIfAbsent(token, () => _ngrams(token, _minLength));
     }
     // Document size is a highly scaled-down proxy of the length.
     final docSize = 1 + math.log(1 + tokens.length) / 100;
@@ -646,13 +668,21 @@ class TokenIndex {
   void remove(String id) {
     _textHashes.remove(id);
     _docSizes.remove(id);
-    final List<String> removeKeys = [];
+    final List<String> removeTokens = [];
     _inverseIds.forEach((String key, Map<String, double> weights) {
       weights.remove(id);
-      if (weights.isEmpty) removeKeys.add(key);
+      if (weights.isEmpty) removeTokens.add(key);
     });
-    removeKeys.forEach(_inverseIds.remove);
-    removeKeys.forEach(_inverseNgrams.remove);
+    removeTokens.forEach(_inverseIds.remove);
+    removeTokens.forEach((token) {
+      for (String reduced in deriveLookupCandidates(token)) {
+        final set = _lookupCandidates[reduced];
+        set.remove(token);
+        if (set.isEmpty) {
+          _lookupCandidates.remove(reduced);
+        }
+      }
+    });
   }
 
   /// Match the text against the corpus and return the tokens that have match.
@@ -665,13 +695,21 @@ class TokenIndex {
 
     // Check which tokens have documents, and assign their weight.
     for (String token in tokens.keys) {
-      final tokenNgrams = _ngrams(token, _minLength);
-      for (String candidate in _inverseIds.keys) {
+      final candidates = new Set<String>();
+      candidates.add(token);
+      for (String reduced in deriveLookupCandidates(token)) {
+        final set = _lookupCandidates[reduced];
+        if (set != null) {
+          candidates.addAll(set);
+        }
+      }
+      final tokenNgrams = ngrams(token, _minLength, 6);
+      for (String candidate in candidates) {
         double candidateWeight = 0.0;
         if (token == candidate) {
           candidateWeight = 1.0;
         } else {
-          final candidateNgrams = _inverseNgrams[candidate];
+          final candidateNgrams = ngrams(candidate, _minLength, 6);
           candidateWeight = _ngramSimilarity(tokenNgrams, candidateNgrams);
         }
         candidateWeight *= tokens[token];
@@ -703,6 +741,8 @@ class TokenIndex {
     return intersectionWeight / supersetWeight;
   }
 
+  /// Returns an {id: score} map of the documents stored in the [TokenIndex].
+  /// The tokens in [tokenMatch] will be used to calculate a weighted sum of scores.
   Map<String, double> scoreDocs(TokenMatch tokenMatch,
       {double weight = 1.0, int wordCount = 1}) {
     // Summarize the scores for the documents.
@@ -738,21 +778,4 @@ class TokenIndex {
   Map<String, double> search(String text) {
     return scoreDocs(lookupTokens(text));
   }
-}
-
-const int _minNgram = 1;
-const int _maxNgram = 6;
-
-Set<String> _ngrams(String text, int minLength) {
-  final ngrams = new Set<String>();
-  for (int ngramLength = math.max(_minNgram, minLength);
-      ngramLength <= _maxNgram;
-      ngramLength++) {
-    if (text.length > ngramLength) {
-      for (int i = 0; i <= text.length - ngramLength; i++) {
-        ngrams.add(text.substring(i, i + ngramLength));
-      }
-    }
-  }
-  return ngrams;
 }

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -128,17 +128,17 @@ Set<String> ngrams(String input, int minLength, int maxLength) {
 }
 
 /// Generates lookup candidates that are, either:
-/// - derived by deleting one character from [input],
-/// - are the prefix part of [input] (min 4 characters)
-/// - are the suffix part of [input] (min 4 characters)
-Set<String> deriveLookupCandidates(String input) {
+/// - derived by deleting one character from [token],
+/// - are the prefix part of [token] (min 4 characters)
+/// - are the suffix part of [token] (min 4 characters)
+Set<String> deriveLookupCandidates(String token) {
   final set = new Set<String>();
-  if (input.length <= 3) {
+  if (token.length <= 3) {
     return set;
   }
-  for (int i = 0; i < input.length; i++) {
-    final prefix = i == 0 ? '' : input.substring(0, i);
-    final suffix = i == input.length - 1 ? '' : input.substring(i + 1);
+  for (int i = 0; i < token.length; i++) {
+    final prefix = i == 0 ? '' : token.substring(0, i);
+    final suffix = i == token.length - 1 ? '' : token.substring(i + 1);
     if (prefix.length > 3) {
       set.add(prefix);
     }

--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -111,3 +111,41 @@ Map<String, double> tokenize(String originalText) {
 }
 
 bool _isLower(String c) => c.toLowerCase() == c;
+
+/// Generates the N-grams of [input], which are continuous character strings of
+/// length between [minLength] and [maxLength] (both inclusive).
+/// Eg. abc -> ab, bc
+Set<String> ngrams(String input, int minLength, int maxLength) {
+  final ngrams = new Set<String>();
+  for (int length = minLength; length <= maxLength; length++) {
+    if (input.length > length) {
+      for (int i = 0; i <= input.length - length; i++) {
+        ngrams.add(input.substring(i, i + length));
+      }
+    }
+  }
+  return ngrams;
+}
+
+/// Generates lookup candidates that are, either:
+/// - derived by deleting one character from [input],
+/// - are the prefix part of [input] (min 4 characters)
+/// - are the suffix part of [input] (min 4 characters)
+Set<String> deriveLookupCandidates(String input) {
+  final set = new Set<String>();
+  if (input.length <= 3) {
+    return set;
+  }
+  for (int i = 0; i < input.length; i++) {
+    final prefix = i == 0 ? '' : input.substring(0, i);
+    final suffix = i == input.length - 1 ? '' : input.substring(i + 1);
+    if (prefix.length > 3) {
+      set.add(prefix);
+    }
+    if (suffix.length > 3) {
+      set.add(suffix);
+    }
+    set.add(prefix + suffix);
+  }
+  return set;
+}

--- a/app/test/search/api_doc_page_test.dart
+++ b/app/test/search/api_doc_page_test.dart
@@ -118,7 +118,7 @@ void main() {
           new SearchQuery.parse(query: 'web page', order: SearchOrder.text));
       expect(json.decode(json.encode(result)), {
         'indexUpdated': isNotNull,
-        'totalCount': 2,
+        'totalCount': 1,
         'packages': [
           {
             'package': 'foo',
@@ -127,13 +127,7 @@ void main() {
               {'title': null, 'path': 'generator.html'},
             ],
           },
-          {
-            'package': 'other_with_api',
-            'score': closeTo(0.032, 0.001), // find serveWebPages
-            'apiPages': [
-              {'title': null, 'path': 'serve.html'},
-            ],
-          },
+          // serveWebPages get low score
           // should not contain `other_without_api`
         ],
       });

--- a/app/test/search/in_app_payments_test.dart
+++ b/app/test/search/in_app_payments_test.dart
@@ -51,7 +51,7 @@ Add _In-App Payments_ to your Flutter app with this plugin.''')));
         'packages': [
           {
             'package': 'flutter_iap',
-            'score': closeTo(0.840, 0.001),
+            'score': closeTo(0.796, 0.001),
           },
         ],
       });

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -124,4 +124,62 @@ Other useful methods will be added soon...
       });
     });
   });
+
+  group('ngrams', () {
+    test('small input', () {
+      expect(ngrams('', 2, 2), new Set());
+      expect(ngrams('a', 2, 2), new Set());
+      expect(ngrams('ab', 2, 2), new Set());
+    });
+
+    test('2-grams', () {
+      expect(
+          ngrams('abcdef', 2, 2), new Set.from(['ab', 'bc', 'cd', 'de', 'ef']));
+    });
+
+    test('2-3-grams', () {
+      expect(
+          ngrams('abcdef', 2, 3),
+          new Set.from([
+            'ab',
+            'bc',
+            'cd',
+            'de',
+            'ef',
+            'abc',
+            'bcd',
+            'cde',
+            'def',
+          ]));
+    });
+  });
+
+  group('deriveLookupCandidates', () {
+    test('small tokens', () {
+      expect(deriveLookupCandidates(''), new Set());
+      expect(deriveLookupCandidates('a'), new Set());
+      expect(deriveLookupCandidates('ab'), new Set());
+      expect(deriveLookupCandidates('abc'), new Set());
+    });
+
+    test('delete characters', () {
+      expect(deriveLookupCandidates('abcd'),
+          new Set.from(['abc', 'abd', 'acd', 'bcd']));
+    });
+
+    test('prefix and postfix', () {
+      expect(
+          deriveLookupCandidates('abcdef'),
+          new Set.from([
+            'abcde', // f deleted
+            'abcdf', // e deleted
+            'abcef', // d deleted
+            'abdef', // c deleted
+            'acdef', // b deleted
+            'bcdef', // a deleted
+            'abcd', // prefix of the input
+            'cdef', // postfix of the input
+          ]));
+    });
+  });
 }


### PR DESCRIPTION
- Reduces the problematic query time (#1831) from 10+ seconds to under 0.5 seconds.
- Refactored ngram and added tests.
- Added documentation to several places.

The core of the change is: for each token, we will store a set of derived tokens, e.g. for `geolocation`, we will store (among others): `geolo`, `ation`, `gelocation`, `geoocation` and many more... At the time of the search we transfer the query input the same way, and we use these lookups to get the original terms that we want to filter on.

The downside is that I've remove the cached pre-calculated ngrams, which makes the query calculate slightly more longer, but keeps the memory in balance (only <10% memory increase locally).