### PR TITLE
Limit readme, changelog and example length.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -30,6 +30,9 @@ import 'upload_signer_service.dart';
 
 final Logger _logger = new Logger('pub.cloud_repository');
 final _random = new Random.secure();
+// The maximum stored length of `README.md` and other user-provided file content
+// that is stored separately in the database.
+final _maxStoredLength = 128 * 1024;
 
 /// Sets the active logged-in user.
 void registerLoggedInUser(String user) => ss.register(#_logged_in_user, user);
@@ -982,13 +985,16 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
   }
 
   final readmeContent = readmeFilename != null
-      ? await readTarballFile(filename, readmeFilename)
+      ? await readTarballFile(filename, readmeFilename,
+          maxLength: _maxStoredLength)
       : null;
   final changelogContent = changelogFilename != null
-      ? await readTarballFile(filename, changelogFilename)
+      ? await readTarballFile(filename, changelogFilename,
+          maxLength: _maxStoredLength)
       : null;
   String exampleContent = exampleFilename != null
-      ? await readTarballFile(filename, exampleFilename)
+      ? await readTarballFile(filename, exampleFilename,
+          maxLength: _maxStoredLength)
       : null;
 
   if (exampleContent != null && exampleContent.trim().isEmpty) {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -68,7 +68,8 @@ Future<List<String>> listTarball(String path) async {
       .toList();
 }
 
-Future<String> readTarballFile(String path, String name) async {
+Future<String> readTarballFile(String path, String name,
+    {int maxLength = 0}) async {
   final result = await Process.run(
     'tar',
     ['-O', '-xzf', path, name],
@@ -77,8 +78,11 @@ Future<String> readTarballFile(String path, String name) async {
   if (result.exitCode != 0) {
     throw new Exception('Failed to read tarball contents.');
   }
-
-  return result.stdout as String;
+  String content = result.stdout as String;
+  if (maxLength > 0 && content.length > maxLength) {
+    content = content.substring(0, maxLength) + '[...]\n\n';
+  }
+  return content;
 }
 
 String canonicalizeVersion(String version) {

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -68,6 +68,10 @@ Future<List<String>> listTarball(String path) async {
       .toList();
 }
 
+/// Reads a text content of [name] from the tar.gz file identified by [path].
+///
+/// When [maxLength] is specified, the text content is cut at [maxLength]
+/// characters (with `[...]\n\n` added to it).
 Future<String> readTarballFile(String path, String name,
     {int maxLength = 0}) async {
   final result = await Process.run(


### PR DESCRIPTION
This is not an exact byte-length, but something to start with. I think we'll need to have a pana suggestion and some kind of penalty for large files. 