### PR TITLE
Using userId for uploader handling

### DIFF
--- a/app/bin/tools/uploader.dart
+++ b/app/bin/tools/uploader.dart
@@ -68,10 +68,10 @@ Future addUploader(String packageName, String uploaderEmail) async {
       throw new Exception('Package $packageName does not exist.');
     }
     print('Current uploaders: ${package.uploaderEmails}');
-    if (package.hasUploader(uploaderEmail)) {
+    final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
+    if (package.hasUploader(user.userId, uploaderEmail)) {
       throw new Exception('Uploader $uploaderEmail already exists');
     }
-    final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
     package.addUploader(user.userId, uploaderEmail);
     T.queueMutations(inserts: [package]);
     await T.commit();
@@ -95,13 +95,13 @@ Future removeUploader(String packageName, String uploaderEmail) async {
     }
 
     print('Current uploaders: ${package.uploaderEmails}');
-    if (!package.hasUploader(uploaderEmail)) {
+    final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
+    if (!package.hasUploader(user.userId, uploaderEmail)) {
       throw new Exception('Uploader $uploaderEmail does not exist');
     }
     if (package.uploaderCount <= 1) {
       throw new Exception('Would remove last uploader');
     }
-    final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
     package.removeUploader(user.userId, uploaderEmail);
     T.queueMutations(inserts: [package]);
     await T.commit();

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -685,7 +685,9 @@ class GCloudPackageRepository extends PackageRepository {
       }
 
       // Add [uploaderEmail] to uploaders and commit.
-      package.addUploader(uploaderEmail);
+      final uploader =
+          await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
+      package.addUploader(uploader.userId, uploaderEmail);
 
       final inserts = <Model>[package];
       if (historyBackend.isEnabled) {
@@ -764,7 +766,9 @@ class GCloudPackageRepository extends PackageRepository {
         }
 
         // Remove the uploader from the list.
-        package.removeUploader(uploaderEmail);
+        final uploader =
+            await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
+        package.removeUploader(uploader.userId, uploaderEmail);
 
         final inserts = <Model>[package];
         if (historyBackend.isEnabled) {

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -766,7 +766,7 @@ class GCloudPackageRepository extends PackageRepository {
         // At the moment we don't validate whether the other e-mail addresses
         // are able to authenticate. To prevent accidentally losing the control
         // of a package, we don't allow self-removal.
-        if (userEmail == uploaderEmail) {
+        if (userEmail == uploaderEmail || user.userId == uploader.userId) {
           await T.rollback();
           throw new GenericProcessingException('Self-removal is not allowed. '
               'Use another account to remove this e-mail address.');

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -756,6 +756,13 @@ class GCloudPackageRepository extends PackageRepository {
               'The uploader to remove does not exist.');
         }
 
+        // We cannot have 0 uploaders, if we would remove the last one, we
+        // fail with an error.
+        if (package.uploaderCount <= 1) {
+          await T.rollback();
+          throw new LastUploaderRemoveException();
+        }
+
         // At the moment we don't validate whether the other e-mail addresses
         // are able to authenticate. To prevent accidentally losing the control
         // of a package, we don't allow self-removal.
@@ -763,13 +770,6 @@ class GCloudPackageRepository extends PackageRepository {
           await T.rollback();
           throw new GenericProcessingException('Self-removal is not allowed. '
               'Use another account to remove this e-mail address.');
-        }
-
-        // We cannot have 0 uploaders, if we would remove the last one, we
-        // fail with an error.
-        if (package.uploaderCount <= 1) {
-          await T.rollback();
-          throw new LastUploaderRemoveException();
         }
 
         // Remove the uploader from the list.

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -80,17 +80,22 @@ class Package extends db.ExpandoModel {
   }
 
   // Check if a user is an uploader for a package.
-  bool hasUploader(String email) {
-    return uploaderEmails
-        .map((s) => s.toLowerCase())
-        .contains(email.toLowerCase());
+  bool hasUploader(String uploaderId, String uploaderEmail) {
+    if (uploaderId != null && uploaders.contains(uploaderId)) {
+      return true;
+    }
+    // fallback to emails in case the migration did not happen to this yet
+    final lowerEmail = uploaderEmail.toLowerCase();
+    return uploaderEmails.any((s) => s.toLowerCase() == lowerEmail);
   }
 
   int get uploaderCount => uploaderEmails.length;
 
   /// Add the id and the email to the list of uploaders.
   void addUploader(String uploaderId, String uploaderEmail) {
-    uploaders.add(uploaderId);
+    if (uploaderId != null) {
+      uploaders.add(uploaderId);
+    }
     uploaderEmails.add(uploaderEmail);
   }
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -86,6 +86,12 @@ class Package extends db.ExpandoModel {
         .contains(email.toLowerCase());
   }
 
+  int get uploaderCount => uploaderEmails.length;
+
+  void addUploader(String email) {
+    uploaderEmails.add(email);
+  }
+
   // Remove the email from the list of uploaders.
   void removeUploader(String email) {
     final lowerEmail = email.toLowerCase();

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -88,17 +88,17 @@ class Package extends db.ExpandoModel {
 
   int get uploaderCount => uploaderEmails.length;
 
-  void addUploader(String email) {
-    uploaderEmails.add(email);
+  /// Add the id and the email to the list of uploaders.
+  void addUploader(String uploaderId, String uploaderEmail) {
+    uploaders.add(uploaderId);
+    uploaderEmails.add(uploaderEmail);
   }
 
   // Remove the email from the list of uploaders.
-  void removeUploader(String email) {
-    final lowerEmail = email.toLowerCase();
-    uploaderEmails = uploaderEmails
-        .map((s) => s.toLowerCase())
-        .where((email) => email != lowerEmail)
-        .toList();
+  void removeUploader(String uploaderId, String uploaderEmail) {
+    final lowerEmail = uploaderEmail.toLowerCase();
+    uploaders.removeWhere((s) => s == uploaderId);
+    uploaderEmails.removeWhere((s) => s.toLowerCase() == lowerEmail);
   }
 
   void updateVersion(PackageVersion pv) {

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -317,6 +317,7 @@ void main() {
 
         final pkg = testPackage.name;
         registerAuthenticatedUser(user);
+        registerAccountBackend(AccountBackendMock());
         await repo.addUploader(pkg, newUploader);
       }
 
@@ -357,6 +358,7 @@ void main() {
         );
         final tarballStorage = new TarballStorageMock();
         final repo = new GCloudPackageRepository(db, tarballStorage);
+        registerAccountBackend(AccountBackendMock());
 
         registerBackend(BackendMock(updatePackageInviteFn: (
             {packageName, type, recipientEmail, fromEmail}) async {
@@ -458,6 +460,7 @@ void main() {
 
         final pkg = testPackage.name;
         registerAuthenticatedUser(testUploaderUser);
+        registerAccountBackend(AccountBackendMock());
         await repo
             .removeUploader(pkg, testUploaderUser.email)
             .catchError(expectAsync2((e, _) {
@@ -479,6 +482,7 @@ void main() {
 
         final pkg = testPackage.name;
         registerAuthenticatedUser(testUploaderUser);
+        registerAccountBackend(AccountBackendMock());
         await repo
             .removeUploader(pkg, 'foo2@bar.com')
             .catchError(expectAsync2((e, _) {
@@ -503,6 +507,7 @@ void main() {
 
         final pkg = testPackage.name;
         registerAuthenticatedUser(foo1);
+        registerAccountBackend(AccountBackendMock());
         await repo
             .removeUploader(pkg, 'foo1@bar.com')
             .catchError(expectAsync2((e, _) {
@@ -536,6 +541,7 @@ void main() {
 
         final pkg = testPackage.name;
         registerAuthenticatedUser(userA);
+        registerAccountBackend(AccountBackendMock());
         await repo.removeUploader(pkg, 'b@x.com');
       });
     });

--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -13,6 +13,8 @@ import 'package:pub_dartlang_org/history/models.dart';
 import 'package:pub_dartlang_org/shared/email.dart';
 import 'package:pub_server/repository.dart' show AsyncUploadInfo;
 
+import 'package:pub_dartlang_org/account/backend.dart';
+import 'package:pub_dartlang_org/account/models.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/email_sender.dart';
 import 'package:pub_dartlang_org/frontend/upload_signer_service.dart';
@@ -431,5 +433,38 @@ class EmailSenderMock implements EmailSender {
   Future sendMessage(EmailMessage message) async {
     sentMessages.add(message);
     return;
+  }
+}
+
+class AccountBackendMock implements AccountBackend {
+  final List<User> users;
+
+  AccountBackendMock({List<User> users})
+      : users = List<User>.from(users ?? const <User>[]);
+
+  @override
+  Future<User> lookupOrCreateUserByEmail(String email) async {
+    return users.firstWhere((u) => u.email == email, orElse: () {
+      final u = User()
+        ..id = email.hashCode.toString()
+        ..email = email;
+      users.add(u);
+      return u;
+    });
+  }
+
+  @override
+  Future<User> lookupUserById(String userId) async {
+    return users.firstWhere((u) => u.userId == userId, orElse: () => null);
+  }
+
+  @override
+  Future<AuthenticatedUser> authenticateWithAccessToken(String accessToken) {
+    return null;
+  }
+
+  @override
+  Future close() {
+    return null;
   }
 }

--- a/app/test/frontend/utils.dart
+++ b/app/test/frontend/utils.dart
@@ -52,6 +52,7 @@ Package createTestPackage({List<AuthenticatedUser> uploaders}) {
     ..name = testPackageKey.id as String
     ..created = new DateTime.utc(2014)
     ..updated = new DateTime.utc(2015)
+    ..uploaders = uploaders.map((user) => user.userId).toList()
     ..uploaderEmails = uploaders.map((user) => user.email).toList()
     ..latestVersionKey = testPackageVersionKey
     ..latestDevVersionKey = testPackageVersionKey;


### PR DESCRIPTION
- keeps working with e-mail addresses only, but `userId` is checked first
- the confirmation of the add-uploader flow is still based on e-mail click only, we don't yet require a second UI authorization flow