### PR TITLE
Dartdoc coverage: separate, non-linear score.

### DIFF
--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -415,6 +415,8 @@ class DartdocReport implements ReportData {
   @override
   final String reportStatus;
 
+  /// The percent of API symbols with documentation.
+  final double coverage;
   final double coverageScore;
 
   /// Suggestions related to the package health score.
@@ -427,6 +429,7 @@ class DartdocReport implements ReportData {
 
   DartdocReport({
     @required this.reportStatus,
+    @required this.coverage,
     @required this.coverageScore,
     @required this.healthSuggestions,
     @required this.maintenanceSuggestions,

--- a/app/lib/scorecard/models.g.dart
+++ b/app/lib/scorecard/models.g.dart
@@ -116,6 +116,7 @@ Map<String, dynamic> _$PanaReportToJson(PanaReport instance) {
 DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
   return DartdocReport(
       reportStatus: json['reportStatus'] as String,
+      coverage: (json['coverage'] as num)?.toDouble(),
       coverageScore: (json['coverageScore'] as num)?.toDouble(),
       healthSuggestions: (json['healthSuggestions'] as List)
           ?.map((e) =>
@@ -130,6 +131,7 @@ DartdocReport _$DartdocReportFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$DartdocReportToJson(DartdocReport instance) {
   final val = <String, dynamic>{
     'reportStatus': instance.reportStatus,
+    'coverage': instance.coverage,
     'coverageScore': instance.coverageScore,
   };
 


### PR DESCRIPTION
- As we want to have a non-linear score, `DartdocReport` should store both the coverage (percent) and the scores separately.
- I've added a non-linear score that should encourage the initial effort.
- We keep apply the `coverage < 0.1` threshold, e.g. a package with 20% dartdoc coverage won't get any penalties yet.