### PR TITLE
Update help page: link to pana's suggestions

### DIFF
--- a/app/lib/frontend/templates/misc.dart
+++ b/app/lib/frontend/templates/misc.dart
@@ -15,7 +15,9 @@ import 'layout.dart';
 
 /// Renders the `views/help.mustache` template.
 String renderHelpPage() {
-  final String content = templateCache.renderTemplate('help', {});
+  final String content = templateCache.renderTemplate('help', {
+    'pana_maintenance_url': urls.panaMaintenanceUrl(),
+  });
   return renderLayoutPage(PageType.package, content,
       title: 'Help | Dart Packages');
 }

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_server/repository.dart' show GenericProcessingException;
 
 import 'packages_overrides.dart';
+import 'versions.dart';
 
 const pubHostedDomain = 'pub.dartlang.org';
 
@@ -205,4 +206,9 @@ String inferServiceProviderName(String url) {
     return 'GitLab';
   }
   return null;
+}
+
+/// Returns the versioned documentation URL for pana's maintenance suggestions.
+String panaMaintenanceUrl() {
+  return 'https://pub.dartlang.org/documentation/pana/$panaVersion/#maintenance-score';
 }

--- a/app/views/help.mustache
+++ b/app/views/help.mustache
@@ -113,9 +113,11 @@ linter:
     at least one new version every year to keep your maintenance score up.
   </p>
   <p>
-    You can find the overall score either near the top of the package's page or to
-    the right of your package in any listing on this site. To get suggestions before
-    publishing, run <a href="https://pub.dartlang.org/packages/pana">pana</a> manually.
+    Pub site uses <a href="https://pub.dartlang.org/packages/pana">pana</a>
+    to create maintenance suggestions. To get suggestions before publishing,
+    run <code>pana</code> locally (using <code>--source path</code>), or
+    validate your package against the
+    <a href="{{& pana_maintenance_url}}">list of checks</a> manually.
   </p>
 
   <h3 id="overall-score">Overall score</h3>
@@ -127,6 +129,10 @@ linter:
       <li>30% code health,</li>
       <li>20% maintenance.</li>
   </ul>
+  <p>
+    You can find the overall score either near the top of the package's page or to
+    the right of your package in any listing on this site.
+  </p>
 
 
   <h2 id="ranking">Ranking</h2>


### PR DESCRIPTION
- fixes #1923
- we are already linking to `pana`'s pub page, adding another link to versioned documentation page
- moved reference of overall score to the section below

/cc @kevmoo 

UI after changes:
<img width="631" alt="screen shot 2019-01-11 at 9 28 45" src="https://user-images.githubusercontent.com/4778111/51022578-e5655300-1584-11e9-8b0a-772874a7cd08.png">

(middle section changed and last paragraph is the moved one)