### PR TITLE
Fix: PackageVersion[Info|Pubspec]

### DIFF
--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -269,7 +269,7 @@ class PackageVersionPubspec extends db.ExpandoModel {
 
   void initFromKey(QualifiedVersionKey key) {
     id = key.qualifiedVersion;
-    namespace = key.namespace;
+    namespace = key.namespace ?? '';
     package = key.package;
     qualifiedPackage = key.qualifiedPackage;
     version = key.version;
@@ -343,7 +343,7 @@ class PackageVersionInfo extends db.ExpandoModel {
 
   void initFromKey(QualifiedVersionKey key) {
     id = key.qualifiedVersion;
-    namespace = key.namespace;
+    namespace = key.namespace ?? '';
     package = key.package;
     qualifiedPackage = key.qualifiedPackage;
     version = key.version;
@@ -363,7 +363,7 @@ class QualifiedVersionKey {
   });
 
   String get qualifiedPackage =>
-      namespace == null ? package : '$namespace:$package';
+      namespace == null || namespace.isEmpty ? package : '$namespace:$package';
 
   String get qualifiedVersion => '$qualifiedPackage-$version';
 }

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -684,7 +684,7 @@ void main() {
         expect(version.sortOrder, 1);
 
         expect(versionPubspec.id, 'foobar_pkg-0.1.1+5');
-        expect(versionPubspec.namespace, isNull);
+        expect(versionPubspec.namespace, '');
         expect(versionPubspec.package, testPackage.name);
         expect(versionPubspec.qualifiedPackage, testPackage.name);
         expect(versionPubspec.version, testPackageVersion.version);
@@ -692,7 +692,7 @@ void main() {
         expect(versionPubspec.pubspec.asJson, loadYaml(testPackagePubspec));
 
         expect(versionInfo.id, 'foobar_pkg-0.1.1+5');
-        expect(versionInfo.namespace, isNull);
+        expect(versionInfo.namespace, '');
         expect(versionInfo.package, testPackage.name);
         expect(versionInfo.qualifiedPackage, testPackage.name);
         expect(versionInfo.version, testPackageVersion.version);


### PR DESCRIPTION
The `namespace` field has an annotation of required and mustn't be null. Setting it to empty string also helps with filtering queries on the global namespace (if it is ever a concern).