### PR TITLE
Refactoring History storage

### DIFF
--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -15,7 +15,6 @@ import 'package:shelf/shelf.dart' as shelf;
 
 import 'package:pub_dartlang_org/dartdoc/backend.dart';
 import 'package:pub_dartlang_org/history/backend.dart';
-import 'package:pub_dartlang_org/history/models.dart';
 import 'package:pub_dartlang_org/job/backend.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/scorecard/scorecard_memcache.dart';
@@ -115,13 +114,6 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
       PackageDependencyBuilder.loadInitialGraphFromDb(db.dbService);
 
   Future uploadFinished(PackageVersion pv) async {
-    await historyBackend.storeEvent(new PackageUploaded(
-      packageName: pv.package,
-      packageVersion: pv.version,
-      uploaderEmail: pv.uploaderEmail,
-      timestamp: pv.created,
-    ));
-
     // Future is not awaited: upload should not be blocked on the package graph initialization.
     depsGraphBuilderFuture.then((depsGraphBuilder) async {
       // Even though the deps graph builder would pick up the new [pv] eventually,

--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -115,14 +115,11 @@ Future<shelf.Handler> setupServices(Configuration configuration) async {
       PackageDependencyBuilder.loadInitialGraphFromDb(db.dbService);
 
   Future uploadFinished(PackageVersion pv) async {
-    await historyBackend.store(new History.entry(
-      source: HistorySource.account,
-      event: new PackageUploaded(
-        packageName: pv.package,
-        packageVersion: pv.version,
-        uploaderEmail: pv.uploaderEmail,
-        timestamp: pv.created,
-      ),
+    await historyBackend.storeEvent(new PackageUploaded(
+      packageName: pv.package,
+      packageVersion: pv.version,
+      uploaderEmail: pv.uploaderEmail,
+      timestamp: pv.created,
     ));
 
     // Future is not awaited: upload should not be blocked on the package graph initialization.

--- a/app/bin/tools/backfill_history.dart
+++ b/app/bin/tools/backfill_history.dart
@@ -47,16 +47,12 @@ Future _backfillPackage(String package) async {
       }
     }
     if (!hasUploaded) {
-      final history = new History.entry(
-        source: HistorySource.account,
-        event: new PackageUploaded(
-          packageName: package,
-          packageVersion: pv.version,
-          uploaderEmail: pv.uploaderEmail,
-          timestamp: pv.created,
-        ),
-      );
-      historyBackend.store(history);
+      historyBackend.storeEvent(new PackageUploaded(
+        packageName: package,
+        packageVersion: pv.version,
+        uploaderEmail: pv.uploaderEmail,
+        timestamp: pv.created,
+      ));
     }
   }
 }

--- a/app/bin/tools/uploader.dart
+++ b/app/bin/tools/uploader.dart
@@ -77,13 +77,10 @@ Future addUploader(String packageName, String uploader) async {
     await T.commit();
     print('Uploader $uploader added to list of uploaders');
 
-    historyBackend.store(new History.entry(
-      source: HistorySource.account,
-      event: new UploaderChanged(
-        packageName: packageName,
-        currentUserEmail: null, // TODO: get system account's email
-        addedUploaderEmails: [uploader],
-      ),
+    historyBackend.storeEvent(new UploaderChanged(
+      packageName: packageName,
+      currentUserEmail: null, // TODO: get system account's email
+      addedUploaderEmails: [uploader],
     ));
   });
 }
@@ -109,13 +106,10 @@ Future removeUploader(String packageName, String uploader) async {
     await T.commit();
     print('Uploader $uploader removed from list of uploaders');
 
-    historyBackend.store(new History.entry(
-      source: HistorySource.account,
-      event: new UploaderChanged(
-        packageName: packageName,
-        currentUserEmail: null, // TODO: get system account's email
-        removedUploaderEmails: [uploader],
-      ),
+    historyBackend.storeEvent(new UploaderChanged(
+      packageName: packageName,
+      currentUserEmail: null, // TODO: get system account's email
+      removedUploaderEmails: [uploader],
     ));
   });
 }

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -490,6 +490,15 @@ class GCloudPackageRepository extends PackageRepository {
           throw new UploaderAlreadyExistsException();
         }
 
+        if (historyBackend.isEnabled) {
+          final history = new History.entry(new UploaderChanged(
+            packageName: packageName,
+            currentUserEmail: userEmail,
+            addedUploaderEmails: [uploaderEmail],
+          ));
+          T.queueMutations(inserts: [history]);
+        }
+
         // Add [uploaderEmail] to uploaders and commit.
         package.uploaderEmails.add(uploaderEmail);
         T.queueMutations(inserts: [package]);
@@ -497,12 +506,6 @@ class GCloudPackageRepository extends PackageRepository {
         if (cache != null) {
           await cache.invalidateUIPackagePage(package.name);
         }
-
-        await historyBackend.storeEvent(new UploaderChanged(
-          packageName: packageName,
-          currentUserEmail: userEmail,
-          addedUploaderEmails: [uploaderEmail],
-        ));
       });
     });
   }
