### PR TITLE
Uploader confirmation

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -211,7 +211,18 @@ class Backend {
         ..expires = now.add(Duration(days: 1))
         ..notificationCount = 1
         ..lastNotified = now;
-      tx.queueMutations(inserts: [invite]);
+
+      final inserts = <Model>[invite];
+      if (historyBackend.isEnabled) {
+        final history = new History.entry(new UploaderInvited(
+          packageName: packageName,
+          currentUserEmail: fromEmail,
+          uploaderUserEmail: recipientEmail,
+        ));
+        inserts.add(history);
+      }
+
+      tx.queueMutations(inserts: inserts);
       await tx.commit();
       return new InviteStatus(urlNonce: invite.urlNonce);
     }) as InviteStatus;

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -273,6 +273,8 @@ class PackageInvite extends db.Model {
   @db.DateTimeProperty()
   DateTime confirmed;
 
+  String get packageName => parentKey.id as String;
+
   /// Create a composite id.
   static String createId(String type, String recipientEmail) =>
       '$type/$recipientEmail';
@@ -285,6 +287,10 @@ class PackageInvite extends db.Model {
   /// The timestamp when the next notification could be sent out.
   DateTime get nextNotification =>
       created.add(Duration(minutes: 1 << notificationCount));
+}
+
+abstract class PackageInviteType {
+  static const newUploader = 'new-uploader';
 }
 
 /// An extract of [Package] and [PackageVersion], for

--- a/app/lib/frontend/templates.dart
+++ b/app/lib/frontend/templates.dart
@@ -673,6 +673,16 @@ class TemplateService {
     );
   }
 
