### PR TITLE
PackageVersion derivatives: pubspec and info.

### DIFF
--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -635,10 +635,12 @@ void main() {
       final dateBeforeTest = new DateTime.now().toUtc();
 
       void validateSuccessfullUpdate(List<Model> inserts) {
-        expect(inserts, hasLength(3));
+        expect(inserts, hasLength(5));
         final package = inserts[0] as Package;
         final version = inserts[1] as PackageVersion;
-        final history = inserts[2] as History;
+        final versionPubspec = inserts[2] as PackageVersionPubspec;
+        final versionInfo = inserts[3] as PackageVersionInfo;
+        final history = inserts[4] as History;
 
         expect(package.key, testPackage.key);
         expect(package.name, testPackage.name);
@@ -657,8 +659,28 @@ void main() {
         expect(version.pubspec.asJson, loadYaml(testPackagePubspec));
         expect(version.libraries, ['test_library.dart']);
         expect(version.downloads, 0);
-
         expect(version.sortOrder, 1);
+
+        expect(versionPubspec.id, 'foobar_pkg-0.1.1+5');
+        expect(versionPubspec.namespace, isNull);
+        expect(versionPubspec.package, testPackage.name);
+        expect(versionPubspec.qualifiedPackage, testPackage.name);
+        expect(versionPubspec.version, testPackageVersion.version);
+        expect(versionPubspec.updated.compareTo(dateBeforeTest) >= 0, isTrue);
+        expect(versionPubspec.pubspec.asJson, loadYaml(testPackagePubspec));
+
+        expect(versionInfo.id, 'foobar_pkg-0.1.1+5');
+        expect(versionInfo.namespace, isNull);
+        expect(versionInfo.package, testPackage.name);
+        expect(versionInfo.qualifiedPackage, testPackage.name);
+        expect(versionInfo.version, testPackageVersion.version);
+        expect(versionInfo.updated.compareTo(dateBeforeTest) >= 0, isTrue);
+        expect(versionInfo.readmeFilename, 'README.md');
+        expect(versionInfo.readmeContent, testPackageReadme);
+        expect(versionInfo.changelogFilename, 'CHANGELOG.md');
+        expect(versionInfo.changelogContent, testPackageChangelog);
+        expect(versionInfo.libraries, ['test_library.dart']);
+        expect(versionInfo.libraryCount, 1);
 
         expect(history.packageName, testPackage.name);
         expect(history.packageVersion, testPackageVersion.version);


### PR DESCRIPTION
Last week we've discussed the possibility of splitting up `PackageVersion` into multiple objects:
- `PackageVersionPubspec` to store only the pubspec (for quick access)
- `PackageVersionInfo` to store the heavier details for package page
- `PackageVersion` could keep the immutable info about the package

Once we (a) start to store them in parallel and (b) have a migration process to update past entries, we can move the readers to use the new ones, and also to remove the extra fields from Datastore.

I've added `QualifiedVersionKey` to standardize the id-generation of the namespaced package names.