### PR TITLE
Further split of handlers.dart: admin, landing, misc.

### DIFF
--- a/app/lib/frontend/handlers_admin.dart
+++ b/app/lib/frontend/handlers_admin.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library pub_dartlang_org.handlers;
+
+import 'dart:async';
+
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../shared/handlers.dart';
+
+import 'backend.dart';
+import 'models.dart';
+import 'templates.dart';
+
+/// Handles requests for /authorized
+shelf.Response authorizedHandler(_) =>
+    htmlResponse(templateService.renderAuthorizedPage());
+
+/// Handles requests for /admin/confirm
+Future<shelf.Response> adminConfirmHandler(shelf.Request request) async {
+  final segments = request.requestedUri.pathSegments;
+  if (segments.length <= 2) {
+    return notFoundHandler(request);
+  }
+  final type = segments[2];
+  if (type == PackageInviteType.newUploader) {
+    if (segments.length != 6) {
+      return _formattedInviteExpiredHandler(request);
+    }
+    final packageName = segments[3];
+    final recipientEmail = segments[4];
+    final urlNonce = segments[5];
+    if (packageName.isEmpty || urlNonce.isEmpty) {
+      return _formattedInviteExpiredHandler(request);
+    }
+    final invite = await backend.confirmPackageInvite(
+      packageName: packageName,
+      type: type,
+      recipientEmail: recipientEmail,
+      urlNonce: urlNonce,
+    );
+    if (invite == null) {
+      return _formattedInviteExpiredHandler(request);
+    }
+    try {
+      await backend.repository.confirmUploader(
+          invite.fromEmail, invite.packageName, invite.recipientEmail);
+    } catch (e) {
+      _formattedInviteExpiredHandler(request, 'Error message:\n\n```\n$e\n```');
+    }
+    return htmlResponse(templateService.renderUploaderConfirmedPage(
+        invite.packageName, invite.recipientEmail));
+  } else {
+    return _formattedInviteExpiredHandler(request);
+  }
+}
+
+Future<shelf.Response> _formattedInviteExpiredHandler(shelf.Request request,
+    [String message = '']) async {
+  return htmlResponse(
+    templateService.renderErrorPage(
+        'Invite expired',
+        'The URL you have clicked expired or became invalid.\n\n$message\n',
+        null),
+    status: 404,
+  );
+}

--- a/app/lib/frontend/handlers_landing.dart
+++ b/app/lib/frontend/handlers_landing.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../shared/handlers.dart';
+import '../shared/platform.dart';
+
+import 'backend.dart';
+import 'search_service.dart';
+import 'templates.dart';
+
+/// Handles requests for /
+Future<shelf.Response> indexLandingHandler(shelf.Request request) =>
+    _indexHandler(request, null);
+
+/// Handles requests for /flutter
+Future<shelf.Response> flutterLandingHandler(shelf.Request request) =>
+    _indexHandler(request, KnownPlatforms.flutter);
+
+/// Handles requests for /web
+Future<shelf.Response> webLandingHandler(shelf.Request request) =>
+    _indexHandler(request, KnownPlatforms.web);
+
+/// Handles requests for:
+/// - /
+/// - /flutter
+/// - /web
+Future<shelf.Response> _indexHandler(
+    shelf.Request request, String platform) async {
+  final String queryText = request.requestedUri.queryParameters['q']?.trim();
+  if (queryText != null) {
+    final String path = request.requestedUri.path;
+    final String separator = path.endsWith('/') ? '' : '/';
+    final String newPath = '$path${separator}packages';
+    return redirectResponse(
+        request.requestedUri.replace(path: newPath).toString());
+  }
+  final isProd = isProductionHost(request);
+  String pageContent =
+      isProd ? await backend.uiPackageCache?.getUIIndexPage(platform) : null;
+  if (pageContent == null) {
+    final packages = await topFeaturedPackages(platform: platform);
+    final minilist = templateService.renderMiniList(packages);
+
+    pageContent = templateService.renderIndexPage(minilist, platform);
+    if (isProd) {
+      await backend.uiPackageCache?.setUIIndexPage(platform, pageContent);
+    }
+  }
+  return htmlResponse(pageContent);
+}

