### PR TITLE
Remove customizationVersion.

### DIFF
--- a/app/lib/dartdoc/dartdoc_runner.dart
+++ b/app/lib/dartdoc/dartdoc_runner.dart
@@ -150,7 +150,6 @@ class DartdocJobProcessor extends JobProcessor {
           'pana: ${versions.panaVersion}\n'
           'dartdoc: ${versions.dartdocVersion}\n'
           'flutter: ${versions.flutterVersion}\n'
-          'customization: ${versions.customizationVersion}\n'
           'usesFlutter: $usesFlutter\n'
           'started: ${new DateTime.now().toUtc().toIso8601String()}\n\n');
 
@@ -393,7 +392,6 @@ class DartdocJobProcessor extends JobProcessor {
       sdkVersion: versions.toolEnvSdkVersion,
       dartdocVersion: versions.dartdocVersion,
       flutterVersion: versions.flutterVersion,
-      customizationVersion: versions.customizationVersion,
       timestamp: new DateTime.now().toUtc(),
       depsResolved: depsResolved,
       hasContent: hasContent,

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -44,10 +44,6 @@ class DartdocEntry {
   /// The version of Flutter that was used to fetch dependencies.
   final String flutterVersion;
 
-  /// The version of pub site customization over the dartdoc-generated HTML.
-  /// See [versions.customizationVersion].
-  final String customizationVersion;
-
   /// When the content was generated.
   final DateTime timestamp;
 
@@ -74,7 +70,6 @@ class DartdocEntry {
     @required this.sdkVersion,
     @required this.dartdocVersion,
     @required this.flutterVersion,
-    @required this.customizationVersion,
     @required this.timestamp,
     @required this.depsResolved,
     @required this.hasContent,
@@ -108,7 +103,6 @@ class DartdocEntry {
       sdkVersion: sdkVersion,
       dartdocVersion: dartdocVersion,
       flutterVersion: flutterVersion,
-      customizationVersion: customizationVersion,
       timestamp: timestamp,
       depsResolved: depsResolved,
       hasContent: hasContent,

--- a/app/lib/dartdoc/models.g.dart
+++ b/app/lib/dartdoc/models.g.dart
@@ -18,7 +18,6 @@ DartdocEntry _$DartdocEntryFromJson(Map<String, dynamic> json) {
       sdkVersion: json['sdkVersion'] as String,
       dartdocVersion: json['dartdocVersion'] as String,
       flutterVersion: json['flutterVersion'] as String,
-      customizationVersion: json['customizationVersion'] as String,
       timestamp: json['timestamp'] == null
           ? null
           : DateTime.parse(json['timestamp'] as String),
@@ -40,7 +39,6 @@ Map<String, dynamic> _$DartdocEntryToJson(DartdocEntry instance) =>
       'sdkVersion': instance.sdkVersion,
       'dartdocVersion': instance.dartdocVersion,
       'flutterVersion': instance.flutterVersion,
-      'customizationVersion': instance.customizationVersion,
       'timestamp': instance.timestamp?.toIso8601String(),
       'depsResolved': instance.depsResolved,
       'hasContent': instance.hasContent,

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -136,7 +136,6 @@ shelf.Response debugResponse([Map<String, dynamic> data]) {
       'pana': panaVersion,
       'flutter': flutterVersion,
       'dartdoc': dartdocVersion,
-      'customization': customizationVersion,
     },
     'scheduler': latestSchedulerStats,
   };

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -48,12 +48,6 @@ final Version semanticFlutterVersion = new Version.parse(flutterVersion);
 final String dartdocVersion = '0.28.0';
 final Version semanticDartdocVersion = new Version.parse(dartdocVersion);
 
-/// The version of our customization going into the output of the dartdoc static
-/// HTML files.
-final String customizationVersion = '0.0.2';
-final Version semanticCustomizationVersion =
-    new Version.parse(customizationVersion);
-
 // Version that control the dartdoc serving.
 // Pin this to a specific version when there is a coordinated upgrade of the
 // generated documentation template or style. The new version can generate the

--- a/app/test/dartdoc/storage_path_test.dart
+++ b/app/test/dartdoc/storage_path_test.dart
@@ -31,7 +31,6 @@ void main() {
       sdkVersion: '2.0.0-dev.32.0',
       dartdocVersion: '0.16.0',
       flutterVersion: '0.1.6',
-      customizationVersion: '0.0.1',
       timestamp: new DateTime(2018, 03, 08),
       depsResolved: true,
       hasContent: true,

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -26,12 +26,11 @@ void main() {
       flutterVersion,
       panaVersion,
       dartdocVersion,
-      customizationVersion,
     ].join('//').hashCode;
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 789460723);
+    expect(hash, 51055713);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {


### PR DESCRIPTION
This predates `runtimeVersion`, and since we are using that, we don't use the `customizationVersion` for anything.