### PR TITLE
Extract the mustache template of the versions tab into separate file.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -110,6 +110,27 @@ String _renderInstallTab(Package package, PackageVersion selectedVersion,
   });
 }
 
+String _renderVersionsTab(
+  PackageVersion selectedVersion,
+  List<PackageVersion> versions,
+  List<Uri> versionDownloadUrls,
+  int totalNumberOfVersions,
+) {
+  final versionTableRows = [];
+  for (int i = 0; i < versions.length; i++) {
+    final PackageVersion version = versions[i];
+    final String url = versionDownloadUrls[i].toString();
+    versionTableRows.add(renderVersionTableRow(version, url));
+  }
+  return templateCache.renderTemplate('pkg/versions_tab', {
+    'package_name': selectedVersion.package,
+    'version_table_rows': versionTableRows,
+    'show_versions_link': totalNumberOfVersions > versions.length,
+    'versions_url': urls.pkgVersionsUrl(selectedVersion.package),
+    'version_count': '$totalNumberOfVersions',
+  });
+}
+
 /// Renders the `views/pkg/show.mustache` template.
 String renderPkgShowPage(
     Package package,
@@ -160,13 +181,6 @@ String renderPkgShowPage(
           '</p>\n'
           '$renderedExample';
     }
-  }
-
-  final versionTableRows = [];
-  for (int i = 0; i < versions.length; i++) {
-    final PackageVersion version = versions[i];
-    final String url = versionDownloadUrls[i].toString();
-    versionTableRows.add(renderVersionTableRow(version, url));
   }
 
   final bool shouldShowDev =
@@ -276,16 +290,14 @@ String renderPkgShowPage(
       'schema_org_pkgmeta_json':
           json.encode(_schemaOrgPkgMeta(package, selectedVersion, analysis)),
     },
-    'version_table_rows': versionTableRows,
-    'show_versions_link': totalNumberOfVersions > versions.length,
-    'versions_url': urls.pkgVersionsUrl(package.name),
     'tabs': tabs,
     'has_no_file_tab': tabs.isEmpty,
-    'version_count': '$totalNumberOfVersions',
     'icons': staticUrls.versionsTableIcons,
     'search_deps_link': urls.searchUrl(q: 'dependency:${package.name}'),
     'install_tab_html': _renderInstallTab(
         package, selectedVersion, isFlutterPackage, analysis?.platforms),
+    'versions_tab_html': _renderVersionsTab(
+        selectedVersion, versions, versionDownloadUrls, totalNumberOfVersions),
   };
   final content = templateCache.renderTemplate('pkg/show', values);
   final packageAndVersion = isVersionPage

--- a/app/lib/frontend/templates/views/pkg/show.mustache
+++ b/app/lib/frontend/templates/views/pkg/show.mustache
@@ -40,24 +40,7 @@
 {{& install_tab_html}}
     </section>
     <section class="content js-content" data-name="-versions-tab-">
