### PR TITLE
Remove the trigger of pana analysis after dartdoc is completed.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -285,21 +285,6 @@ class DartdocJobProcessor extends JobProcessor {
 
     await dartdocBackend.removeObsolete(job.packageName, job.packageVersion);
 
-    // Trigger analyzer job to pick up the new dartdoc results.
-    final pkgStatus = await scoreCardBackend.getPackageStatus(
-        job.packageName, job.packageVersion);
-    if (pkgStatus.exists &&
-        !pkgStatus.isDiscontinued &&
-        !pkgStatus.isObsolete) {
-      await jobBackend.createOrUpdate(
-          JobService.analyzer,
-          job.packageName,
-          job.packageVersion,
-          job.isLatestStable,
-          job.packageVersionUpdated,
-          true);
-    }
-
     if (abortLog != null) {
       return JobStatus.aborted;
     } else {


### PR DESCRIPTION
The trigger is no longer needed, as the ScoreCard model merges separate reports itself.

This should have been removed in one of the earlier ScoreCard-migration PRs, and I remember doing the commit, but I may have missed pushing it.