### PR TITLE
Fix CI tests.

### DIFF
--- a/app/test/frontend/handlers_test.dart
+++ b/app/test/frontend/handlers_test.dart
@@ -11,6 +11,7 @@ import 'package:test/test.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
+import 'package:pub_dartlang_org/frontend/static_files.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
@@ -28,7 +29,9 @@ void tScopedTest(String name, Future func()) {
   });
 }
 
-void main() {
+Future main() async {
+  await updateLocalBuiltFiles();
+
   final pageSize = 10;
   final topQueryLimit = 15;
 


### PR DESCRIPTION
It looks like CI tests are failing because the built files are not always present before the given test is executed. (dart2js output is required for rendering even the error page.) Adding the explicit file update to make sure they are present.