### PR TITLE
Refactor the content of pub-data.json: name-> symbol

### DIFF
--- a/app/lib/dartdoc/pub_dartdoc_data.dart
+++ b/app/lib/dartdoc/pub_dartdoc_data.dart
@@ -23,15 +23,16 @@ class PubDartdocData {
 
 @JsonSerializable(includeIfNull: false)
 class ApiElement {
-  final String name;
+  final String symbol;
   final String kind;
   final String parent;
   final String source;
   final String href;
   final String documentation;
+  String _qualifiedName;
 
   ApiElement({
-    @required this.name,
+    @required this.symbol,
     @required this.kind,
     @required this.parent,
     @required this.source,
@@ -39,8 +40,15 @@ class ApiElement {
     @required this.documentation,
   });
 
-  factory ApiElement.fromJson(Map<String, dynamic> json) =>
-      _$ApiElementFromJson(json);
+  factory ApiElement.fromJson(Map<String, dynamic> json) {
+    if (json.containsKey('name')) {
+      json['symbol'] = (json['name'] as String).split('.').last;
+    }
+    return _$ApiElementFromJson(json);
+  }
 
   Map<String, dynamic> toJson() => _$ApiElementToJson(this);
+
+  String get qualifiedName =>
+      _qualifiedName ??= parent == null ? symbol : '$parent.$symbol';
 }

--- a/app/lib/dartdoc/pub_dartdoc_data.g.dart
+++ b/app/lib/dartdoc/pub_dartdoc_data.g.dart
@@ -19,7 +19,7 @@ Map<String, dynamic> _$PubDartdocDataToJson(PubDartdocData instance) =>
 
 ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
   return ApiElement(
-      name: json['name'] as String,
+      symbol: json['symbol'] as String,
       kind: json['kind'] as String,
       parent: json['parent'] as String,
       source: json['source'] as String,
@@ -36,7 +36,7 @@ Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
     }
   }
 
-  writeNotNull('name', instance.name);
+  writeNotNull('symbol', instance.symbol);
   writeNotNull('kind', instance.kind);
   writeNotNull('parent', instance.parent);
   writeNotNull('source', instance.source);

--- a/pkg/pub_dartdoc/lib/pub_dartdoc_data.dart
+++ b/pkg/pub_dartdoc/lib/pub_dartdoc_data.dart
@@ -23,15 +23,16 @@ class PubDartdocData {
 
 @JsonSerializable(includeIfNull: false)
 class ApiElement {
-  final String name;
+  final String symbol;
   final String kind;
   final String parent;
   final String source;
   final String href;
   final String documentation;
+  String _qualifiedName;
 
   ApiElement({
-    @required this.name,
+    @required this.symbol,
     @required this.kind,
     @required this.parent,
     @required this.source,
@@ -39,8 +40,15 @@ class ApiElement {
     @required this.documentation,
   });
 
-  factory ApiElement.fromJson(Map<String, dynamic> json) =>
-      _$ApiElementFromJson(json);
+  factory ApiElement.fromJson(Map<String, dynamic> json) {
+    if (json.containsKey('name')) {
+      json['symbol'] = (json['name'] as String).split('.').last;
+    }
+    return _$ApiElementFromJson(json);
+  }
 
   Map<String, dynamic> toJson() => _$ApiElementToJson(this);
+
+  String get qualifiedName =>
+      _qualifiedName ??= parent == null ? symbol : '$parent.$symbol';
 }

--- a/pkg/pub_dartdoc/lib/pub_dartdoc_data.g.dart
+++ b/pkg/pub_dartdoc/lib/pub_dartdoc_data.g.dart
@@ -19,7 +19,7 @@ Map<String, dynamic> _$PubDartdocDataToJson(PubDartdocData instance) =>
 
 ApiElement _$ApiElementFromJson(Map<String, dynamic> json) {
   return ApiElement(
-      name: json['name'] as String,
+      symbol: json['symbol'] as String,
       kind: json['kind'] as String,
       parent: json['parent'] as String,
       source: json['source'] as String,
@@ -36,7 +36,7 @@ Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
     }
   }
 
-  writeNotNull('name', instance.name);
+  writeNotNull('symbol', instance.symbol);
   writeNotNull('kind', instance.kind);
   writeNotNull('parent', instance.parent);
   writeNotNull('source', instance.source);

--- a/pkg/pub_dartdoc/lib/pub_data_generator.dart
+++ b/pkg/pub_dartdoc/lib/pub_data_generator.dart
@@ -42,12 +42,15 @@ class PubDataGenerator implements Generator {
     final apiMap = <String, ApiElement>{};
     void addElement(ModelElement elem) {
       final isReferenced = elem.kind == 'library' || elem.kind == 'class';
+      final fqnParts = elem.fullyQualifiedName.split('.');
+      final symbol = fqnParts.removeLast();
+      final parent = fqnParts.isEmpty ? null : fqnParts.join('.');
       apiMap.putIfAbsent(
           elem.fullyQualifiedName,
           () => new ApiElement(
-                name: elem.fullyQualifiedName,
+                symbol: symbol,
                 kind: elem.kind,
-                parent: elem.enclosingElement?.fullyQualifiedName,
+                parent: parent,
                 // TODO: decide if keeping the source reference is worth it
                 // We could probably store it more efficiently by not repeating
                 // the filename every time.
@@ -68,7 +71,7 @@ class PubDataGenerator implements Generator {
       if (a.parent == null && b.parent != null) return -1;
       if (a.parent != null && b.parent == null) return 1;
       if (a.parent != b.parent) return a.parent.compareTo(b.parent);
-      return a.name.compareTo(b.name);
+      return a.symbol.compareTo(b.symbol);
     });
 
     final extract = new PubDartdocData(apiElements: apiElements);

--- a/pkg/pub_dartdoc/test/self-pub-data.json
+++ b/pkg/pub_dartdoc/test/self-pub-data.json
@@ -1,108 +1,113 @@
 {
   "apiElements": [
     {
-      "name": "pub_dartdoc_data",
+      "symbol": "pub_dartdoc_data",
       "kind": "library",
       "href": "pub_dartdoc_data/pub_dartdoc_data-library.html"
     },
     {
-      "name": "pub_data_generator",
+      "symbol": "pub_data_generator",
       "kind": "library",
       "href": "pub_data_generator/pub_data_generator-library.html"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement",
+      "symbol": "ApiElement",
       "kind": "class",
       "parent": "pub_dartdoc_data",
       "href": "pub_dartdoc_data/ApiElement-class.html"
     },
     {
-      "name": "pub_dartdoc_data.PubDartdocData",
+      "symbol": "PubDartdocData",
       "kind": "class",
       "parent": "pub_dartdoc_data",
       "href": "pub_dartdoc_data/PubDartdocData-class.html"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.documentation",
+      "symbol": "documentation",
       "kind": "property",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.fromJson",
+      "symbol": "fromJson",
       "kind": "constructor",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.href",
+      "symbol": "href",
       "kind": "property",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.kind",
+      "symbol": "kind",
       "kind": "property",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.name",
+      "symbol": "parent",
       "kind": "property",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.parent",
+      "symbol": "qualifiedName",
       "kind": "property",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.source",
+      "symbol": "source",
       "kind": "property",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.ApiElement.toJson",
+      "symbol": "symbol",
+      "kind": "property",
+      "parent": "pub_dartdoc_data.ApiElement"
+    },
+    {
+      "symbol": "toJson",
       "kind": "method",
       "parent": "pub_dartdoc_data.ApiElement"
     },
     {
-      "name": "pub_dartdoc_data.PubDartdocData.apiElements",
+      "symbol": "apiElements",
       "kind": "property",
       "parent": "pub_dartdoc_data.PubDartdocData"
     },
     {
-      "name": "pub_dartdoc_data.PubDartdocData.fromJson",
+      "symbol": "fromJson",
       "kind": "constructor",
       "parent": "pub_dartdoc_data.PubDartdocData"
     },
     {
-      "name": "pub_dartdoc_data.PubDartdocData.toJson",
+      "symbol": "toJson",
       "kind": "method",
       "parent": "pub_dartdoc_data.PubDartdocData"
     },
     {
-      "name": "pub_data_generator.PubDataGenerator",
+      "symbol": "PubDataGenerator",
       "kind": "class",
       "parent": "pub_data_generator",
       "href": "pub_data_generator/PubDataGenerator-class.html",
       "documentation": "Generates `pub-data.json` in the output directory, containing the extracted\n[PubDartdocData] instance."
     },
     {
-      "name": "pub_data_generator.fileName",
+      "symbol": "fileName",
       "kind": "top-level constant",
       "parent": "pub_data_generator"
     },
     {
-      "name": "pub_data_generator.PubDataGenerator.generate",
+      "symbol": "generate",
       "kind": "method",
       "parent": "pub_data_generator.PubDataGenerator",
       "documentation": "Generate the documentation for the given package in the specified\ndirectory. Completes the returned future when done."
     },
     {
-      "name": "pub_data_generator.PubDataGenerator.onFileCreated",
+      "symbol": "onFileCreated",
       "kind": "property",
       "parent": "pub_data_generator.PubDataGenerator",
       "documentation": "Fires when a file is created."
     },
     {
-      "name": "pub_data_generator.PubDataGenerator.writtenFiles",
+      "symbol": "writtenFiles",
       "kind": "property",
       "parent": "pub_data_generator.PubDataGenerator",
       "documentation": "Fetches all filenames written by this generator."


### PR DESCRIPTION
The current `name` becomes the calculated (and cached) field of `qualifiedName`, and `symbol` contains only the last part of that name. As a result the generated file size is smaller, and we reduce the chance of OOM (#1740)

I've kept a small transformation in the `fromJson` constructor, in order to be backward-compatible with the earlier version.

This is a precursor of another refactor, where we would remove the `parent` field, and would store the child entries in a tree, and we need only the `symbol`s there.