### PR TITLE
Update search index only if there is an analysis available.

### DIFF
--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -148,10 +148,8 @@ Future<shelf.Response> _packageVersionHandlerHtml(
       }
     }
     final Stopwatch serviceSw = new Stopwatch()..start();
-    final analysisKey =
-        new AnalysisKey(selectedVersion.package, selectedVersion.version);
-    final AnalysisView analysisView =
-        await analyzerClient.getAnalysisView(analysisKey);
+    final AnalysisView analysisView = await analyzerClient.getAnalysisView(
+        selectedVersion.package, selectedVersion.version);
     _packageAnalysisLatencyTracker.add(serviceSw.elapsed);
 
     final versionDownloadUrls =

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -43,6 +43,13 @@ void registerSnapshotStorage(SnapshotStorage storage) =>
 SnapshotStorage get snapshotStorage =>
     ss.lookup(#_snapshotStorage) as SnapshotStorage;
 
+/// Exception when a package or a version is missing, or has other flags that
+/// indicate it should be removed from the search index.
+class RemovedPackageException implements Exception {}
+
+/// Exception when a package does not have its analysis yet.
+class MissingAnalysisException implements Exception {}
+
 /// Datastore-related access methods for the search service
 class SearchBackend {
   final DatastoreDB _db;
@@ -52,22 +59,28 @@ class SearchBackend {
   /// Loads the latest stable version, its analysis results and extracted
   /// dartdoc content, and returns a [PackageDocument] objects for search.
   ///
-  /// When a package, its latest version or its analysis is missing, the method
-  /// returns with null.
+  /// When a package, or its latest version is missing, the method throws
+  /// [RemovedPackageException].
+  ///
+  /// When either the analysis is not completed yet, the method returns with
+  /// null.
   Future<PackageDocument> loadDocument(String packageName) async {
     final packageKey = _db.emptyKey.append(Package, id: packageName);
     final p = (await _db.lookup<Package>([packageKey])).single;
     if (p == null || p.isDiscontinued == true) {
-      return null;
+      throw RemovedPackageException();
     }
 
     final pv = (await _db.lookup<PackageVersion>([p.latestVersionKey])).single;
     if (pv == null) {
-      return null;
+      throw RemovedPackageException();
     }
 
     final analysisView =
         await analyzerClient.getAnalysisView(packageName, pv.version);
+    if (!analysisView.hasPanaSummary) {
+      throw MissingAnalysisException();
+    }
 
     final pubDataContent = await dartdocClient.getTextContent(
         packageName, 'latest', 'pub-data.json',

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -64,7 +64,8 @@ class SearchBackend {
   ///
   /// When either the analysis is not completed yet, the method returns with
   /// null.
-  Future<PackageDocument> loadDocument(String packageName) async {
+  Future<PackageDocument> loadDocument(String packageName,
+      {bool requireAnalysis = false}) async {
     final packageKey = _db.emptyKey.append(Package, id: packageName);
     final p = (await _db.lookup<Package>([packageKey])).single;
     if (p == null || p.isDiscontinued == true) {
@@ -78,7 +79,7 @@ class SearchBackend {
 
     final analysisView =
         await analyzerClient.getAnalysisView(packageName, pv.version);
-    if (!analysisView.hasPanaSummary) {
+    if (requireAnalysis && !analysisView.hasPanaSummary) {
       throw MissingAnalysisException();
     }
 

--- a/app/lib/search/backend.dart
+++ b/app/lib/search/backend.dart
@@ -66,8 +66,8 @@ class SearchBackend {
       return null;
     }
 
-    final analysisView = await analyzerClient
-        .getAnalysisView(AnalysisKey(packageName, pv.version));
+    final analysisView =
+        await analyzerClient.getAnalysisView(packageName, pv.version);
 
     final pubDataContent = await dartdocClient.getTextContent(
         packageName, 'latest', 'pub-data.json',

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -13,8 +13,6 @@ import '../job/backend.dart';
 import '../scorecard/backend.dart';
 import '../scorecard/models.dart';
 
-import 'analyzer_service.dart';
-
 export 'package:pana/pana.dart' show LicenseFile, PkgDependency, Suggestion;
 export 'analyzer_service.dart' hide AnalysisData;
 
@@ -31,22 +29,18 @@ final Logger _logger = new Logger('pub.analyzer_client');
 /// Client methods that access the analyzer service and the internals of the
 /// analysis data. This keeps the interface narrow over the raw analysis data.
 class AnalyzerClient {
-  Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) {
-    return Future.wait(keys.map(getAnalysisView));
-  }
-
-  Future<AnalysisView> getAnalysisView(AnalysisKey key) async {
-    if (key == null) {
-      return null;
-    }
-    final card = await scoreCardBackend
-        .getScoreCardData(key.package, key.version, onlyCurrent: false);
+  Future<AnalysisView> getAnalysisView(String package, String version) async {
+    final card = await scoreCardBackend.getScoreCardData(
+      package,
+      version,
+      onlyCurrent: false,
+    );
     if (card == null) {
       return new AnalysisView();
     }
     final reports = await scoreCardBackend.loadReports(
-      key.package,
-      key.version,
+      package,
+      version,
       runtimeVersion: card.runtimeVersion,
     );
     final panaReport = reports[ReportType.pana] as PanaReport;

--- a/app/lib/shared/analyzer_service.dart
+++ b/app/lib/shared/analyzer_service.dart
@@ -4,26 +4,6 @@
 
 import 'package:meta/meta.dart';
 
-class AnalysisKey {
-  final String package;
-  final String version;
-
-  AnalysisKey(this.package, this.version);
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is AnalysisKey &&
-          package == other.package &&
-          version == other.version;
-
-  @override
-  int get hashCode => package.hashCode ^ version.hashCode;
-
-  @override
-  String toString() => '$package $version';
-}
-
 /// These status codes mark the status of the analysis, not the result/report.
 enum AnalysisStatus {
   /// Analysis was aborted without a report.

--- a/app/test/frontend/mocks.dart
+++ b/app/test/frontend/mocks.dart
@@ -8,7 +8,6 @@ import 'package:pub_dartlang_org/frontend/models.dart';
 import 'package:pub_dartlang_org/frontend/search_service.dart';
 import 'package:pub_dartlang_org/scorecard/backend.dart';
 import 'package:pub_dartlang_org/scorecard/models.dart';
-import 'package:pub_dartlang_org/shared/analyzer_service.dart';
 import 'package:pub_dartlang_org/shared/analyzer_client.dart';
 import 'package:pub_dartlang_org/shared/dartdoc_client.dart';
 import 'package:pub_dartlang_org/shared/search_client.dart';
@@ -226,12 +225,8 @@ class AnalyzerClientMock implements AnalyzerClient {
   Future close() async => null;
 
   @override
-  Future<AnalysisView> getAnalysisView(AnalysisKey key) async =>
+  Future<AnalysisView> getAnalysisView(String package, String version) async =>
       mockAnalysisView;
-
-  @override
-  Future<List<AnalysisView>> getAnalysisViews(Iterable<AnalysisKey> keys) =>
-      Future.wait(keys.map(getAnalysisView));
 
   @override
   Future triggerAnalysis(

--- a/app/test/search/handlers_test.dart
+++ b/app/test/search/handlers_test.dart
@@ -116,7 +116,8 @@ class MockSearchBackend implements SearchBackend {
   List<String> packages = ['pkg_foo'];
 
   @override
-  Future<PackageDocument> loadDocument(String packageName) async {
+  Future<PackageDocument> loadDocument(String packageName,
+      {bool requireAnalysis = false}) async {
     if (!packages.contains(packageName)) {
       return null;
     }


### PR DESCRIPTION
This addresses the search index part of #2053, #2057 and #2060. With this change, the index updater checks if there is a valid analysis for the loaded version, and if there is nothing yet, it will not load the document into the index. As the analysis completes, the index should pick up the updated scorecard, and will trigger a new update again.

I'm not a fan of using exception for such control flow, but it just seemed the best choice.