### PR TITLE
Metrics API: show metrics for (older) versions too.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -177,8 +177,9 @@ Future<shelf.Response> apiPackageMetricsHandler(shelf.Request request) async {
     return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }
   final packageName = parts[3];
-  final data = await scoreCardBackend.getScoreCardData(packageName, null,
-      onlyCurrent: false);
+  final packageVersion = request.requestedUri.queryParameters['version'];
+  final data = await scoreCardBackend
+      .getScoreCardData(packageName, packageVersion, onlyCurrent: false);
   if (data == null) {
     return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }


### PR DESCRIPTION
The lack of this option makes it harder to debug prod issues.