### PR TITLE
cronjob for backup of datastore

### DIFF
--- a/app/bin/service/frontend.dart
+++ b/app/bin/service/frontend.dart
@@ -63,9 +63,8 @@ Future _main(FrontendEntryMessage message) async {
     );
     await runHandler(
       _logger,
-      (shelf.Request request) => appHandler(request, apiHandler),
+      (shelf.Request request) => appHandler(request, apiHandler, cron.handler),
       sanitize: true,
-      cronJobHandler: cron.handler,
     );
   });
 }

--- a/app/lib/frontend/cronjobs.dart
+++ b/app/lib/frontend/cronjobs.dart
@@ -1,0 +1,86 @@
+import 'package:shelf/shelf.dart' show Request, Response;
+import 'package:logging/logging.dart' show Logger;
+import 'package:googleapis_auth/auth_io.dart' as auth;
+import 'package:googleapis/datastore/v1.dart' as datastore;
+import 'package:ulid/ulid.dart' show Ulid;
+
+final _log = new Logger('pub.cronjobs');
+
+class CronJobs {
+  final String backupBucketName;
+
+  CronJobs({
+    this.backupBucketName,
+  });
+
+  Future<Response> handler(Request request) async {
+    final job = _resolve(request.url.path);
+    if (job == null) {
+      return Response.notFound('no-such-cron-job');
+    }
+    _log.finest('### Cron: ${request.url.path}');
+    final ok = await job();
+    if (!ok) {
+      _log.shout('### Cron failed: ${request.url.path}');
+      return Response.internalServerError(
+        body: 'cron failed ${request.url.path}',
+      );
+    }
+    _log.finest('### Cron successful: ${request.url.path}');
+    return Response.ok('cron successful: ${request.url.path}');
+  }
+
+  /// Map from path to cronjob.
+  Future<bool> Function() _resolve(String path) {
+    return <String, Future<bool> Function()>{
+      '/cron/datastore-backup': datastoreBackup,
+    }[path];
+  }
+
+  /// Backup datastore
+  Future<bool> datastoreBackup() async {
+    if (backupBucketName == null) {
+      _log.shout('datastore backup not configured!!!');
+      return false;
+    }
+
+    // Get credentials via. metadata service (this only works on GCP/AppEngine)
+    final client = await auth.clientViaMetadataServer();
+    try {
+      // Create a unique job id, in case multiple jobs are trigger concurrently
+      final id = Ulid().toString();
+
+      // Get date as: YYYY-MM-DD
+      final now = DateTime.now().toUtc();
+      final date = [
+        now.year.toString(),
+        now.month.toString().padLeft(2, '0'),
+        now.day.toString().padLeft(2, '0'),
+      ].join('-');
+
+      // Start the backup operation
+      _log.finest('starting datastore backup: $date/job-$id');
+      final api = datastore.DatastoreApi(client);
+      var op = await api.projects.export(
+        datastore.GoogleDatastoreAdminV1ExportEntitiesRequest()
+          ..outputUrlPrefix = 'gs://$backupBucketName/$date/job-$id/',
+        'dartlang-pub',
+      );
+
+      // Refresh long-running operation until it's done
+      while (!op.done) {
+        op = await api.projects.operations.get(op.name);
+        await Future.delayed(Duration(seconds: 30));
+      }
+      if (op.error != null) {
+        _log.shout(
+            'datastore backup job $date/job-$id failed: ${op.error.message}');
+        return false;
+      }
+      _log.finest('datastore backup job $date/job-$id completed successfully');
+      return true;
+    } finally {
+      client.close();
+    }
+  }
+}

--- a/app/lib/frontend/cronjobs.dart
+++ b/app/lib/frontend/cronjobs.dart
@@ -51,12 +51,7 @@ class CronJobs {
       final id = Ulid().toString();
 
       // Get date as: YYYY-MM-DD
-      final now = DateTime.now().toUtc();
-      final date = [
-        now.year.toString(),
-        now.month.toString().padLeft(2, '0'),
-        now.day.toString().padLeft(2, '0'),
-      ].join('-');
+      final date = DateTime.now().toUtc().toIso8601String().split('T').first;
 
       // Start the backup operation
       _log.finest('starting datastore backup: $date/job-$id');

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -39,11 +39,11 @@ void _logPubHeaders(shelf.Request request) {
 ///   - /api/*
 Future<shelf.Response> appHandler(
   shelf.Request request,
-  shelf.Handler shelfPubApi,
+  shelf.Handler shelfPubApi, [
   shelf.Handler cronHandler,
-) async {
+]) async {
   // Handle cron requests, we checked the IP in handler_helpers.dart
-  if (request.headers['x-appengine-cron'] == 'true') {
+  if (cronHandler != null && request.headers['x-appengine-cron'] == 'true') {
     return cronHandler(request);
   }
 

--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -38,7 +38,15 @@ void _logPubHeaders(shelf.Request request) {
 /// The passed in [shelfPubApi] handler will be used for handling requests to
 ///   - /api/*
 Future<shelf.Response> appHandler(
-    shelf.Request request, shelf.Handler shelfPubApi) async {
+  shelf.Request request,
+  shelf.Handler shelfPubApi,
+  shelf.Handler cronHandler,
+) async {
+  // Handle cron requests, we checked the IP in handler_helpers.dart
+  if (request.headers['x-appengine-cron'] == 'true') {
+    return cronHandler(request);
+  }
+
   final path = request.requestedUri.path;
 
   _logPubHeaders(request);

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -631,6 +631,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
+  ulid:
+    dependency: "direct main"
+    description:
+      name: ulid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   utf:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   archive: '2.0.3'
   mailer: '2.1.1'
   uuid: '1.0.3'
+  ulid: ^1.0.1
 
 dev_dependencies:
   build_runner: '^1.0.0'

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,0 +1,5 @@
+cron:
+- description: 'weekly datastore backup'
+  schedule: every tuesday 02:00
+  url: /cron/datastore-backup
+  target: default  # frontend


### PR DESCRIPTION
I'm thinking we can deploy this to staging before we configure
a bucket to be used for backup. If we roll to staging sometime
Monday, we can probably search the logs tuesday/wednesday for
a failed cronjob, as it's supposed to shout if there is
no bucket configured.

Trying this in tests makes little sense, as the thing most likely to fail here is the appengine integration.