+  /// Renders the `views/uploader_confirmed.mustache` template.
+  String renderUploaderConfirmedPage(String package, String uploaderEmail) {
+    final String content = _renderTemplate('uploader_confirmed', {
+      'package': package,
+      'uploader_email': uploaderEmail,
+    });
+    return renderLayoutPage(PageType.package, content,
+        title: 'Uploader confirmed', includeSurvey: false);
+  }
+
   /// Renders the `views/authorized.mustache` template.
   String renderAuthorizedPage() {
     final String content = _renderTemplate('authorized', {});

--- a/app/lib/history/models.dart
+++ b/app/lib/history/models.dart
@@ -92,11 +92,13 @@ abstract class HistoryEvent {
 class HistoryUnion {
   final PackageUploaded packageUploaded;
   final UploaderChanged uploaderChanged;
+  final UploaderInvited uploaderInvited;
   final AnalysisCompleted analysisCompleted;
 
   HistoryUnion({
     this.packageUploaded,
     this.uploaderChanged,
+    this.uploaderInvited,
     this.analysisCompleted,
   }) {
     assert(_items.where((x) => x != null).length == 1);
@@ -107,6 +109,8 @@ class HistoryUnion {
       return new HistoryUnion(packageUploaded: event);
     } else if (event is UploaderChanged) {
       return new HistoryUnion(uploaderChanged: event);
+    } else if (event is UploaderInvited) {
+      return new HistoryUnion(uploaderInvited: event);
     } else if (event is AnalysisCompleted) {
       return new HistoryUnion(analysisCompleted: event);
     } else {
@@ -121,6 +125,7 @@ class HistoryUnion {
     return <HistoryEvent>[
       packageUploaded,
       uploaderChanged,
+      uploaderInvited,
       analysisCompleted,
     ];
   }
@@ -206,6 +211,39 @@ class UploaderChanged implements HistoryEvent {
   }
 
   Map<String, dynamic> toJson() => _$UploaderChangedToJson(this);
+}
+
+@JsonSerializable(includeIfNull: false)
+class UploaderInvited implements HistoryEvent {
+  @override
+  final String packageName;
+  final String currentUserEmail;
+  final String uploaderUserEmail;
+  @override
+  final DateTime timestamp;
+
+  UploaderInvited({
+    @required this.packageName,
+    @required this.currentUserEmail,
+    @required this.uploaderUserEmail,
+    DateTime timestamp,
+  }) : this.timestamp = timestamp ?? new DateTime.now().toUtc();
+
+  factory UploaderInvited.fromJson(Map<String, dynamic> json) =>
+      _$UploaderInvitedFromJson(json);
+
+  @override
+  String get packageVersion => null;
+
+  @override
+  String get source => HistorySource.account;
+
+  @override
+  String formatMarkdown() {
+    return '`$currentUserEmail` invited `$uploaderUserEmail` to be an uploader.';
+  }
+
+  Map<String, dynamic> toJson() => _$UploaderInvitedToJson(this);
 }
 
 @JsonSerializable()

--- a/app/lib/history/models.g.dart
+++ b/app/lib/history/models.g.dart
@@ -16,6 +16,10 @@ HistoryUnion _$HistoryUnionFromJson(Map<String, dynamic> json) {
           ? null
           : UploaderChanged.fromJson(
               json['uploaderChanged'] as Map<String, dynamic>),
+      uploaderInvited: json['uploaderInvited'] == null
+          ? null
+          : UploaderInvited.fromJson(
+              json['uploaderInvited'] as Map<String, dynamic>),
       analysisCompleted: json['analysisCompleted'] == null
           ? null
           : AnalysisCompleted.fromJson(
@@ -33,6 +37,7 @@ Map<String, dynamic> _$HistoryUnionToJson(HistoryUnion instance) {
 
   writeNotNull('packageUploaded', instance.packageUploaded?.toJson());
   writeNotNull('uploaderChanged', instance.uploaderChanged?.toJson());
+  writeNotNull('uploaderInvited', instance.uploaderInvited?.toJson());
   writeNotNull('analysisCompleted', instance.analysisCompleted?.toJson());
   return val;
 }
@@ -83,6 +88,32 @@ Map<String, dynamic> _$UploaderChangedToJson(UploaderChanged instance) {
   writeNotNull('currentUserEmail', instance.currentUserEmail);
   writeNotNull('addedUploaderEmails', instance.addedUploaderEmails);
   writeNotNull('removedUploaderEmails', instance.removedUploaderEmails);
+  writeNotNull('timestamp', instance.timestamp?.toIso8601String());
+  return val;
+}
+
+UploaderInvited _$UploaderInvitedFromJson(Map<String, dynamic> json) {
+  return UploaderInvited(
+      packageName: json['packageName'] as String,
+      currentUserEmail: json['currentUserEmail'] as String,
+      uploaderUserEmail: json['uploaderUserEmail'] as String,
+      timestamp: json['timestamp'] == null
+          ? null
+          : DateTime.parse(json['timestamp'] as String));
+}
+
+Map<String, dynamic> _$UploaderInvitedToJson(UploaderInvited instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('packageName', instance.packageName);
+  writeNotNull('currentUserEmail', instance.currentUserEmail);
+  writeNotNull('uploaderUserEmail', instance.uploaderUserEmail);
   writeNotNull('timestamp', instance.timestamp?.toIso8601String());
   return val;
 }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_server/repository.dart' show GenericProcessingException;
 
@@ -79,6 +80,19 @@ String searchUrl({String platform, String q, int page}) {
   return new Uri(
     path: packagesPath,
     queryParameters: params.isEmpty ? null : params,
+  ).toString();
+}
+
+String pkgInviteUrl({
+  @required String type,
+  @required String package,
+  @required String email,
+  @required String urlNonce,
+}) {
+  return new Uri(
+    scheme: 'https',
+    host: pubHostedDomain,
+    path: p.join('/admin/confirm', type, package, email, urlNonce),
   ).toString();
 }
 

--- a/app/test/frontend/golden/uploader_confirmed_page.html
+++ b/app/test/frontend/golden/uploader_confirmed_page.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-13"></script>
+  <script src="/static/js/gtag.js?hash=mocked_hash_673383334"></script>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:site" content="@dart_lang" />
+  <meta property="og:site_name" content="Dart Packages" />
+  <title>Uploader confirmed</title>
+  <meta property="og:title" content="Uploader confirmed" />
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
+  <meta itemprop="image" content="/static/img/dart-logo-400x400.png" />
+  <meta property="og:image" content="/static/img/dart-logo-400x400.png" />
+  <link rel="shortcut icon" href="/favicon.ico" />
+  <meta name="description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
+  <meta property="og:description" content="Pub is the package manager for the Dart programming language, containing reusable libraries &amp; packages for Flutter, AngularDart, and general Dart programs." />
+  <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
+  <link href="/static/highlight/github.css" rel="stylesheet" />
+  <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css" />
+  <link href="/static/css/style.css?hash=mocked_hash_714113458" rel="stylesheet" type="text/css" />
+  <script src="/static/js/script.dart.js?hash=mocked_hash_918742474" defer></script>
+</head>
+<body>
+<header class="site-header">
+  <h1 class="_visuallyhidden">Dart pub</h1>
+  <button class="hamburger"></button>
+  <div class="mask"></div>
+  <div class="nav-wrap">
+    <div class="nav-header"><a class="logo" href="/"><img src="/static/img/dart-logo.svg" alt="dart pub logo"></a>
+      <div class="_flex-space"></div>
+      <button class="close"></button>
+    </div>
+    <nav class="site-nav">
+      <span>Getting Started:</span>
+      <div class="sub-wrap hoverable">
+        <button class="button">Flutter</button>
+        <div class="sub-nav">
+          <a class="link" target="_blank" rel="noopener" href="https://flutter.io/using-packages/">Using Packages</a>
+          <a class="link" target="_blank" rel="noopener" href="https://flutter.io/developing-packages/">Developing Packages and Plugins</a>
+        </div>
+      </div>
+      <div class="sub-wrap hoverable">
+        <button class="button">Web &amp; Server</button>
+        <div class="sub-nav">
+          <a class="link" target="_blank" rel="noopener" href="https://www.dartlang.org/tools/pub/get-started">Using Packages</a>
+          <a class="link" target="_blank" rel="noopener" href="https://www.dartlang.org/tools/pub/publishing">Publishing a Package</a>
+          <a class="link" target="_blank" rel="noopener" href="https://www.dartlang.org/tools/pub">Overview</a>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>
+
+  <div class="_banner-bg">
+    <main class="package-banner">
+      <form class="search-bar" action="/packages">
+        <input class="input" name="q" placeholder="Search Dart packages" autocomplete="on" autofocus />
+        <button class="icon"></button>
+      </form>
+    </main>
+  </div>
+
+
+
+<main>
+  
+<h1>Uploader confirmed</h1>
+
+<p>
+  <code>uploader@example.com</code> has been added to uploaders for package <code>pkg_foo</code>.
+</p>
+
+</main>
+
+<footer class="site-footer">
+  <a class="link" href="https://www.dartlang.org/">Dart language</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/terms/">Terms</a>
+  <a class="link" href="https://www.google.com/intl/en/policies/privacy/">Privacy</a>
+  <a class="link" href="/help">Help</a>
+  <a class="link" href="/feed.atom"><img src="/static/img/atom-feed-icon-32x32.png" class="inline-icon" /></a>
+  <a class="link github_issue" href="https://github.com/dart-lang/pub-dartlang-dart/issues/new">Report an issue with this site</a>
+</footer>
+<script src="/static/highlight/highlight.pack.js"></script>
+<script src="/static/highlight/init.js"></script>
+</body>
+</html>

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -59,6 +59,7 @@ class BackendMock implements Backend {
   final Function lookupPackageVersionFun;
   final Function versionsOfPackageFun;
   final Function downloadUrlFun;
+  final Function updatePackageInviteFn;
 
   BackendMock({
     this.newestPackagesFun,
@@ -69,6 +70,7 @@ class BackendMock implements Backend {
     this.lookupPackageVersionFun,
     this.versionsOfPackageFun,
     this.downloadUrlFun,
+    this.updatePackageInviteFn,
   });
 
   @override
@@ -185,8 +187,16 @@ class BackendMock implements Backend {
     String type,
     String recipientEmail,
     String fromEmail,
-  }) {
-    throw new UnimplementedError();
+  }) async {
+    if (updatePackageInviteFn == null) {
+      throw new Exception('no downloadUrlFun');
+    }
+    return (await updatePackageInviteFn(
+      packageName: packageName,
+      type: type,
+      recipientEmail: recipientEmail,
+      fromEmail: fromEmail,
+    )) as InviteStatus;
   }
 
   @override

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -207,6 +207,11 @@ class TemplateMock implements TemplateService {
   }
 
   @override
+  String renderUploaderConfirmedPage(String package, String uploaderEmail) {
+    return _response;
+  }
+
+  @override
   String renderErrorPage(
       String title, String message, List<PackageView> packages) {
     return _response;

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -457,6 +457,12 @@ void main() {
       expectGoldenFile(html, 'authorized_page.html');
     });
 
+    test('uploader confirmed page', () {
+      final String html = templates.renderUploaderConfirmedPage(
+          'pkg_foo', 'uploader@example.com');
+      expectGoldenFile(html, 'uploader_confirmed_page.html');
+    });
+
     test('error page', () {
       final String html =
           templates.renderErrorPage('error_title', 'error_message', [

--- a/app/test/shared/urls_test.dart
+++ b/app/test/shared/urls_test.dart
@@ -147,4 +147,17 @@ void main() {
       expect(inferIssueTrackerUrl('$repo/a/b/c'), tracker);
     });
   });
+
+  group('Invite urls', () {
+    test('new uploader invite', () {
+      expect(
+          pkgInviteUrl(
+            type: 'new-uploader',
+            package: 'pkg_foo',
+            email: 'uploader@example.com',
+            urlNonce: 'abcdefghijklmnop1234567890',
+          ),
+          'https://pub.dartlang.org/admin/confirm/new-uploader/pkg_foo/uploader@example.com/abcdefghijklmnop1234567890');
+    });
+  });
 }

--- a/app/views/uploader_confirmed.mustache
+++ b/app/views/uploader_confirmed.mustache
@@ -1,0 +1,9 @@
+{{! Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<h1>Uploader confirmed</h1>
+
+<p>
+  <code>{{uploader_email}}</code> has been added to uploaders for package <code>{{package}}</code>.
+</p>


### PR DESCRIPTION
#1759

While a few parts missing, I wanted to start a discussion about it:
- There is no invalid code / expired invite error message, we just fall back on the default 404.
- There is no second click to actually confirm and/or check the id of the current user.
- Tests: the current (failing) tests with this change seems to be not useful anymore, I lean on removing them entirely. This is the first time when using `package:pub_server`'s internals seems to be in our way.

I think this is the bare minimum that should be done for the feature, and we can add the missing pieces on top as needed. WDYT?