@@ -554,17 +557,20 @@ class GCloudPackageRepository extends PackageRepository {
               'Use another account to remove this e-mail address.');
         }
 
+        if (historyBackend.isEnabled) {
+          final history = new History.entry(new UploaderChanged(
+            packageName: packageName,
+            currentUserEmail: userEmail,
+            removedUploaderEmails: [uploaderEmail],
+          ));
+          T.queueMutations(inserts: [history]);
+        }
+
         T.queueMutations(inserts: [package]);
         await T.commit();
         if (cache != null) {
           await cache.invalidateUIPackagePage(package.name);
         }
-
-        await historyBackend.storeEvent(new UploaderChanged(
-          packageName: packageName,
-          currentUserEmail: userEmail,
-          removedUploaderEmails: [uploaderEmail],
-        ));
       });
     });
   }

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -366,6 +366,16 @@ class GCloudPackageRepository extends PackageRepository {
         // Apply update: Push to cloud storage
         await tarballUpload(package.name, newVersion.version);
 
+        if (historyBackend.isEnabled) {
+          final history = new History.entry(new PackageUploaded(
+            packageName: newVersion.package,
+            packageVersion: newVersion.version,
+            uploaderEmail: newVersion.uploaderEmail,
+            timestamp: newVersion.created,
+          ));
+          T.queueMutations(inserts: [history]);
+        }
+
         // Apply update: Update datastore.
         _logger.info('Trying to commit datastore changes.');
         T.queueMutations(inserts: [package, newVersion]);

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -488,13 +488,10 @@ class GCloudPackageRepository extends PackageRepository {
           await cache.invalidateUIPackagePage(package.name);
         }
 
-        await historyBackend.store(new History.entry(
-          source: HistorySource.account,
-          event: new UploaderChanged(
-            packageName: packageName,
-            currentUserEmail: userEmail,
-            addedUploaderEmails: [uploaderEmail],
-          ),
+        await historyBackend.storeEvent(new UploaderChanged(
+          packageName: packageName,
+          currentUserEmail: userEmail,
+          addedUploaderEmails: [uploaderEmail],
         ));
       });
     });
@@ -553,13 +550,10 @@ class GCloudPackageRepository extends PackageRepository {
           await cache.invalidateUIPackagePage(package.name);
         }
 
-        await historyBackend.store(new History.entry(
-          source: HistorySource.account,
-          event: new UploaderChanged(
-            packageName: packageName,
-            currentUserEmail: userEmail,
-            removedUploaderEmails: [uploaderEmail],
-          ),
+        await historyBackend.storeEvent(new UploaderChanged(
+          packageName: packageName,
+          currentUserEmail: userEmail,
+          removedUploaderEmails: [uploaderEmail],
         ));
       });
     });

