### PR TITLE
Removing HistoryScope

### DIFF
--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -115,7 +115,7 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
       PackageDependencyBuilder.loadInitialGraphFromDb(db.dbService);
 
   Future uploadFinished(PackageVersion pv) async {
-    await historyBackend.store(new History.package(
+    await historyBackend.store(new History.entry(
       source: HistorySource.account,
       event: new PackageUploaded(
         packageName: pv.package,

--- a/app/bin/tools/backfill_history.dart
+++ b/app/bin/tools/backfill_history.dart
@@ -41,15 +41,13 @@ Future _backfillPackage(String package) async {
   await for (PackageVersion pv in query.run()) {
     bool hasUploaded = false;
     await for (History history in historyBackend.getAll(
-        scope: HistoryScope.package,
-        packageName: package,
-        packageVersion: pv.version)) {
+        packageName: package, packageVersion: pv.version)) {
       if (history.historyEvent is PackageUploaded) {
         hasUploaded = true;
       }
     }
     if (!hasUploaded) {
-      final history = new History.package(
+      final history = new History.entry(
         source: HistorySource.account,
         event: new PackageUploaded(
           packageName: package,

--- a/app/bin/tools/uploader.dart
+++ b/app/bin/tools/uploader.dart
@@ -77,7 +77,7 @@ Future addUploader(String packageName, String uploader) async {
     await T.commit();
     print('Uploader $uploader added to list of uploaders');
 
-    historyBackend.store(new History.package(
+    historyBackend.store(new History.entry(
       source: HistorySource.account,
       event: new UploaderChanged(
         packageName: packageName,
@@ -109,7 +109,7 @@ Future removeUploader(String packageName, String uploader) async {
     await T.commit();
     print('Uploader $uploader removed from list of uploaders');
 
-    historyBackend.store(new History.package(
+    historyBackend.store(new History.entry(
       source: HistorySource.account,
       event: new UploaderChanged(
         packageName: packageName,

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -488,7 +488,7 @@ class GCloudPackageRepository extends PackageRepository {
           await cache.invalidateUIPackagePage(package.name);
         }
 
-        await historyBackend.store(new History.package(
+        await historyBackend.store(new History.entry(
           source: HistorySource.account,
           event: new UploaderChanged(
             packageName: packageName,
@@ -553,7 +553,7 @@ class GCloudPackageRepository extends PackageRepository {
           await cache.invalidateUIPackagePage(package.name);
         }
 
-        await historyBackend.store(new History.package(
+        await historyBackend.store(new History.entry(
           source: HistorySource.account,
           event: new UploaderChanged(
             packageName: packageName,

--- a/app/lib/frontend/handlers_custom_api.dart
+++ b/app/lib/frontend/handlers_custom_api.dart
@@ -202,7 +202,6 @@ Future<shelf.Response> apiPackageMetricsHandler(shelf.Request request) async {
 Future<shelf.Response> apiHistoryHandler(shelf.Request request) async {
   final list = await historyBackend
       .getAll(
-        scope: request.requestedUri.queryParameters['scope'],
         packageName: request.requestedUri.queryParameters['package'],
         packageVersion: request.requestedUri.queryParameters['version'],
         limit: 25,
@@ -215,7 +214,6 @@ Future<shelf.Response> apiHistoryHandler(shelf.Request request) async {
               'package': h.packageName,
               'version': h.packageVersion,
               'timestamp': h.timestamp.toIso8601String(),
-              'scope': h.scope,
               'source': h.source,
               'eventType': h.eventType,
               'eventData': h.eventData,

--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -40,13 +40,11 @@ class HistoryBackend {
   }
 
   Stream<History> getAll({
-    @required String scope,
     @required String packageName,
     String packageVersion,
     int limit,
   }) {
     final query = _db.query<History>()
-      ..filter('scope =', scope)
       ..filter('packageName =', packageName)
       ..order('-timestamp');
     if (limit != null && limit > 0) {

--- a/app/lib/history/models.dart
+++ b/app/lib/history/models.dart
@@ -19,11 +19,6 @@ abstract class HistorySource {
   static const String dartdoc = 'dartdoc';
 }
 
-abstract class HistoryScope {
-  static const String package = 'package';
-  static const String version = 'version';
-}
-
 @db.Kind(name: 'History', idType: db.IdType.String)
 class History extends db.ExpandoModel {
   History();
@@ -33,7 +28,6 @@ class History extends db.ExpandoModel {
     this.packageVersion,
     this.timestamp,
     this.source,
-    this.scope,
     HistoryUnion union,
   }) {
     id = _uuid.v4();
@@ -43,36 +37,18 @@ class History extends db.ExpandoModel {
     eventData = map.values.single as Map<String, dynamic>;
   }
 
-  factory History.package({
+  factory History.entry({
     @required String source,
     @required HistoryEvent event,
   }) {
     return new History._(
       packageName: event.packageName,
-      packageVersion: event.packageVersion,
+      packageVersion: event.packageVersion ?? '*',
       timestamp: event.timestamp,
       source: source,
-      scope: HistoryScope.package,
       union: new HistoryUnion.ofEvent(event),
     );
   }
-
-  factory History.version({
-    @required String source,
-    @required HistoryEvent event,
-  }) {
-    return new History._(
-      packageName: event.packageName,
-      packageVersion: event.packageVersion,
-      timestamp: event.timestamp,
-      source: source,
-      scope: HistoryScope.version,
-      union: new HistoryUnion.ofEvent(event),
-    );
-  }
-
-  @db.StringProperty(required: true)
-  String scope;
 
   @db.StringProperty(required: true)
   String packageName;

--- a/index.yaml
+++ b/index.yaml
@@ -22,7 +22,6 @@ indexes:
 
 #- kind: History
 #  properties:
-#  - name: scope
 #  - name: packageName
 #  - name: packageVersion
 #  - name: timestamp
@@ -30,7 +29,6 @@ indexes:
 #
 #- kind: History
 #  properties:
-#  - name: scope
 #  - name: packageName
 #  - name: timestamp
 #    direction: desc


### PR DESCRIPTION
This is rather a thought-experiment than a solid intent: I'm not really sure of the usefulness of the `scope` field, and removing it seems to simplify both the query patterns and probably the display of the entries too. Let's discuss if you think we should have it for whatever reasons I'm overlooking right now.