### PR TITLE
Replacing the use of uploaderEmail(s)

### DIFF
--- a/app/bin/tools/dart2_constraint_stats.dart
+++ b/app/bin/tools/dart2_constraint_stats.dart
@@ -15,6 +15,7 @@ import 'package:gcloud/db.dart';
 import 'package:gcloud/storage.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import 'package:pub_dartlang_org/account/backend.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/model_properties.dart';
 import 'package:pub_dartlang_org/frontend/service_utils.dart';
@@ -48,6 +49,7 @@ Future main(List<String> args) async {
   final onlyDart2Packages = <String>[];
 
   await withProdServices(() async {
+    registerAccountBackend(AccountBackend(dbService));
     final bucket =
         storageService.bucket(activeConfiguration.popularityDumpBucketName);
     registerPopularityStorage(new PopularityStorage(storageService, bucket));
@@ -105,7 +107,9 @@ Future main(List<String> args) async {
         }
       }
       if (selectForNotification && allowsDartDev && !allowsDart2) {
-        authorsToNotify.add(latest.uploaderEmail);
+        final uploaderEmail =
+            await accountBackend.getEmailOfUserId(latest.uploader);
+        authorsToNotify.add(uploaderEmail);
         packagesToNotify.add(p.name);
       }
     }

--- a/app/bin/tools/uploader.dart
+++ b/app/bin/tools/uploader.dart
@@ -55,7 +55,9 @@ Future listUploaders(String packageName) async {
     if (package == null) {
       throw new Exception('Package $packageName does not exist.');
     }
-    print('Current uploaders: ${package.uploaderEmails}');
+    final uploaderEmails =
+        await accountBackend.getEmailsOfUserIds(package.uploaders);
+    print('Current uploaders: $uploaderEmails');
   });
 }
 
