### PR TITLE
Simplify search index updates.

### DIFF
--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -39,7 +39,7 @@ void main() {
         registerPackageIndex(new SimplePackageIndex());
         registerDartSdkIndex(new SimplePackageIndex());
         await packageIndex
-            .addPackages(await searchBackend.loadDocuments(['pkg_foo']));
+            .addPackage(await searchBackend.loadDocument('pkg_foo'));
         await packageIndex.merge();
       }
 
@@ -116,17 +116,18 @@ class MockSearchBackend implements SearchBackend {
   List<String> packages = ['pkg_foo'];
 
   @override
-  Future<List<PackageDocument>> loadDocuments(List<String> packages) async {
-    return packages.map((String package) {
-      return new PackageDocument(
-        package: package,
-        version: '1.0.1',
-        devVersion: '1.0.1-dev',
-        platforms: ['web', 'other'],
-        description: 'Foo package about nothing really. Maybe JSON.',
-        readme: 'Some JSON to XML mapping.',
-        popularity: 0.1,
-      );
-    }).toList();
+  Future<PackageDocument> loadDocument(String packageName) async {
+    if (!packages.contains(packageName)) {
+      return null;
+    }
+    return PackageDocument(
+      package: packageName,
+      version: '1.0.1',
+      devVersion: '1.0.1-dev',
+      platforms: ['web', 'other'],
+      description: 'Foo package about nothing really. Maybe JSON.',
+      readme: 'Some JSON to XML mapping.',
+      popularity: 0.1,
+    );
   }
 }


### PR DESCRIPTION
The batch updates were introduced to:
- Follow the batch updates of typical search indexes (e.g. Lucene is more efficient if more updates are merged at the same time), in case we were to migrate to any of them.
- Make Datastore access of `Package` and `PackageVersion` entries more efficient.

Over time it was extended with the analysis/scorecard entries and with extracted dartdoc content, and the efficiency of Datastore access is less of a concern, as the other parts dominate the processing time.

This change improves the cache access timeouts (#1971), as it reduces the concurrent access to Redis.

Fixes #1984.
