### PR TITLE
Separate TemplateCache from TemplateService.

### DIFF
--- a/app/lib/frontend/service_utils.dart
+++ b/app/lib/frontend/service_utils.dart
@@ -5,7 +5,6 @@
 library pub_dartlang_org.server_common;
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:gcloud/db.dart';
 import 'package:gcloud/service_scope.dart';
@@ -20,8 +19,6 @@ import 'backend.dart';
 import 'oauth2_service.dart';
 import 'search_service.dart';
 import 'upload_signer_service.dart';
-
-final String templatePath = Platform.script.resolve('../views').toFilePath();
 
 void initOAuth2Service() {
   // The oauth2 service is used for getting an email address from an oauth2

--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -27,14 +27,19 @@ void registerStaticFileCache(StaticFileCache cache) {
   _cache = cache;
 }
 
-String _resolveStaticDirPath() {
+/// Returns the path of the `app/` directory.
+String resolveAppDir() {
   if (Platform.script.path.contains('bin/server.dart')) {
-    return Platform.script.resolve('../../static').toFilePath();
+    return Platform.script.resolve('../').toFilePath();
   }
   if (Platform.script.path.contains('app/test')) {
-    return path.join(Directory.current.path, '../static');
+    return Directory.current.path;
   }
   throw new Exception('Unknown script: ${Platform.script}');
+}
+
+String _resolveStaticDirPath() {
+  return path.join(resolveAppDir(), '../static');
 }
 
 /// Stores static files in memory for fast http serving.

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -21,8 +21,6 @@ import 'utils.dart' show fileAnIssueContent;
 
 Future runHandler(Logger logger, shelf.Handler handler,
     {bool sanitize = false}) {
-  registerTemplateService(new TemplateService(templateDirectory: templatePath));
-
   handler = _uriValidationRequestWrapper(handler);
   handler = _userAuthParsingWrapper(handler);
   if (sanitize) {

--- a/app/test/frontend/handlers_atom_feed_test.dart
+++ b/app/test/frontend/handlers_atom_feed_test.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/backend.dart';
-import 'package:pub_dartlang_org/frontend/templates.dart';
 
 import '../shared/utils.dart';
 
@@ -18,7 +17,6 @@ import 'utils.dart';
 
 void tScopedTest(String name, Future func()) {
   scopedTest(name, () {
-    registerTemplateService(new TemplateMock());
     return func();
   });
 }

--- a/app/test/frontend/handlers_custom_api_test.dart
+++ b/app/test/frontend/handlers_custom_api_test.dart
@@ -11,7 +11,6 @@ import 'package:yaml/yaml.dart';
 
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
-import 'package:pub_dartlang_org/frontend/templates.dart';
 
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';
@@ -21,7 +20,6 @@ import 'utils.dart';
 
 void tScopedTest(String name, Future func()) {
   scopedTest(name, () {
-    registerTemplateService(new TemplateMock());
     return func();
   });
 }

--- a/app/test/frontend/handlers_redirects_test.dart
+++ b/app/test/frontend/handlers_redirects_test.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 import 'package:pub_dartlang_org/frontend/handlers_redirects.dart';
-import 'package:pub_dartlang_org/frontend/templates.dart';
 
 import '../shared/handlers_test_utils.dart';
 import '../shared/utils.dart';
@@ -18,7 +17,6 @@ import 'handlers_test_utils.dart';
 
 void tScopedTest(String name, Future func()) {
   scopedTest(name, () {
-    registerTemplateService(new TemplateMock());
     return func();
   });
 }

--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -11,7 +11,6 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
-import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
@@ -25,7 +24,6 @@ import 'utils.dart';
 
 void tScopedTest(String name, Future func()) {
   scopedTest(name, () {
-    registerTemplateService(new TemplateMock());
     return func();
   });
 }

--- a/app/test/frontend/handlers_test_utils.dart
+++ b/app/test/frontend/handlers_test_utils.dart
@@ -6,7 +6,6 @@ library pub_dartlang_org.frontend.handlers_test;
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 
@@ -15,7 +14,6 @@ import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/handlers.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
-import 'package:pub_dartlang_org/frontend/templates.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/scorecard/models.dart';
 import 'package:pub_dartlang_org/shared/analyzer_service.dart';
@@ -38,7 +36,9 @@ Future<shelf.Response> issueGetUri(Uri uri) async {
 Future expectHtmlResponse(shelf.Response response, {int status = 200}) async {
   expect(response.statusCode, status);
   expect(response.headers['content-type'], 'text/html; charset="utf-8"');
-  expect(await response.readAsString(), TemplateMock._response);
+  final content = await response.readAsString();
+  expect(content, contains('<!DOCTYPE html>'));
+  expect(content, contains('</html>'));
 }
 
 Future expectAtomXmlResponse(shelf.Response response,
@@ -202,107 +202,6 @@ class BackendMock implements Backend {
   @override
   Future deleteObsoleteInvites() {
     throw new UnimplementedError();
-  }
-}
-
-class TemplateMock implements TemplateService {
-  static final String _response = 'foobar';
-
-  @override
-  String get templateDirectory => null;
-
-  @override
-  String renderAuthorizedPage() {
-    return _response;
-  }
-
-  @override
-  String renderUploaderConfirmedPage(String package, String uploaderEmail) {
-    return _response;
-  }
-
-  @override
-  String renderErrorPage(
-      String title, String message, List<PackageView> packages) {
-    return _response;
-  }
-
-  @override
-  String renderHelpPage() {
-    return _response;
-  }
-
-  @override
-  String renderIndexPage(String topHtml, String platform) {
-    return _response;
-  }
-
-  @override
-  String renderMiniList(List<PackageView> packages) {
-    return _response;
-  }
-
-  @override
-  String renderLayoutPage(
-    PageType type,
-    String contentHtml, {
-    @required String title,
-    String pageDescription,
-    String faviconUrl,
-    String canonicalUrl,
-    String platform,
-    SearchQuery searchQuery,
-    bool includeSurvey = true,
-    bool noIndex = false,
-  }) =>
-      _response;
-
-  @override
-  String renderPagination(PageLinks pageLinks) {
-    return _response;
-  }
-
-  @override
-  String renderPkgIndexPage(
-      List<PackageView> packages, PageLinks links, String currentPlatform,
-      {SearchQuery searchQuery, int totalCount}) {
-    return _response;
-  }
-
-  @override
-  String renderPkgShowPage(
-      Package package,
-      bool isVersionPage,
-      List<PackageVersion> versions,
-      List<Uri> versionDownloadUrls,
-      PackageVersion selectedVersion,
-      PackageVersion latestStableVersion,
-      PackageVersion latestDevVersion,
-      int totalNumberOfVersions,
-      ScoreCardData card,
-      AnalysisView analysis) {
-    return _response;
-  }
-
-  @override
-  String renderPkgVersionsPage(String package, List<PackageVersion> versions,
-      List<Uri> versionDownloadUrls) {
-    return _response;
-  }
-
-  @override
-  String renderAnalysisTab(
-      String package, String sdkConstraint, extract, analysis) {
-    return _response;
-  }
-
-  @override
-  String renderPlatformTabs({
-    String platform,
-    SearchQuery searchQuery,
-    bool isLanding = false,
-  }) {
-    return _response;
   }
 }
 

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -41,8 +41,6 @@ void main() {
       registerStaticFileCache(cache);
     });
 
-    final templates = new TemplateService(templateDirectory: 'views');
-
     void expectGoldenFile(String content, String fileName,
         {bool isFragment = false}) {
       // Making sure it is valid HTML
@@ -65,7 +63,7 @@ void main() {
     }
 
     test('index page', () {
-      final popularHtml = templates.renderMiniList([
+      final popularHtml = templateService.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
@@ -75,12 +73,12 @@ void main() {
           ),
         ),
       ]);
-      final String html = templates.renderIndexPage(popularHtml, null);
+      final String html = templateService.renderIndexPage(popularHtml, null);
       expectGoldenFile(html, 'index_page.html');
     });
 
     test('landing page flutter', () {
-      final popularHtml = templates.renderMiniList([
+      final popularHtml = templateService.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
@@ -91,12 +89,12 @@ void main() {
         ),
       ]);
       final String html =
-          templates.renderIndexPage(popularHtml, KnownPlatforms.flutter);
+          templateService.renderIndexPage(popularHtml, KnownPlatforms.flutter);
       expectGoldenFile(html, 'flutter_landing_page.html');
     });
 
     test('landing page web', () {
-      final popularHtml = templates.renderMiniList([
+      final popularHtml = templateService.renderMiniList([
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
@@ -107,12 +105,12 @@ void main() {
         ),
       ]);
       final String html =
-          templates.renderIndexPage(popularHtml, KnownPlatforms.web);
+          templateService.renderIndexPage(popularHtml, KnownPlatforms.web);
       expectGoldenFile(html, 'web_landing_page.html');
     });
 
     test('package show page', () {
-      final String html = templates.renderPkgShowPage(
+      final String html = templateService.renderPkgShowPage(
           testPackage,
           false,
           [testPackageVersion],
@@ -150,7 +148,7 @@ void main() {
     });
 
     test('package show page - with version', () {
-      final String html = templates.renderPkgShowPage(
+      final String html = templateService.renderPkgShowPage(
           testPackage,
           true,
           [testPackageVersion],
@@ -188,7 +186,7 @@ void main() {
     });
 
     test('package show page with flutter_plugin', () {
-      final String html = templates.renderPkgShowPage(
+      final String html = templateService.renderPkgShowPage(
           testPackage,
           false,
           [flutterPackageVersion],
@@ -211,7 +209,7 @@ void main() {
     });
 
     test('package show page with outdated version', () {
-      final String html = templates.renderPkgShowPage(
+      final String html = templateService.renderPkgShowPage(
           testPackage,
           true /* isVersionPage */,
           [testPackageVersion],
@@ -229,7 +227,7 @@ void main() {
     });
 
     test('package show page with discontinued version', () {
-      final String html = templates.renderPkgShowPage(
+      final String html = templateService.renderPkgShowPage(
           discontinuedPackage,
           false,
           [testPackageVersion],
@@ -254,7 +252,7 @@ void main() {
         ..panaVersion = '0.10.9'
         ..panaSuggestions = summary?.suggestions
         ..maintenanceSuggestions = summary.maintenance?.suggestions;
-      final String html = templates.renderPkgShowPage(
+      final String html = templateService.renderPkgShowPage(
           testPackage,
           true /* isVersionPage */,
           [testPackageVersion],
@@ -274,7 +272,8 @@ void main() {
 
     test('no content for analysis tab', () async {
       // no content
-      expect(templates.renderAnalysisTab('pkg_foo', null, null, null), isNull);
+      expect(templateService.renderAnalysisTab('pkg_foo', null, null, null),
+          isNull);
     });
 
     test('analysis tab: http', () async {
@@ -288,13 +287,13 @@ void main() {
       final panaReport =
           new PanaReport.fromJson(reports['pana'] as Map<String, dynamic>);
       final view = new AnalysisView(card: card, panaReport: panaReport);
-      final String html = templates.renderAnalysisTab(
+      final String html = templateService.renderAnalysisTab(
           'http', '>=1.23.0-dev.0.0 <2.0.0', card, view);
       expectGoldenFile(html, 'analysis_tab_http.html', isFragment: true);
     });
 
     test('mock analysis tab', () async {
-      final String html = templates.renderAnalysisTab(
+      final String html = templateService.renderAnalysisTab(
           'pkg_foo',
           '>=1.25.0-dev.9.0 <2.0.0',
           new ScoreCardData(
@@ -339,7 +338,7 @@ void main() {
     });
 
     test('aborted analysis tab', () async {
-      final String html = templates.renderAnalysisTab(
+      final String html = templateService.renderAnalysisTab(
           'pkg_foo',
           null,
           new ScoreCardData(),
@@ -352,7 +351,7 @@ void main() {
     });
 
     test('outdated analysis tab', () async {
-      final String html = templates.renderAnalysisTab(
+      final String html = templateService.renderAnalysisTab(
           'pkg_foo',
           null,
           new ScoreCardData(flags: [PackageFlags.isObsolete]),
@@ -364,7 +363,7 @@ void main() {
     });
 
     test('package index page', () {
-      final String html = templates.renderPkgIndexPage([
+      final String html = templateService.renderPkgIndexPage([
         new PackageView.fromModel(
           package: testPackage,
           version: testPackageVersion,
@@ -385,7 +384,7 @@ void main() {
     test('package index page with search', () {
       final searchQuery =
           new SearchQuery.parse(query: 'foobar', order: SearchOrder.top);
-      final String html = templates.renderPkgIndexPage(
+      final String html = templateService.renderPkgIndexPage(
         [
           new PackageView.fromModel(
             package: testPackage,
@@ -415,7 +414,7 @@ void main() {
 
     test('search with supported qualifier', () {
       final searchQuery = new SearchQuery.parse(query: 'email:user@domain.com');
-      final String html = templates.renderPkgIndexPage(
+      final String html = templateService.renderPkgIndexPage(
         [],
         new PageLinks.empty(),
         null,
@@ -427,7 +426,7 @@ void main() {
 
     test('search with unsupported qualifier', () {
       final searchQuery = new SearchQuery.parse(query: 'foo:bar');
-      final String html = templates.renderPkgIndexPage(
+      final String html = templateService.renderPkgIndexPage(
         [],
         new PageLinks.empty(),
         null,
@@ -438,7 +437,7 @@ void main() {
     });
 
     test('package versions page', () {
-      final String html = templates.renderPkgVersionsPage(
+      final String html = templateService.renderPkgVersionsPage(
         'foobar',
         [
           testPackageVersion,
@@ -453,19 +452,19 @@ void main() {
     });
 
     test('authorized page', () {
-      final String html = templates.renderAuthorizedPage();
+      final String html = templateService.renderAuthorizedPage();
       expectGoldenFile(html, 'authorized_page.html');
     });
 
     test('uploader confirmed page', () {
-      final String html = templates.renderUploaderConfirmedPage(
+      final String html = templateService.renderUploaderConfirmedPage(
           'pkg_foo', 'uploader@example.com');
       expectGoldenFile(html, 'uploader_confirmed_page.html');
     });
 
     test('error page', () {
       final String html =
-          templates.renderErrorPage('error_title', 'error_message', [
+          templateService.renderErrorPage('error_title', 'error_message', [
         new PackageView(
           name: 'popular_pkg',
           version: '1.0.2',
@@ -479,32 +478,36 @@ void main() {
     });
 
     test('pagination: single page', () {
-      final String html = templates.renderPagination(new PageLinks.empty());
+      final String html =
+          templateService.renderPagination(new PageLinks.empty());
       expectGoldenFile(html, 'pagination_single.html', isFragment: true);
     });
 
     test('pagination: in the middle', () {
-      final String html = templates.renderPagination(new PageLinks(90, 299));
+      final String html =
+          templateService.renderPagination(new PageLinks(90, 299));
       expectGoldenFile(html, 'pagination_middle.html', isFragment: true);
     });
 
     test('pagination: at first page', () {
-      final String html = templates.renderPagination(new PageLinks(0, 600));
+      final String html =
+          templateService.renderPagination(new PageLinks(0, 600));
       expectGoldenFile(html, 'pagination_first.html', isFragment: true);
     });
 
     test('pagination: at last page', () {
-      final String html = templates.renderPagination(new PageLinks(90, 91));
+      final String html =
+          templateService.renderPagination(new PageLinks(90, 91));
       expectGoldenFile(html, 'pagination_last.html', isFragment: true);
     });
 
     test('platform tabs: list', () {
-      final String html = templates.renderPlatformTabs(platform: 'web');
+      final String html = templateService.renderPlatformTabs(platform: 'web');
       expectGoldenFile(html, 'platform_tabs_list.html', isFragment: true);
     });
 
     test('platform tabs: search', () {
-      final String html = templates.renderPlatformTabs(
+      final String html = templateService.renderPlatformTabs(
           searchQuery: new SearchQuery.parse(
         query: 'foo',
         platform: 'web',


### PR DESCRIPTION
First step in https://github.com/dart-lang/pub-dartlang-dart/issues/1907:
- no need for scoping
- no need for `TemplateMock`
- autodetecting `views/` directory works fine (based on the same approach we are already using in `static_files.dart`)

This enables the refactoring of the individual rendering methods into separate files.