@@ -67,7 +69,9 @@ Future addUploader(String packageName, String uploaderEmail) async {
     if (package == null) {
       throw new Exception('Package $packageName does not exist.');
     }
-    print('Current uploaders: ${package.uploaderEmails}');
+    final uploaderEmails =
+        await accountBackend.getEmailsOfUserIds(package.uploaders);
+    print('Current uploaders: $uploaderEmails');
     final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
     if (package.hasUploader(user.userId, uploaderEmail)) {
       throw new Exception('Uploader $uploaderEmail already exists');
@@ -97,7 +101,9 @@ Future removeUploader(String packageName, String uploaderEmail) async {
       throw new Exception('Package $packageName does not exist.');
     }
 
-    print('Current uploaders: ${package.uploaderEmails}');
+    final uploaderEmails =
+        await accountBackend.getEmailsOfUserIds(package.uploaders);
+    print('Current uploaders: $uploaderEmails');
     final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
     if (!package.hasUploader(user.userId, uploaderEmail)) {
       throw new Exception('Uploader $uploaderEmail does not exist');

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -490,11 +490,11 @@ class GCloudPackageRepository extends PackageRepository {
       // Check if the uploader of the new version is allowed to upload to
       // the package.
       if (!package.hasUploader(user.userId, user.email)) {
-        _logger.info('User ${newVersion.uploaderEmail} is not an uploader '
+        _logger.info('User ${user.userId} (${user.email}) is not an uploader '
             'for package ${package.name}, rolling transaction back.');
         await T.rollback();
         throw new UnauthorizedAccessException(
-            'Unauthorized user: ${newVersion.uploaderEmail} is not allowed to '
+            'Unauthorized user: ${user.email} is not allowed to '
             'upload versions to package ${package.name}.');
       }
 
@@ -554,13 +554,16 @@ class GCloudPackageRepository extends PackageRepository {
       }
     });
 
+    final uploaderEmails =
+        await accountBackend.getEmailsOfUserIds(package.uploaders);
+
     // Notify uploaders via e-mail that a new version has been published.
     await emailSender.sendMessage(
       createPackageUploadedEmail(
         packageName: newVersion.package,
         packageVersion: newVersion.version,
-        uploaderEmail: newVersion.uploaderEmail,
-        authorizedUploaders: package.uploaderEmails
+        uploaderEmail: user.email,
+        authorizedUploaders: uploaderEmails
             .map((email) => new EmailAddress(null, email))
             .toList(),
       ),
@@ -1033,8 +1036,7 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
     ..libraries = libraries
     ..downloads = 0
     ..sortOrder = 1
-    ..uploader = user.userId
-    ..uploaderEmail = user.email;
+    ..uploader = user.userId;
 
   final versionPubspec = models.PackageVersionPubspec()
     ..initFromKey(key)

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:shelf/shelf.dart' as shelf;
 
+import '../../account/backend.dart';
 import '../../shared/analyzer_client.dart';
 import '../../shared/handlers.dart';
 import '../../shared/packages_overrides.dart';
@@ -74,9 +75,12 @@ Future<shelf.Response> _packageShowHandlerJson(
   final versions = await backend.versionsOfPackage(packageName);
   sortPackageVersionsDesc(versions, decreasing: false);
 
+  final uploaderEmails =
+      await accountBackend.getEmailsOfUserIds(package.uploaders);
+
   final json = {
     'name': package.name,
-    'uploaders': package.uploaderEmails,
+    'uploaders': uploaderEmails,
     'versions':
         versions.map((packageVersion) => packageVersion.version).toList(),
   };
@@ -160,8 +164,12 @@ Future<shelf.Response> _packageVersionHandlerHtml(
     }).toList());
     _packagePreRenderLatencyTracker.add(serviceSw.elapsed);
 
+    final uploaderEmails =
+        await accountBackend.getEmailsOfUserIds(package.uploaders);
+
     cachedPage = renderPkgShowPage(
         package,
+        uploaderEmails,
         versionName != null,
         first10Versions,
         versionDownloadUrls,

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -89,7 +89,7 @@ class Package extends db.ExpandoModel {
     return uploaderEmails.any((s) => s.toLowerCase() == lowerEmail);
   }
 
-  int get uploaderCount => uploaderEmails.length;
+  int get uploaderCount => uploaders.length;
 
   /// Add the id and the email to the list of uploaders.
   void addUploader(String uploaderId, String uploaderEmail) {

--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -113,6 +113,7 @@ String _renderInstallTab(Package package, PackageVersion selectedVersion,
 /// Renders the `views/pkg/show.mustache` template.
 String renderPkgShowPage(
     Package package,
+    List<String> uploaderEmails,
     bool isVersionPage,
     List<PackageVersion> versions,
     List<Uri> versionDownloadUrls,
@@ -264,7 +265,7 @@ String renderPkgShowPage(
       'links': links,
       // TODO: make this 'Uploaders' if Package.uploaders is > 1?!
       'uploaders_title': 'Uploader',
-      'uploaders_html': _getAuthorsHtml(package.uploaderEmails),
+      'uploaders_html': _getAuthorsHtml(uploaderEmails),
       'short_created': selectedVersion.shortCreated,
       'license_html': _renderLicenses(baseUrl, analysis?.licenses),
       'score_box_html': renderScoreBox(card?.overallScore,

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -13,6 +13,7 @@ import 'package:logging/logging.dart';
 
 import 'package:pub_dartdoc_data/pub_dartdoc_data.dart';
 
+import '../account/backend.dart';
 import '../frontend/models.dart';
 import '../shared/analyzer_client.dart';
 import '../shared/dartdoc_client.dart';
@@ -102,7 +103,7 @@ class SearchBackend {
       popularity: popularity,
       maintenance: analysisView.maintenanceScore,
       dependencies: _buildDependencies(analysisView),
-      emails: _buildEmails(p, pv),
+      emails: await _buildEmails(p, pv),
       apiDocPages: apiDocPages,
       timestamp: new DateTime.now().toUtc(),
     );
@@ -116,9 +117,10 @@ class SearchBackend {
     return dependencies;
   }
 
-  List<String> _buildEmails(Package p, PackageVersion pv) {
+  Future<List<String>> _buildEmails(Package p, PackageVersion pv) async {
     final Set<String> emails = new Set<String>();
-    emails.addAll(p.uploaderEmails.cast<String>());
+    final uploaderEmails = await accountBackend.getEmailsOfUserIds(p.uploaders);
+    emails.addAll(uploaderEmails.where((email) => email != null));
     for (String value in pv.pubspec.authors) {
       final EmailAddress author = new EmailAddress.parse(value);
       if (author.email == null) continue;

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -541,7 +541,8 @@ void main() {
 
         final pkg = testPackage.name;
         registerAuthenticatedUser(userA);
-        registerAccountBackend(AccountBackendMock());
+        registerAccountBackend(
+            AccountBackendMock(authenticatedUsers: [userA, userB]));
         await repo.removeUploader(pkg, 'b@x.com');
       });
     });
@@ -854,6 +855,8 @@ void main() {
             final repo = new GCloudPackageRepository(db, tarballStorage,
                 finishCallback: finishCallback);
             registerAuthenticatedUser(testUploaderUser);
+            registerAccountBackend(
+                AccountBackendMock(authenticatedUsers: [testUploaderUser]));
             final emailSenderMock = new EmailSenderMock();
             registerEmailSender(emailSenderMock);
             registerHistoryBackend(new HistoryBackendMock());
@@ -1044,6 +1047,8 @@ void main() {
             final repo = new GCloudPackageRepository(db, tarballStorage,
                 finishCallback: finishCallback);
             registerAuthenticatedUser(testUploaderUser);
+            registerAccountBackend(
+                AccountBackendMock(authenticatedUsers: [testUploaderUser]));
             registerHistoryBackend(new HistoryBackendMock());
             final emailSenderMock = new EmailSenderMock();
             registerEmailSender(emailSenderMock);

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -530,7 +530,7 @@ void main() {
             }),
             queueMutationFun: ({inserts, deletes}) {
               expect(inserts, hasLength(2));
-              expect(inserts.first.uploaderEmails.contains('b@x.com'), isFalse);
+              expect(inserts.first.uploaders.contains('uuid-b'), isFalse);
               expect(inserts[1] is History, isTrue);
               completion.complete();
             },
@@ -667,6 +667,7 @@ void main() {
         expect(package.key, testPackage.key);
         expect(package.name, testPackage.name);
         expect(package.latestVersionKey, testPackageVersion.key);
+        expect(package.uploaders, ['uuid-hans-at-juergen-dot-com']);
         expect(package.uploaderEmails, ['hans@juergen.com']);
         expect(package.created.compareTo(dateBeforeTest) >= 0, isTrue);
         expect(package.updated.compareTo(dateBeforeTest) >= 0, isTrue);

--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -459,6 +459,31 @@ class AccountBackendMock implements AccountBackend {
   }
 
   @override
+  Future<List<User>> lookupUsersById(List<String> userIds) async {
+    final result = <User>[];
+    for (String userId in userIds) {
+      result.add(await lookupUserById(userId));
+    }
+    return result;
+  }
+
+  @override
+  Future<String> getEmailOfUserId(String userId) async {
+    return users
+        .firstWhere((u) => u.userId == userId, orElse: () => null)
+        ?.email;
+  }
+
+  @override
+  Future<List<String>> getEmailsOfUserIds(List<String> userIds) async {
+    final result = <String>[];
+    for (String userId in userIds) {
+      result.add(await getEmailOfUserId(userId));
+    }
+    return result;
+  }
+
+  @override
   Future<AuthenticatedUser> authenticateWithAccessToken(String accessToken) {
     return null;
   }

--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -439,8 +439,16 @@ class EmailSenderMock implements EmailSender {
 class AccountBackendMock implements AccountBackend {
   final List<User> users;
 
-  AccountBackendMock({List<User> users})
-      : users = List<User>.from(users ?? const <User>[]);
+  AccountBackendMock({
+    List<User> users,
+    List<AuthenticatedUser> authenticatedUsers,
+  }) : users = List<User>.from(users ?? const <User>[]) {
+    authenticatedUsers?.forEach((u) {
+      this.users.add(User()
+        ..id = u.userId
+        ..email = u.email);
+    });
+  }
 
   @override
   Future<User> lookupOrCreateUserByEmail(String email) async {

--- a/app/test/frontend/handlers/listing_test.dart
+++ b/app/test/frontend/handlers/listing_test.dart
@@ -4,6 +4,8 @@
 
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/account/backend.dart';
+import 'package:pub_dartlang_org/account/models.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
@@ -13,6 +15,7 @@ import 'package:pub_dartlang_org/shared/search_service.dart';
 
 import '../../shared/handlers_test_utils.dart';
 import '../../shared/utils.dart';
+import '../backend_test_utils.dart';
 import '../mocks.dart';
 import '../utils.dart';
 
@@ -48,6 +51,11 @@ Future main() async {
         expect(package, 'foobar_pkg');
         return [testPackageVersion];
       });
+      registerAccountBackend(AccountBackendMock(users: [
+        User()
+          ..id = 'uuid-hans-at-juergen-dot-com'
+          ..email = 'hans@juergen.com',
+      ]));
       registerBackend(backend);
       await expectJsonResponse(await issueGet('/packages/foobar_pkg.json'),
           body: {

--- a/app/test/frontend/handlers/package_test.dart
+++ b/app/test/frontend/handlers/package_test.dart
@@ -4,6 +4,8 @@
 
 import 'package:test/test.dart';
 
+import 'package:pub_dartlang_org/account/backend.dart';
+import 'package:pub_dartlang_org/account/models.dart';
 import 'package:pub_dartlang_org/frontend/backend.dart';
 import 'package:pub_dartlang_org/frontend/static_files.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
@@ -11,6 +13,7 @@ import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 
 import '../../shared/handlers_test_utils.dart';
+import '../backend_test_utils.dart';
 import '../mocks.dart';
 import '../utils.dart';
 
@@ -31,6 +34,11 @@ Future main() async {
         return Uri.parse('http://blobstore/$package/$version');
       });
       registerBackend(backend);
+      registerAccountBackend(AccountBackendMock(users: [
+        User()
+          ..id = 'uuid-hans-at-juergen-dot-com'
+          ..email = 'hans@juergen.com',
+      ]));
       registerAnalyzerClient(new AnalyzerClientMock());
       registerDartdocClient(new DartdocClientMock());
       registerScoreCardBackend(new ScoreCardBackendMock());
@@ -81,6 +89,11 @@ Future main() async {
         return Uri.parse('http://blobstore/$package/$version');
       });
       registerBackend(backend);
+      registerAccountBackend(AccountBackendMock(users: [
+        User()
+          ..id = 'uuid-hans-at-juergen-dot-com'
+          ..email = 'hans@juergen.com',
+      ]));
       registerAnalyzerClient(new AnalyzerClientMock());
       registerDartdocClient(new DartdocClientMock());
       registerScoreCardBackend(new ScoreCardBackendMock());

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -125,6 +125,7 @@ void main() {
     test('package show page', () {
       final String html = renderPkgShowPage(
           testPackage,
+          testPackage.uploaderEmails,
           false,
           [testPackageVersion],
           [Uri.parse('http://dart-example.com/')],
@@ -176,6 +177,7 @@ void main() {
     test('package show page - with version', () {
       final String html = renderPkgShowPage(
           testPackage,
+          testPackage.uploaderEmails,
           true,
           [testPackageVersion],
           [Uri.parse('http://dart-example.com/')],
@@ -226,6 +228,7 @@ void main() {
     test('package show page with flutter_plugin', () {
       final String html = renderPkgShowPage(
         testPackage,
+        testPackage.uploaderEmails,
         false,
         [flutterPackageVersion],
         [Uri.parse('http://dart-example.com/')],
@@ -264,6 +267,7 @@ void main() {
     test('package show page with outdated version', () {
       final String html = renderPkgShowPage(
           testPackage,
+          testPackage.uploaderEmails,
           true /* isVersionPage */,
           [testPackageVersion],
           [Uri.parse('http://dart-example.com/')],
@@ -284,6 +288,7 @@ void main() {
     test('package show page with discontinued version', () {
       final String html = renderPkgShowPage(
           discontinuedPackage,
+          discontinuedPackage.uploaderEmails,
           false,
           [testPackageVersion],
           [Uri.parse('http://dart-example.com/')],
@@ -306,6 +311,7 @@ void main() {
           testPackageVersion.package, testPackageVersion.version);
       final String html = renderPkgShowPage(
           testPackage,
+          testPackage.uploaderEmails,
           true /* isVersionPage */,
           [testPackageVersion],
           [Uri.parse('http://dart-example.com/')],


### PR DESCRIPTION
Replacing the use, in order to prepare for the fields' removal.

Added a 10-minute cache for userId -> email lookups. This should be safe, as the emails are in most cases used for display-only, maybe the email notification on upload can have another option to skip the cache.
