### PR TITLE
Catch all exceptions on URI validation.

### DIFF
--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -86,7 +86,7 @@ bool _isValidUri(shelf.Request request) {
   try {
     // should be able to parse path segments
     uri.pathSegments.forEach(Uri.decodeComponent);
-  } on ArgumentError catch (_) {
+  } catch (_) {
     return false;
   }
   return true;


### PR DESCRIPTION
Fixes #1967. We could also go on the path of adding another catch close for the `FormatException`, but I think it is safe to say that in any case we want to get it parsed without exceptions.