### PR TITLE
Fix NPEs in search index updates.

### DIFF
--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -71,8 +71,10 @@ class SearchBackend {
 
     final pubDataFutures = Future.wait<String>(
       packages.map(
-        (p) => dartdocClient.getTextContent(p.name, 'latest', 'pub-data.json',
-            timeout: const Duration(minutes: 1)),
+        (p) => p == null
+            ? Future<String>.value()
+            : dartdocClient.getTextContent(p.name, 'latest', 'pub-data.json',
+                timeout: const Duration(minutes: 1)),
       ),
     );
 

--- a/app/lib/search/updater.dart
+++ b/app/lib/search/updater.dart
@@ -133,6 +133,9 @@ class BatchIndexUpdater implements TaskRunner {
 
         await _updateSnapshotIfNeeded(docs);
       }
+    } catch (e, st) {
+      _logger.warning('Index update error.', e, st);
+      rethrow;
     } finally {
       completer.complete();
       _ongoingBatchUpdate = null;

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -36,6 +36,9 @@ class AnalyzerClient {
   }
 
   Future<AnalysisView> getAnalysisView(AnalysisKey key) async {
+    if (key == null) {
+      return null;
+    }
     final card = await scoreCardBackend
         .getScoreCardData(key.package, key.version, onlyCurrent: false);
     if (card == null) {


### PR DESCRIPTION
The issues were silent, because index updater did not log them and the exception is not propagated properly (opened #1984 to track it).

With the periodic snapshot update, this will address #1954.