### PR TITLE
Update stale search index data periodically.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -102,6 +102,7 @@ Future _main(FrontendEntryMessage message) async {
           sleep: const Duration(minutes: 10),
           skipHistory: true,
         ),
+        batchIndexUpdater.periodicUpdateTaskSource,
       ],
     );
     scheduler.run();


### PR DESCRIPTION
The two-hour check period is long enough that we don't build up a queue that will update the same items over and over, and the 24-hour period is for roughly matching the requirements of #1932.

I've deployed this to staging, and will monitor it before merging.