--- a/app/lib/frontend/handlers_misc.dart
+++ b/app/lib/frontend/handlers_misc.dart
@@ -1,0 +1,76 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http_parser/http_parser.dart';
+import 'package:path/path.dart' as path;
+import 'package:shelf/shelf.dart' as shelf;
+
+import '../shared/handlers.dart';
+import '../shared/packages_overrides.dart';
+import '../shared/urls.dart' as urls;
+import '../shared/utils.dart';
+
+import 'backend.dart';
+import 'static_files.dart';
+import 'templates.dart';
+
+/// Handles requests for /help
+Future<shelf.Response> helpPageHandler(shelf.Request request) async {
+  return htmlResponse(templateService.renderHelpPage());
+}
+
+/// Handles requests for /sitemap.txt
+Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
+  // Google wants the return page to have < 50,000 entries and be less than
+  // 50MB -  https://support.google.com/webmasters/answer/183668?hl=en
+  // As of 2018-01-01, the return page is ~3,000 entries and ~140KB
+  // By restricting to packages that have been updated in the last two years,
+  // the count is closer to ~1,500
+
+  final twoYearsAgo = new DateTime.now().subtract(twoYears);
+  final items = new List.from(const ['', 'help', 'web', 'flutter']
+      .map((url) => '${urls.siteRoot}/$url'));
+
+  final stream = backend.allPackageNames(
+      updatedSince: twoYearsAgo, excludeDiscontinued: true);
+  await for (var package in stream) {
+    if (isSoftRemoved(package)) continue;
+    items.add(urls.pkgPageUrl(package, includeHost: true));
+    items.add(urls.pkgDocUrl(package, isLatest: true, includeHost: true));
+  }
+
+  items.sort();
+
+  return new shelf.Response.ok(items.join('\n'));
+}
+
+/// Handles requests for /static/* content
+Future<shelf.Response> staticsHandler(shelf.Request request) async {
+  // Simplifies all of '.', '..', '//'!
+  final String normalized = path.normalize(request.requestedUri.path);
+  final StaticFile staticFile = staticFileCache.getFile(normalized);
+  if (staticFile != null) {
+    if (isNotModified(request, staticFile.lastModified, staticFile.etag)) {
+      return new shelf.Response.notModified();
+    }
+    final String hash = request.requestedUri.queryParameters['hash'];
+    final Duration cacheAge = hash != null && hash == staticFile.etag
+        ? staticLongCache
+        : staticShortCache;
+    return new shelf.Response.ok(
+      staticFile.bytes,
+      headers: {
+        HttpHeaders.contentTypeHeader: staticFile.contentType,
+        HttpHeaders.contentLengthHeader: staticFile.bytes.length.toString(),
+        HttpHeaders.lastModifiedHeader: formatHttpDate(staticFile.lastModified),
+        HttpHeaders.etagHeader: staticFile.etag,
+        HttpHeaders.cacheControlHeader: 'max-age: ${cacheAge.inSeconds}',
+      },
+    );
+  }
+  return notFoundHandler(request);
+}

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -110,3 +110,15 @@ class SearchResultPage {
   factory SearchResultPage.empty(SearchQuery query) =>
       new SearchResultPage(query, 0, []);
 }
+
+/// Returns the top packages for displaying them on a landing page.
+Future<List<PackageView>> topFeaturedPackages(
+    {String platform, int count = 15}) async {
+  // TODO: store top packages in memcache
+  final result = await searchService.search(new SearchQuery.parse(
+    platform: platform,
+    limit: count,
+    isAd: true,
+  ));
+  return result.packages.take(count).toList();
+}


### PR DESCRIPTION
Separated the following files (for #1756) with no change in logic:
- `handlers_admin.dart` for `/authorization` and `/admin/confirm`
- `handlers_landing.dart` for landing pages (`/`, `/flutter`, `/web`)
- `handlers_misc.dart` for hard-to-categorize pages (`/help`, `/sitemap.txt`, `/static/*`)

