### PR TITLE
Reserve pkg:core and pkg:math

### DIFF
--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -170,10 +170,12 @@ const List<String> _reservedWords = const <String>[
 ];
 
 final _reservedPackageNames = <String>[
+  'core',
   'google_maps_flutter',
   'hummingbird',
   'in_app_purchase',
   'location_background',
+  'math',
   'webview_flutter',
 ].map(reducePackageName).toList();
 


### PR DESCRIPTION
pkg:math is published, but it's just a placeholder. We should remove it. CC @natebosch 
pkg:core was requested by @lrhn