### PR TITLE
Show hash link on hovering header rows.

### DIFF
--- a/app/lib/shared/markdown.dart
+++ b/app/lib/shared/markdown.dart
@@ -35,6 +35,8 @@ String markdownToHtml(String text, String baseUrl) {
   return m.renderToHtml(nodes) + '\n';
 }
 
+final _headers = Set.from(<String>['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
 /// Adds an extra <a href="#hash">#</a> element to all h1,h2,h3..h6 elements.
 class _HashLink implements m.NodeVisitor {
   @override
@@ -45,19 +47,19 @@ class _HashLink implements m.NodeVisitor {
 
   @override
   void visitElementAfter(m.Element element) {
-    if (!element.tag.startsWith('h') ||
-        element.tag.length != 2 ||
-        element.generatedId == null ||
-        element.children.length != 1) {
-      return;
+    final isHeaderWithHash = _headers.contains(element.tag) &&
+        element.generatedId != null &&
+        element.children.length == 1;
+
+    if (isHeaderWithHash) {
+      element.attributes['class'] = 'hash-header';
+      element.children.addAll([
+        m.Text(' '),
+        m.Element('a', [m.Text('#')])
+          ..attributes['href'] = '#${element.generatedId}'
+          ..attributes['class'] = 'hash-link',
+      ]);
     }
-    element.attributes['class'] = 'hash-header';
-    element.children.addAll([
-      m.Text(' '),
-      m.Element('a', [m.Text('#')])
-        ..attributes['href'] = '#${element.generatedId}'
-        ..attributes['class'] = 'hash-link',
-    ]);
   }
 }
 

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -95,7 +95,7 @@
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
-        <h1 id="test-package">Test Package</h1>
+        <h1 class="hash-header" id="test-package">Test Package <a class="hash-link" href="#test-package">#</a></h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
@@ -103,7 +103,7 @@
 
       </section>
       <section class="content  js-content markdown-body" data-name="-changelog-tab-">
-        <h1 id="changelog">Changelog</h1>
+        <h1 class="hash-header" id="changelog">Changelog <a class="hash-link" href="#changelog">#</a></h1>
 <p>0.1.1 - test package</p>
 
       </section>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -92,7 +92,7 @@
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
-        <h1 id="test-package">Test Package</h1>
+        <h1 class="hash-header" id="test-package">Test Package <a class="hash-link" href="#test-package">#</a></h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
@@ -100,7 +100,7 @@
 
       </section>
       <section class="content  js-content markdown-body" data-name="-changelog-tab-">
-        <h1 id="changelog">Changelog</h1>
+        <h1 class="hash-header" id="changelog">Changelog <a class="hash-link" href="#changelog">#</a></h1>
 <p>0.1.1 - test package</p>
 
       </section>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -90,7 +90,7 @@
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
-        <h1 id="test-package">Test Package</h1>
+        <h1 class="hash-header" id="test-package">Test Package <a class="hash-link" href="#test-package">#</a></h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
@@ -98,7 +98,7 @@
 
       </section>
       <section class="content  js-content markdown-body" data-name="-changelog-tab-">
-        <h1 id="changelog">Changelog</h1>
+        <h1 class="hash-header" id="changelog">Changelog <a class="hash-link" href="#changelog">#</a></h1>
 <p>0.1.1 - test package</p>
 
       </section>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -93,7 +93,7 @@
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
-        <h1 id="test-package">Test Package</h1>
+        <h1 class="hash-header" id="test-package">Test Package <a class="hash-link" href="#test-package">#</a></h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
@@ -101,7 +101,7 @@
 
       </section>
       <section class="content  js-content markdown-body" data-name="-changelog-tab-">
-        <h1 id="changelog">Changelog</h1>
+        <h1 class="hash-header" id="changelog">Changelog <a class="hash-link" href="#changelog">#</a></h1>
 <p>0.1.1 - test package</p>
 
       </section>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -93,7 +93,7 @@
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
-        <h1 id="test-package">Test Package</h1>
+        <h1 class="hash-header" id="test-package">Test Package <a class="hash-link" href="#test-package">#</a></h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
@@ -101,7 +101,7 @@
 
       </section>
       <section class="content  js-content markdown-body" data-name="-changelog-tab-">
-        <h1 id="changelog">Changelog</h1>
+        <h1 class="hash-header" id="changelog">Changelog <a class="hash-link" href="#changelog">#</a></h1>
 <p>0.1.1 - test package</p>
 
       </section>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -97,7 +97,7 @@
       </li>
     </ul>
       <section class="content -active js-content markdown-body" data-name="-readme-tab-">
-        <h1 id="test-package">Test Package</h1>
+        <h1 class="hash-header" id="test-package">Test Package <a class="hash-link" href="#test-package">#</a></h1>
 <p>This is a readme file.</p>
 <pre><code class="language-dart">void main() {
 }
@@ -105,7 +105,7 @@
 
       </section>
       <section class="content  js-content markdown-body" data-name="-changelog-tab-">
-        <h1 id="changelog">Changelog</h1>
+        <h1 class="hash-header" id="changelog">Changelog <a class="hash-link" href="#changelog">#</a></h1>
 <p>0.1.1 - test package</p>
 
       </section>

--- a/app/test/shared/markdown_test.dart
+++ b/app/test/shared/markdown_test.dart
@@ -15,6 +15,11 @@ void main() {
     test('do not render inline html', () {
       expect(markdownToHtml('<a></a>', null), '<p>&lt;a>&lt;/a></p>\n');
     });
+
+    test('render link ids', () {
+      expect(markdownToHtml('# ABC def', null),
+          '<h1 class="hash-header" id="abc-def">ABC def <a class="hash-link" href="#abc-def">#</a></h1>\n');
+    });
   });
 
   group('Valid custom base URL', () {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1239,4 +1239,18 @@ pre > code {
   }
 }
 
+/******************************************************
+  Markdown customization
+******************************************************/
+
+.markdown-body .hash-link {
+  color: #ccc;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out 0.1s;
+}
+
+.markdown-body .hash-header:hover .hash-link {
+  opacity: 1;
+}
+
 /*# sourceMappingURL=style.css.map */


### PR DESCRIPTION
Fixes #1947.

Displays the `#` character on hovering, which is clickable and links to the given row:

<img width="189" alt="screen shot 2019-01-15 at 13 29 15" src="https://user-images.githubusercontent.com/4778111/51180792-b5da8180-18c9-11e9-9acb-19d8a2a3f25e.png">
