### PR TITLE
Self-documenting API symbols count as documented symbols.

### DIFF
--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -176,6 +176,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.0"
+  english_words:
+    dependency: "direct main"
+    description:
+      name: english_words
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.5"
   fixnum:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   pana: '0.12.8'
   # 3rd-party packages with pinned versions
   archive: '2.0.3'
+  english_words: '3.1.5'
   mailer: '2.1.1'
   uuid: '1.0.3'
 

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -105,7 +105,25 @@ Other useful methods will be added soon...
       });
     });
 
-    test('Cased words', () {
+    test('CamelCase extraction', () {
+      expect(extractCamelCase('CamelCaseWord').toList(),
+          ['Camel', 'Case', 'Word']);
+      expect(extractCamelCase('firstLowerCase').toList(),
+          ['first', 'Lower', 'Case']);
+      expect(extractCamelCase('snake_case_word').toList(), ['snake_case_word']);
+    });
+
+    test('isSelfDocumenting positive examples', () {
+      expect(isSelfDocumenting('todayBorderColor'), true);
+      expect(isSelfDocumenting('weekendTextStyle'), true);
+    });
+
+    test('isSelfDocumenting negative examples', () {
+      expect(isSelfDocumenting('abcdef'), false);
+      expect(isSelfDocumenting('AbcDef'), false);
+    });
+
+    test('Cased tokens', () {
       expect(tokenize('CamelCase snake_case firstLowerCase'), {
         'camelcase': 1.0,
         'camel': 0.5555555555555556,


### PR DESCRIPTION
This makes @filiph's `english_words` package our dependency, and we will use the top 5000 word as a filter for checking whether an API symbol is made of English words. The words are inlined Dart code (const lists).

https://github.com/dart-lang/pub-dartlang-dart/issues/1881