--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -27,6 +27,8 @@ class HistoryBackend {
   final bool _enabled = Platform.environment['HISTORY_ENABLED'] == '1';
   HistoryBackend(this._db);
 
+  bool get isEnabled => _enabled;
+
   Future storeEvent(HistoryEvent event) async {
     final history = new History.entry(event);
     if (!_enabled) {

--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -22,13 +22,17 @@ void registerHistoryBackend(HistoryBackend backend) =>
 HistoryBackend get historyBackend =>
     ss.lookup(#_historyBackend) as HistoryBackend;
 
+/// Stores and queries [History] entries.
 class HistoryBackend {
   final DatastoreDB _db;
   final bool _enabled = Platform.environment['HISTORY_ENABLED'] == '1';
   HistoryBackend(this._db);
 
+  /// Whether the storing of the entries is enabled.
   bool get isEnabled => _enabled;
 
+  /// Store a history [event]. When storing is not enabled, this will only log
+  /// the method call, and not store the entry in Datastore.
   Future storeEvent(HistoryEvent event) async {
     final history = new History.entry(event);
     if (!_enabled) {

--- a/app/lib/history/backend.dart
+++ b/app/lib/history/backend.dart
@@ -27,7 +27,8 @@ class HistoryBackend {
   final bool _enabled = Platform.environment['HISTORY_ENABLED'] == '1';
   HistoryBackend(this._db);
 
-  Future store(History history) async {
+  Future storeEvent(HistoryEvent event) async {
+    final history = new History.entry(event);
     if (!_enabled) {
       _logger.info('History is not enabled, store aborted: '
           '${history.packageName} ${history.packageVersion} ${history.eventType}');

--- a/app/lib/history/models.dart
+++ b/app/lib/history/models.dart
@@ -37,15 +37,12 @@ class History extends db.ExpandoModel {
     eventData = map.values.single as Map<String, dynamic>;
   }
 
-  factory History.entry({
-    @required String source,
-    @required HistoryEvent event,
-  }) {
+  factory History.entry(HistoryEvent event) {
     return new History._(
       packageName: event.packageName,
       packageVersion: event.packageVersion ?? '*',
       timestamp: event.timestamp,
-      source: source,
+      source: event.source,
       union: new HistoryUnion.ofEvent(event),
     );
   }
@@ -84,6 +81,7 @@ class History extends db.ExpandoModel {
 }
 
 abstract class HistoryEvent {
+  String get source;
   String get packageName;
   String get packageVersion;
   DateTime get timestamp;
@@ -153,6 +151,9 @@ class PackageUploaded implements HistoryEvent {
       _$PackageUploadedFromJson(json);
 
   @override
+  String get source => HistorySource.account;
+
+  @override
   String formatMarkdown() {
     return 'Version $packageVersion was uploaded by `$uploaderEmail`.';
   }
@@ -183,6 +184,9 @@ class UploaderChanged implements HistoryEvent {
 
   factory UploaderChanged.fromJson(Map<String, dynamic> json) =>
       _$UploaderChangedFromJson(json);
+
+  @override
+  String get source => HistorySource.account;
 
   @override
   String formatMarkdown() {
@@ -225,6 +229,9 @@ class AnalysisCompleted implements HistoryEvent {
 
   factory AnalysisCompleted.fromJson(Map<String, dynamic> json) =>
       _$AnalysisCompletedFromJson(json);
+
+  @override
+  String get source => HistorySource.analyzer;
 
   @override
   String formatMarkdown() {

--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -410,6 +410,9 @@ class HistoryBackendMock implements HistoryBackend {
   final storedHistories = <History>[];
 
   @override
+  bool get isEnabled => false;
+
+  @override
   Stream<History> getAll(
       {String scope, String packageName, String packageVersion, int limit}) {
     throw new UnimplementedError();

--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -416,8 +416,8 @@ class HistoryBackendMock implements HistoryBackend {
   }
 
   @override
-  Future store(History history) async {
-    storedHistories.add(history);
+  Future storeEvent(HistoryEvent event) async {
+    storedHistories.add(new History.entry(event));
   }
 }
 


### PR DESCRIPTION
- `source` is coming from `HistoryEvent`, no need to specify it separately (I've considered removing it altogether, but might be useful, and it also could have an optional override later.)
- there is no need for the `store(History)` method on the backend, as we should either store it in a transaction, or a `HistoryEvent` parameter would be sufficient.
- updated frontend code to store `History` entries in transaction.
