### PR TITLE
Basic verification model and access methods.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -172,7 +172,7 @@ class Backend {
       {Duration expires = const Duration(days: 1)}) async {
     final id = _uuid.v4().toString();
     final now = new DateTime.now().toUtc();
-    final verification = new models.UrlNonce()
+    final urlNonce = new models.UrlNonce()
       ..parentKey = db.emptyKey
       ..id = id
       ..created = now
@@ -182,7 +182,7 @@ class Backend {
       ..updateHash();
 
     final query = db.query<models.UrlNonce>()
-      ..filter('dedupHash =', verification.dedupHash);
+      ..filter('dedupHash =', urlNonce.dedupHash);
     // TODO: match parameters too for 100% certainty
     // The chance of mis-classification is low, but we should eventually address it.
     final count = await query
@@ -193,7 +193,7 @@ class Backend {
       return null;
     }
 
-    await db.commit(inserts: [verification]);
+    await db.commit(inserts: [urlNonce]);
     return id;
   }
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -281,8 +281,13 @@ class UrlSecret extends db.Model {
         sha256.convert(utf8.encode('$action/$parametersJson')).toString();
   }
 
-  bool isActive() =>
-      confirmed == null && expires.isAfter(new DateTime.now().toUtc());
+  bool isActive() {
+    final now = new DateTime.now().toUtc();
+    if (confirmed != null && now.difference(confirmed).inMinutes < 10) {
+      return true;
+    }
+    return expires.isAfter(now);
+  }
 }
 
 /// An extract of [Package] and [PackageVersion], for

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -248,8 +248,8 @@ abstract class SecretKey {
 /// that the given verification instance can't be reused for different purpose
 /// (e.g. filling the [parameters] for one goal and then trigger an action in
 /// another part of the application for another goal).
-@db.Kind(name: 'UrlSecret', idType: db.IdType.String)
-class UrlSecret extends db.Model {
+@db.Kind(name: 'UrlNonce', idType: db.IdType.String)
+class UrlNonce extends db.Model {
   @db.DateTimeProperty()
   DateTime created;
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -241,7 +241,8 @@ abstract class SecretKey {
   ];
 }
 
-/// A random ID, typically sent via e-mail, to verify and confirm an action.
+/// Secret random UUID, typically embedded in a URL and sent via e-mail, to
+/// verify and confirm an action.
 ///
 /// [action] identifies the trigger and scope of the verification. It ensures
 /// that the given verification instance can't be reused for different purpose

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -247,8 +247,8 @@ abstract class SecretKey {
 /// that the given verification instance can't be reused for different purpose
 /// (e.g. filling the [parameters] for one goal and then trigger an action in
 /// another part of the application for another goal).
-@db.Kind(name: 'Verification', idType: db.IdType.String)
-class Verification extends db.Model {
+@db.Kind(name: 'UrlSecret', idType: db.IdType.String)
+class UrlSecret extends db.Model {
   @db.DateTimeProperty()
   DateTime created;
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -282,12 +282,13 @@ class UrlNonce extends db.Model {
         sha256.convert(utf8.encode('$action/$parametersJson')).toString();
   }
 
+  /// Whether the entry is still waiting and it is still valid for confirmation.
   bool isActive() {
     final now = new DateTime.now().toUtc();
     if (confirmed != null && now.difference(confirmed).inMinutes < 10) {
       return true;
     }
-    return expires.isAfter(now);
+    return confirmed == null && expires.isAfter(now);
   }
 }
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -7,6 +7,7 @@ library pub_dartlang_org.appengine_repository.models;
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:crypto/crypto.dart' show sha256;
 import 'package:gcloud/db.dart' as db;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -260,6 +261,9 @@ class Verification extends db.Model {
   @db.StringProperty()
   String parametersJson;
 
+  @db.StringProperty()
+  String dedupHash;
+
   @db.DateTimeProperty()
   DateTime confirmed;
 
@@ -271,6 +275,14 @@ class Verification extends db.Model {
   set parameters(Map<String, dynamic> value) {
     parametersJson = value == null ? null : json.encode(value);
   }
+
+  void updateHash() {
+    dedupHash =
+        sha256.convert(utf8.encode('$action/$parametersJson')).toString();
+  }
+
+  bool isActive() =>
+      confirmed == null && expires.isAfter(new DateTime.now().toUtc());
 }
 
 /// An extract of [Package] and [PackageVersion], for

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -4,6 +4,7 @@
 
 library pub_dartlang_org.appengine_repository.models;
 
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:gcloud/db.dart' as db;
@@ -237,6 +238,39 @@ abstract class SecretKey {
     smtpUsername,
     smtpPassword,
   ];
+}
+
+/// A random ID, typically sent via e-mail, to verify and confirm an action.
+///
+/// [action] identifies the trigger and scope of the verification. It ensures
+/// that the given verification instance can't be reused for different purpose
+/// (e.g. filling the [parameters] for one goal and then trigger an action in
+/// another part of the application for another goal).
+@db.Kind(name: 'Verification', idType: db.IdType.String)
+class Verification extends db.Model {
+  @db.DateTimeProperty()
+  DateTime created;
+
+  @db.DateTimeProperty()
+  DateTime expires;
+
+  @db.StringProperty(required: true)
+  String action;
+
+  @db.StringProperty()
+  String parametersJson;
+
+  @db.DateTimeProperty()
+  DateTime confirmed;
+
+  Map<String, dynamic> get parameters {
+    if (parametersJson == null) return null;
+    return json.decode(parametersJson) as Map<String, dynamic>;
+  }
+
+  set parameters(Map<String, dynamic> value) {
+    parametersJson = value == null ? null : json.encode(value);
+  }
 }
 
 /// An extract of [Package] and [PackageVersion], for

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -170,12 +170,12 @@ class BackendMock implements Backend {
   }
 
   @override
-  Future<Map<String, dynamic>> confirmVerification(String action, String id) {
+  Future<Map<String, dynamic>> confirmUrlNonce(String action, String id) {
     throw new UnimplementedError();
   }
 
   @override
-  Future<String> createVerification(
+  Future<String> createUrlNonce(
       String action, Map<String, dynamic> parameters,
       {Duration expires = const Duration(days: 1)}) {
     throw new UnimplementedError();

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -168,6 +168,18 @@ class BackendMock implements Backend {
     }
     return (await downloadUrlFun(package, version)) as Uri;
   }
+
+  @override
+  Future<Map<String, dynamic>> confirmVerification(String action, String id) {
+    throw new UnimplementedError();
+  }
+
+  @override
+  Future<String> createVerification(
+      String action, Map<String, dynamic> parameters,
+      {Duration expires = const Duration(days: 1)}) {
+    throw new UnimplementedError();
+  }
 }
 
 class TemplateMock implements TemplateService {

--- a/app/test/frontend/models_test.dart
+++ b/app/test/frontend/models_test.dart
@@ -154,17 +154,17 @@ version: 1.0.9
       });
     });
 
-    group('Verification', () {
+    group('UrlSecret', () {
       test('hash', () {
-        final v1 = new Verification()
+        final v1 = new UrlSecret()
           ..action = 'a'
           ..parameters = {'x': 1, 'y': 2}
           ..updateHash();
-        final v2 = new Verification()
+        final v2 = new UrlSecret()
           ..action = 'a'
           ..parameters = {'x': 1, 'y': 3}
           ..updateHash();
-        final v3 = new Verification()
+        final v3 = new UrlSecret()
           ..action = 'a'
           ..parameters = {'x': 1, 'y': 2}
           ..updateHash();

--- a/app/test/frontend/models_test.dart
+++ b/app/test/frontend/models_test.dart
@@ -156,15 +156,15 @@ version: 1.0.9
 
     group('UrlSecret', () {
       test('hash', () {
-        final v1 = new UrlSecret()
+        final v1 = new UrlNonce()
           ..action = 'a'
           ..parameters = {'x': 1, 'y': 2}
           ..updateHash();
-        final v2 = new UrlSecret()
+        final v2 = new UrlNonce()
           ..action = 'a'
           ..parameters = {'x': 1, 'y': 3}
           ..updateHash();
-        final v3 = new UrlSecret()
+        final v3 = new UrlNonce()
           ..action = 'a'
           ..parameters = {'x': 1, 'y': 2}
           ..updateHash();

--- a/app/test/frontend/models_test.dart
+++ b/app/test/frontend/models_test.dart
@@ -153,5 +153,24 @@ version: 1.0.9
         expect(p.dependsOnFlutterSdk, isFalse);
       });
     });
+
+    group('Verification', () {
+      test('hash', () {
+        final v1 = new Verification()
+          ..action = 'a'
+          ..parameters = {'x': 1, 'y': 2}
+          ..updateHash();
+        final v2 = new Verification()
+          ..action = 'a'
+          ..parameters = {'x': 1, 'y': 3}
+          ..updateHash();
+        final v3 = new Verification()
+          ..action = 'a'
+          ..parameters = {'x': 1, 'y': 2}
+          ..updateHash();
+        expect(v1.dedupHash, equals(v3.dedupHash));
+        expect(v1.dedupHash, isNot(equals(v2.dedupHash)));
+      });
+    });
   });
 }


### PR DESCRIPTION
I was going back and forth on this one, and the current model seems to be a reasonable start:
- An event can create a Verification entry in Datastore (providing extra parameters), which is then returns an ID.
- The ID can be shared with the recipients via an URL.
- As the recipient clicks on the URL, the ID is checked for confirmation, but only with the action matched. Different action (and their different parameters) can't be mixed. The return value is the parameters (for the first confirmation) or null (if does not exists, expired, or already confirmed).

What I couldn't decide yet: whether we want to delete such entries. I think we can keep them around in case they prove to be useful, and if they are not needed, we can remove them e.g. after a few months. But the same confirm method could delete them too.

#1759