-      <table class="version-table" data-package="{{package.name}}">
-        <thead>
-        <tr>
-          <th>Version</th>
-          <th>Uploaded</th>
-          <th class="documentation" width="60">Documentation</th>
-          <th class="archive" width="60">Archive</th>
-        </tr>
-        </thead>
-        {{#version_table_rows}}{{& .}}{{/version_table_rows}}
-      </table>
-      {{#show_versions_link}}
-        <p>
-          <a href="{{& versions_url}}">
-            All {{version_count}} versions...
-          </a>
-        </p>
-      {{/show_versions_link}}
+      {{& versions_tab_html}}
     </section>
     <section class="content js-content" data-name="-analysis-tab-">
       {{^package.analysis_html}}

--- a/app/lib/frontend/templates/views/pkg/versions_tab.mustache
+++ b/app/lib/frontend/templates/views/pkg/versions_tab.mustache
@@ -1,0 +1,25 @@
+{{! Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<table class="version-table" data-package="{{package_name}}">
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Uploaded</th>
+      <th class="documentation" width="60">Documentation</th>
+      <th class="archive" width="60">Archive</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{#version_table_rows}}
+    {{& .}}
+  {{/version_table_rows}}
+  </tbody>
+</table>
+
+{{#show_versions_link}}
+  <p>
+    <a href="{{& versions_url}}">All {{version_count}} versions...</a>
+  </p>
+{{/show_versions_link}}

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -172,24 +172,26 @@ import 'package:foobar_pkg/foolib.dart';
                   <th class="archive" width="60">Archive</th>
                 </tr>
               </thead>
-              <tr data-version="0.1.1+5">
-                <td>
-                  <strong>
-                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                  </strong>
-                </td>
-                <td>Jan 1, 2014</td>
-                <td class="documentation">
-                  <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                    <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                  </a>
-                </td>
-                <td class="archive">
-                  <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                    <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                  </a>
-                </td>
-              </tr>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </section>
           <section class="content js-content" data-name="-analysis-tab-">

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -163,24 +163,26 @@ import 'package:foobar_pkg/foolib.dart';
                   <th class="archive" width="60">Archive</th>
                 </tr>
               </thead>
-              <tr data-version="0.1.1+5">
-                <td>
-                  <strong>
-                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                  </strong>
-                </td>
-                <td>Jan 1, 2014</td>
-                <td class="documentation">
-                  <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                    <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                  </a>
-                </td>
-                <td class="archive">
-                  <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                    <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                  </a>
-                </td>
-              </tr>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </section>
           <section class="content js-content" data-name="-analysis-tab-">

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -150,24 +150,26 @@ import 'package:foobar_pkg/foolib.dart';
                   <th class="archive" width="60">Archive</th>
                 </tr>
               </thead>
-              <tr data-version="0.1.1+5">
-                <td>
-                  <strong>
-                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                  </strong>
-                </td>
-                <td>Jan 1, 2015</td>
-                <td class="documentation">
-                  <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                    <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                  </a>
-                </td>
-                <td class="archive">
-                  <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                    <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                  </a>
-                </td>
-              </tr>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2015</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </section>
           <section class="content js-content" data-name="-analysis-tab-">

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -164,24 +164,26 @@ import 'package:foobar_pkg/foolib.dart';
                   <th class="archive" width="60">Archive</th>
                 </tr>
               </thead>
-              <tr data-version="0.1.1+5">
-                <td>
-                  <strong>
-                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                  </strong>
-                </td>
-                <td>Jan 1, 2014</td>
-                <td class="documentation">
-                  <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                    <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                  </a>
-                </td>
-                <td class="archive">
-                  <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                    <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                  </a>
-                </td>
-              </tr>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </section>
           <section class="content js-content" data-name="-analysis-tab-">

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -164,24 +164,26 @@ import 'package:foobar_pkg/foolib.dart';
                   <th class="archive" width="60">Archive</th>
                 </tr>
               </thead>
-              <tr data-version="0.1.1+5">
-                <td>
-                  <strong>
-                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                  </strong>
-                </td>
-                <td>Jan 1, 2014</td>
-                <td class="documentation">
-                  <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                    <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                  </a>
-                </td>
-                <td class="archive">
-                  <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                    <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                  </a>
-                </td>
-              </tr>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </section>
           <section class="content js-content" data-name="-analysis-tab-">

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -174,24 +174,26 @@ import 'package:foobar_pkg/foolib.dart';
                   <th class="archive" width="60">Archive</th>
                 </tr>
               </thead>
-              <tr data-version="0.1.1+5">
-                <td>
-                  <strong>
-                    <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
-                  </strong>
-                </td>
-                <td>Jan 1, 2014</td>
-                <td class="documentation">
-                  <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
-                    <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
-                  </a>
-                </td>
-                <td class="archive">
-                  <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
-                    <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
-                  </a>
-                </td>
-              </tr>
+              <tbody>
+                <tr data-version="0.1.1+5">
+                  <td>
+                    <strong>
+                      <a href="/packages/foobar_pkg/versions/0.1.1+5">0.1.1+5</a>
+                    </strong>
+                  </td>
+                  <td>Jan 1, 2014</td>
+                  <td class="documentation">
+                    <a href="/documentation/foobar_pkg/0.1.1+5/" rel="nofollow" title="Go to the documentation of foobar_pkg 0.1.1+5">
+                      <img src="/static/img/ic_drive_document_black_24dp.svg" alt="Go to the documentation of foobar_pkg 0.1.1+5"/>
+                    </a>
+                  </td>
+                  <td class="archive">
+                    <a href="http://dart-example.com/" title="Download foobar_pkg 0.1.1+5 archive">
+                      <img src="/static/img/ic_get_app_black_24dp.svg" alt="Download foobar_pkg 0.1.1+5 archive"/>
+                    </a>
+                  </td>
+                </tr>
+              </tbody>
             </table>
           </section>
           <section class="content js-content" data-name="-analysis-tab-">


### PR DESCRIPTION
There is one template change: I've added a `<tbody>` element for grouping the rows, as we had already a separate `<thead>`.