### PR TITLE
Added missing import dart:async

### DIFF
--- a/app/lib/frontend/handlers_atom_feed.dart
+++ b/app/lib/frontend/handlers_atom_feed.dart
@@ -4,6 +4,7 @@
 
 library pub_dartlang_org.atom_feed;
 
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:markdown/markdown.dart' as md;

--- a/app/lib/frontend/handlers_custom_api.dart
+++ b/app/lib/frontend/handlers_custom_api.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 


### PR DESCRIPTION
My editor showed warnings because `Future` wasn't defined, how did this work?