### PR TITLE
Upgrade versions

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -322,6 +322,9 @@ class DartdocJobProcessor extends JobProcessor {
       if (!validateLinks) {
         args.add('--no-validate-links');
       }
+      if (envConfig.toolEnvDartSdkDir != null) {
+        args.addAll(['--sdk-dir', envConfig.toolEnvDartSdkDir]);
+      }
       final pr = await runProc(
         'dart',
         ['bin/pub_dartdoc.dart']..addAll(args),

--- a/app/lib/frontend/model_properties.dart
+++ b/app/lib/frontend/model_properties.dart
@@ -7,11 +7,9 @@ library pub_dartlang_org.model_properties;
 import 'dart:convert';
 
 import 'package:gcloud/db.dart';
+import 'package:pana/pana.dart' show SdkConstraintStatus;
 import 'package:pubspec_parse/pubspec_parse.dart' as pubspek show Pubspec;
-import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
-
-final _dart2OrLater = new VersionConstraint.parse('>=2.0.0');
 
 Map<String, dynamic> _loadYaml(String yamlString) {
   final map = loadYaml(yamlString) as Map;
@@ -79,11 +77,10 @@ class Pubspec {
     return _asString(environment['sdk']);
   }
 
-  VersionConstraint get sdkVersionConstraint => _inner.environment['sdk'];
-
+  // TODO: migrate uses to SdkConstraintStatus.isDart2Compatible
   bool get supportsOnlyLegacySdk {
-    return sdkVersionConstraint == null ||
-        !sdkVersionConstraint.allowsAny(_dart2OrLater);
+    final s = SdkConstraintStatus.fromSdkVersion(_inner.environment['sdk']);
+    return !s.isDart2Compatible;
   }
 
   /// Whether the pubspec file contains a flutter.plugin entry.

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -46,7 +46,7 @@ final String flutterVersion = '1.1.9';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml
-final String dartdocVersion = '0.27.0';
+final String dartdocVersion = '0.28.0';
 final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
 
 /// The version of our customization going into the output of the dartdoc static

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = new RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-const String runtimeVersion = '2019.01.09';
+const String runtimeVersion = '2019.01.21';
 final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to
@@ -25,22 +25,21 @@ final Version semanticRuntimeVersion = new Version.parse(runtimeVersion);
 ///
 /// Make sure that at least two versions are kept here as the next candidates
 /// when the version switch happens:
+/// - 2019.01.21
 /// - 2019.01.09
 /// - 2018.12.05
 /// - 2018.11.22
 /// - 2018.11.12
 /// - 2018.10.23
 /// - 2018.10.01
-/// - 2018.09.17
-/// - 2018.09.11
-final String gcBeforeRuntimeVersion = '2018.09.03';
+final String gcBeforeRuntimeVersion = '2018.10.01';
 
 // keep in-sync with SDK version in .travis.yml, .mono_repo.yml and Dockerfile
 final String runtimeSdkVersion = '2.1.1-dev.1.0';
 final String toolEnvSdkVersion = '2.1.0';
 
 // keep in-sync with app/pubspec.yaml
-final String panaVersion = '0.12.10';
+final String panaVersion = '0.12.11';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
 final String flutterVersion = '1.1.7';

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -42,7 +42,7 @@ final String toolEnvSdkVersion = '2.1.0';
 final String panaVersion = '0.12.11';
 final Version semanticPanaVersion = new Version.parse(panaVersion);
 
-final String flutterVersion = '1.1.7';
+final String flutterVersion = '1.1.9';
 final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       name: pana
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   path:
     dependency: "direct main"
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   yaml: '^2.1.12'
   # pana version to be pinned
   # keep in-sync with app/lib/shared/versions.dart
-  pana: '0.12.10'
+  pana: '0.12.11'
   # 3rd-party packages with pinned versions
   archive: '2.0.3'
   mailer: '2.1.1'

--- a/app/test/dartdoc/golden/pana_0.12.2_index.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.27.0">
+  <meta name="generator" content="made with love by dartdoc 0.28.0">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="canonical" href="https://pub.dartlang.org/documentation/pana/0.12.2/index.html">
@@ -13,7 +13,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -87,12 +87,12 @@ Options:
             <h2>Libraries</h2>
           <dl>
             <dt id="models">
-              <span class="name"><a href="models/models-library.html">models</a></span> 
+              <span class="name"><a href="models/models-library.html">models</a></span>             
             </dt>
             <dd>
               
             </dd>            <dt id="pana">
-              <span class="name"><a href="pana/pana-library.html">pana</a></span> 
+              <span class="name"><a href="pana/pana-library.html">pana</a></span>             
             </dt>
             <dd>
               
@@ -108,6 +108,7 @@ Options:
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_index.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_index.out.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="generator" content="made with love by dartdoc 0.27.0">
+  <meta name="generator" content="made with love by dartdoc 0.28.0">
   <meta name="description" content="pana API docs, for the Dart programming language.">
   <title>pana - Dart API docs</title>
   <link rel="alternate" href="/documentation/pana/latest/">
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -93,12 +93,12 @@ Options:
             <h2>Libraries</h2>
           <dl>
             <dt id="models">
-              <span class="name"><a href="models/models-library.html">models</a></span> 
+              <span class="name"><a href="models/models-library.html">models</a></span>             
             </dt>
             <dd>
               
             </dd>            <dt id="pana">
-              <span class="name"><a href="pana/pana-library.html">pana</a></span> 
+              <span class="name"><a href="pana/pana-library.html">pana</a></span>             
             </dt>
             <dd>
               
@@ -114,6 +114,7 @@ Options:
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -180,59 +180,59 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
           <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
-          <span class="signature">&#8594; int</span> 
+          <span class="signature">&#8594; int</span>         
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
-          <div class="features">read-only, override</div>
+                  <div class="features">read-only, override</div>
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
-          <span class="signature">&#8594; String</span> 
+          <span class="signature">&#8594; String</span>         
         </dt>
         <dd>
           
-          <div class="features">final</div>
+                  <div class="features">final</div>
 </dd>
         <dt id="path" class="property">
           <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
-          <span class="signature">&#8594; String</span> 
+          <span class="signature">&#8594; String</span>         
         </dt>
         <dd>
           
-          <div class="features">final</div>
+                  <div class="features">final</div>
 </dd>
         <dt id="shortFormatted" class="property">
           <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-          <span class="signature">&#8594; String</span> 
+          <span class="signature">&#8594; String</span>         
         </dt>
         <dd>
           
-          <div class="features">read-only</div>
+                  <div class="features">read-only</div>
 </dd>
         <dt id="url" class="property">
           <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
-          <span class="signature">&#8594; String</span> 
+          <span class="signature">&#8594; String</span>         
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+                  <div class="features">@JsonKey(includeIfNull: false), final</div>
 </dd>
         <dt id="version" class="property">
           <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
-          <span class="signature">&#8594; String</span> 
+          <span class="signature">&#8594; String</span>         
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+                  <div class="features">@JsonKey(includeIfNull: false), final</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
           <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
-          <span class="signature">&#8594; Type</span> 
+          <span class="signature">&#8594; Type</span>         
         </dt>
         <dd class="inherited">
           A representation of the runtime type of the object.
-          <div class="features">read-only, inherited</div>
+                  <div class="features">read-only, inherited</div>
 </dd>
       </dl>
     </section>
@@ -244,37 +244,37 @@
           <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
             <span class="returntype parameter">&#8594; <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
           </span>
-          </dt>
+                  </dt>
         <dd>
           
-          
+                  
 </dd>
         <dt id="toString" class="callable">
           <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; String</span>
           </span>
-          </dt>
+                  </dt>
         <dd>
           Returns a string representation of this object.
-          <div class="features">override</div>
+                  <div class="features">override</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">&#8594; dynamic</span>
           </span>
-          </dt>
+                  </dt>
         <dd class="inherited">
           Invoked when a non-existent method or property is accessed. <a href="pana/LicenseFile/noSuchMethod.html">[...]</a>
-          <div class="features">inherited</div>
+                  <div class="features">inherited</div>
 </dd>
         <dt id="toJson" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">&#8594; Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
           </span>
-          </dt>
+                  </dt>
         <dd class="inherited">
           
-          <div class="features">inherited</div>
+                  <div class="features">inherited</div>
 </dd>
       </dl>
     </section>
@@ -286,10 +286,10 @@
           <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">&#8594; bool</span>
           </span>
-          </dt>
+                  </dt>
         <dd>
           The equality operator. <a href="pana/LicenseFile/operator_equals.html">[...]</a>
-          <div class="features">override</div>
+                  <div class="features">override</div>
 </dd>
       </dl>
     </section>
@@ -337,6 +337,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_class.out.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -185,59 +185,59 @@
       <dl class="properties">
         <dt id="hashCode" class="property">
           <span class="name"><a href="pana/LicenseFile/hashCode.html">hashCode</a></span>
-          <span class="signature">→ int</span> 
+          <span class="signature">→ int</span>         
         </dt>
         <dd>
           The hash code for this object. <a href="pana/LicenseFile/hashCode.html">[...]</a>
-          <div class="features">read-only, override</div>
+                  <div class="features">read-only, override</div>
 </dd>
         <dt id="name" class="property">
           <span class="name"><a href="pana/LicenseFile/name.html">name</a></span>
-          <span class="signature">→ String</span> 
+          <span class="signature">→ String</span>         
         </dt>
         <dd>
           
-          <div class="features">final</div>
+                  <div class="features">final</div>
 </dd>
         <dt id="path" class="property">
           <span class="name"><a href="pana/LicenseFile/path.html">path</a></span>
-          <span class="signature">→ String</span> 
+          <span class="signature">→ String</span>         
         </dt>
         <dd>
           
-          <div class="features">final</div>
+                  <div class="features">final</div>
 </dd>
         <dt id="shortFormatted" class="property">
           <span class="name"><a href="pana/LicenseFile/shortFormatted.html">shortFormatted</a></span>
-          <span class="signature">→ String</span> 
+          <span class="signature">→ String</span>         
         </dt>
         <dd>
           
-          <div class="features">read-only</div>
+                  <div class="features">read-only</div>
 </dd>
         <dt id="url" class="property">
           <span class="name"><a href="pana/LicenseFile/url.html">url</a></span>
-          <span class="signature">→ String</span> 
+          <span class="signature">→ String</span>         
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+                  <div class="features">@JsonKey(includeIfNull: false), final</div>
 </dd>
         <dt id="version" class="property">
           <span class="name"><a href="pana/LicenseFile/version.html">version</a></span>
-          <span class="signature">→ String</span> 
+          <span class="signature">→ String</span>         
         </dt>
         <dd>
           
-          <div class="features">@JsonKey(includeIfNull: false), final</div>
+                  <div class="features">@JsonKey(includeIfNull: false), final</div>
 </dd>
         <dt id="runtimeType" class="property inherited">
           <span class="name"><a href="pana/LicenseFile/runtimeType.html">runtimeType</a></span>
-          <span class="signature">→ Type</span> 
+          <span class="signature">→ Type</span>         
         </dt>
         <dd class="inherited">
           A representation of the runtime type of the object.
-          <div class="features">read-only, inherited</div>
+                  <div class="features">read-only, inherited</div>
 </dd>
       </dl>
     </section>
@@ -249,37 +249,37 @@
           <span class="name"><a href="pana/LicenseFile/change.html">change</a></span><span class="signature">(<wbr>{<span class="parameter" id="change-param-url"><span class="type-annotation">String</span> <span class="parameter-name">url</span></span> })
             <span class="returntype parameter">→ <a href="pana/LicenseFile-class.html">LicenseFile</a></span>
           </span>
-          </dt>
+                  </dt>
         <dd>
           
-          
+                  
 </dd>
         <dt id="toString" class="callable">
           <span class="name"><a href="pana/LicenseFile/toString.html">toString</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">→ String</span>
           </span>
-          </dt>
+                  </dt>
         <dd>
           Returns a string representation of this object.
-          <div class="features">override</div>
+                  <div class="features">override</div>
 </dd>
         <dt id="noSuchMethod" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/noSuchMethod.html">noSuchMethod</a></span><span class="signature">(<wbr><span class="parameter" id="noSuchMethod-param-invocation"><span class="type-annotation">Invocation</span> <span class="parameter-name">invocation</span></span>)
             <span class="returntype parameter">→ dynamic</span>
           </span>
-          </dt>
+                  </dt>
         <dd class="inherited">
           Invoked when a non-existent method or property is accessed. <a href="pana/LicenseFile/noSuchMethod.html">[...]</a>
-          <div class="features">inherited</div>
+                  <div class="features">inherited</div>
 </dd>
         <dt id="toJson" class="callable inherited">
           <span class="name"><a href="pana/LicenseFile/toJson.html">toJson</a></span><span class="signature">(<wbr>)
             <span class="returntype parameter">→ Map<span class="signature">&lt;<wbr><span class="type-parameter">String</span>, <span class="type-parameter">dynamic</span>&gt;</span></span>
           </span>
-          </dt>
+                  </dt>
         <dd class="inherited">
           
-          <div class="features">inherited</div>
+                  <div class="features">inherited</div>
 </dd>
       </dl>
     </section>
@@ -291,10 +291,10 @@
           <span class="name"><a href="pana/LicenseFile/operator_equals.html">operator ==</a></span><span class="signature">(<wbr><span class="parameter" id="==-param-other"><span class="type-annotation">Object</span> <span class="parameter-name">other</span></span>)
             <span class="returntype parameter">→ bool</span>
           </span>
-          </dt>
+                  </dt>
         <dd>
           The equality operator. <a href="pana/LicenseFile/operator_equals.html">[...]</a>
-          <div class="features">override</div>
+                  <div class="features">override</div>
 </dd>
       </dl>
     </section>
@@ -342,6 +342,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -108,6 +108,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_constructor.out.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -113,6 +113,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -109,6 +109,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_license_file_name_field.out.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -114,6 +114,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.html
@@ -14,7 +14,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -142,7 +142,7 @@
 
     <section class="multi-line-signature">
         <span class="returntype">String</span>
-        <span class="name ">prettyJson</span>
+                <span class="name ">prettyJson</span>
 (<wbr><span class="parameter" id="prettyJson-param-obj"><span class="type-annotation">dynamic</span> <span class="parameter-name">obj</span></span>)
     </section>
     
@@ -181,6 +181,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
+++ b/app/test/dartdoc/golden/pana_0.12.2_pretty_json.out.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="static-assets/github.css">
   <link rel="stylesheet" href="static-assets/styles.css">
   <link rel="icon" href="static-assets/favicon.png">
-
+  
 </head>
 
 <body>
@@ -147,7 +147,7 @@
 
     <section class="multi-line-signature">
         <span class="returntype">String</span>
-        <span class="name ">prettyJson</span>
+                <span class="name ">prettyJson</span>
 (<wbr><span class="parameter" id="prettyJson-param-obj"><span class="type-annotation">dynamic</span> <span class="parameter-name">obj</span></span>)
     </section>
     
@@ -186,6 +186,7 @@
     pana 0.12.2
   </span>
 
+  
 </footer>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -31,7 +31,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 106200837);
+    expect(hash, 421801817);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: dartdoc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.0"
+    version: "0.28.0"
   file:
     dependency: transitive
     description:
@@ -204,6 +204,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  mustache:
+    dependency: transitive
+    description:
+      name: mustache
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   node_preamble:
     dependency: transitive
     description:

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   pub_dartdoc_data:
     path: ../pub_dartdoc_data
   # dartdoc version to be pinned, keep in-sync with app/lib/shared/versions.dart
-  dartdoc: 0.27.0
+  dartdoc: 0.28.0
 
 dev_dependencies:
   test: '^1.3.0'


### PR DESCRIPTION
- Flutter: only version upgrade
- pana: updated `supportsOnlyLegacySdk` in `model_properties.dart`. Will update the stored field names in later PR(s).
- dartdoc: updated templates, and also found a missing piece that fixes #1972
- increasing the GCd version to `2018.10.01`.

(deploying to staging)