### PR TITLE
Remove unused entries from generated pub-data.json

### DIFF
--- a/app/lib/dartdoc/pub_dartdoc_data.dart
+++ b/app/lib/dartdoc/pub_dartdoc_data.dart
@@ -21,21 +21,13 @@ class PubDartdocData {
   Map<String, dynamic> toJson() => _$PubDartdocDataToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(includeIfNull: false)
 class ApiElement {
   final String name;
-
   final String kind;
-
-  @JsonKey(includeIfNull: false)
   final String parent;
-
   final String source;
-
-  @JsonKey(includeIfNull: false)
   final String href;
-
-  @JsonKey(includeIfNull: false)
   final String documentation;
 
   ApiElement({

--- a/app/lib/dartdoc/pub_dartdoc_data.g.dart
+++ b/app/lib/dartdoc/pub_dartdoc_data.g.dart
@@ -28,10 +28,7 @@ ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
-  final val = <String, dynamic>{
-    'name': instance.name,
-    'kind': instance.kind,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -39,8 +36,10 @@ Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
     }
   }
 
+  writeNotNull('name', instance.name);
+  writeNotNull('kind', instance.kind);
   writeNotNull('parent', instance.parent);
-  val['source'] = instance.source;
+  writeNotNull('source', instance.source);
   writeNotNull('href', instance.href);
   writeNotNull('documentation', instance.documentation);
   return val;

--- a/pkg/pub_dartdoc/lib/pub_dartdoc_data.dart
+++ b/pkg/pub_dartdoc/lib/pub_dartdoc_data.dart
@@ -21,21 +21,13 @@ class PubDartdocData {
   Map<String, dynamic> toJson() => _$PubDartdocDataToJson(this);
 }
 
-@JsonSerializable()
+@JsonSerializable(includeIfNull: false)
 class ApiElement {
   final String name;
-
   final String kind;
-
-  @JsonKey(includeIfNull: false)
   final String parent;
-
   final String source;
-
-  @JsonKey(includeIfNull: false)
   final String href;
-
-  @JsonKey(includeIfNull: false)
   final String documentation;
 
   ApiElement({

--- a/pkg/pub_dartdoc/lib/pub_dartdoc_data.g.dart
+++ b/pkg/pub_dartdoc/lib/pub_dartdoc_data.g.dart
@@ -28,10 +28,7 @@ ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
-  final val = <String, dynamic>{
-    'name': instance.name,
-    'kind': instance.kind,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -39,8 +36,10 @@ Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
     }
   }
 
+  writeNotNull('name', instance.name);
+  writeNotNull('kind', instance.kind);
   writeNotNull('parent', instance.parent);
-  val['source'] = instance.source;
+  writeNotNull('source', instance.source);
   writeNotNull('href', instance.href);
   writeNotNull('documentation', instance.documentation);
   return val;

--- a/pkg/pub_dartdoc/lib/pub_data_generator.dart
+++ b/pkg/pub_dartdoc/lib/pub_data_generator.dart
@@ -41,14 +41,19 @@ class PubDataGenerator implements Generator {
 
     final apiMap = <String, ApiElement>{};
     void addElement(ModelElement elem) {
+      final isReferenced = elem.kind == 'library' || elem.kind == 'class';
       apiMap.putIfAbsent(
           elem.fullyQualifiedName,
           () => new ApiElement(
                 name: elem.fullyQualifiedName,
                 kind: elem.kind,
                 parent: elem.enclosingElement?.fullyQualifiedName,
-                source: p.relative(elem.sourceFileName, from: _inputDirectory),
-                href: _trimToNull(elem.href),
+                // TODO: decide if keeping the source reference is worth it
+                // We could probably store it more efficiently by not repeating
+                // the filename every time.
+                // source: p.relative(elem.sourceFileName, from: _inputDirectory),
+                source: null,
+                href: isReferenced ? _trimToNull(elem.href) : null,
                 documentation: _trimToNull(elem.documentation),
               ));
       if (elem.enclosingElement is ModelElement) {

--- a/pkg/pub_dartdoc/test/self-pub-data.json
+++ b/pkg/pub_dartdoc/test/self-pub-data.json
@@ -3,143 +3,108 @@
     {
       "name": "pub_dartdoc_data",
       "kind": "library",
-      "source": "lib/pub_dartdoc_data.dart",
       "href": "pub_dartdoc_data/pub_dartdoc_data-library.html"
     },
     {
       "name": "pub_data_generator",
       "kind": "library",
-      "source": "lib/pub_data_generator.dart",
       "href": "pub_data_generator/pub_data_generator-library.html"
     },
     {
       "name": "pub_dartdoc_data.ApiElement",
       "kind": "class",
       "parent": "pub_dartdoc_data",
-      "source": "lib/pub_dartdoc_data.dart",
       "href": "pub_dartdoc_data/ApiElement-class.html"
     },
     {
       "name": "pub_dartdoc_data.PubDartdocData",
       "kind": "class",
       "parent": "pub_dartdoc_data",
-      "source": "lib/pub_dartdoc_data.dart",
       "href": "pub_dartdoc_data/PubDartdocData-class.html"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.documentation",
       "kind": "property",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/documentation.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.fromJson",
       "kind": "constructor",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/ApiElement.fromJson.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.href",
       "kind": "property",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/href.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.kind",
       "kind": "property",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/kind.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.name",
       "kind": "property",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/name.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.parent",
       "kind": "property",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/parent.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.source",
       "kind": "property",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/source.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.ApiElement.toJson",
       "kind": "method",
-      "parent": "pub_dartdoc_data.ApiElement",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/ApiElement/toJson.html"
+      "parent": "pub_dartdoc_data.ApiElement"
     },
     {
       "name": "pub_dartdoc_data.PubDartdocData.apiElements",
       "kind": "property",
-      "parent": "pub_dartdoc_data.PubDartdocData",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/PubDartdocData/apiElements.html"
+      "parent": "pub_dartdoc_data.PubDartdocData"
     },
     {
       "name": "pub_dartdoc_data.PubDartdocData.fromJson",
       "kind": "constructor",
-      "parent": "pub_dartdoc_data.PubDartdocData",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/PubDartdocData/PubDartdocData.fromJson.html"
+      "parent": "pub_dartdoc_data.PubDartdocData"
     },
     {
       "name": "pub_dartdoc_data.PubDartdocData.toJson",
       "kind": "method",
-      "parent": "pub_dartdoc_data.PubDartdocData",
-      "source": "lib/pub_dartdoc_data.dart",
-      "href": "pub_dartdoc_data/PubDartdocData/toJson.html"
+      "parent": "pub_dartdoc_data.PubDartdocData"
     },
     {
       "name": "pub_data_generator.PubDataGenerator",
       "kind": "class",
       "parent": "pub_data_generator",
-      "source": "lib/pub_data_generator.dart",
       "href": "pub_data_generator/PubDataGenerator-class.html",
       "documentation": "Generates `pub-data.json` in the output directory, containing the extracted\n[PubDartdocData] instance."
     },
     {
       "name": "pub_data_generator.fileName",
       "kind": "top-level constant",
-      "parent": "pub_data_generator",
-      "source": "lib/pub_data_generator.dart",
-      "href": "pub_data_generator/fileName-constant.html"
+      "parent": "pub_data_generator"
     },
     {
       "name": "pub_data_generator.PubDataGenerator.generate",
       "kind": "method",
       "parent": "pub_data_generator.PubDataGenerator",
-      "source": "lib/pub_data_generator.dart",
-      "href": "pub_data_generator/PubDataGenerator/generate.html",
       "documentation": "Generate the documentation for the given package in the specified\ndirectory. Completes the returned future when done."
     },
     {
       "name": "pub_data_generator.PubDataGenerator.onFileCreated",
       "kind": "property",
       "parent": "pub_data_generator.PubDataGenerator",
-      "source": "lib/pub_data_generator.dart",
-      "href": "pub_data_generator/PubDataGenerator/onFileCreated.html",
       "documentation": "Fires when a file is created."
     },
     {
       "name": "pub_data_generator.PubDataGenerator.writtenFiles",
       "kind": "property",
       "parent": "pub_data_generator.PubDataGenerator",
-      "source": "lib/pub_data_generator.dart",
-      "href": "pub_data_generator/PubDataGenerator/writtenFiles.html",
       "documentation": "Fetches all filenames written by this generator."
     }
   ]


### PR DESCRIPTION
This is a non-breaking change:
- `source` is not used at all at the moment
- `href` is used only for libraries and classes, the rest does not need it

Reduces file size by 25% in certain cases (e.g. [`googleapis`](https://github.com/dart-lang/pub-dartlang-dart/issues/1740#issuecomment-446524732))