### PR TITLE
 Remove runtimeVersion and isCurrent from ScoreCardMemcache.

### DIFF
--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -60,9 +60,8 @@ class ScoreCardBackend {
       }
       packageVersion = p.latestVersion;
     }
-    final cached = await scoreCardMemcache.getScoreCardData(
-        packageName, packageVersion, versions.runtimeVersion,
-        onlyCurrent: onlyCurrent);
+    final cached =
+        await scoreCardMemcache.getScoreCardData(packageName, packageVersion);
     if (cached != null && cached.hasReports(requiredReportTypes)) {
       return cached;
     }
@@ -221,8 +220,7 @@ class ScoreCardBackend {
       await tx.commit();
     });
 
-    scoreCardMemcache.invalidate(
-        packageName, packageVersion, versions.runtimeVersion);
+    scoreCardMemcache.invalidate(packageName, packageVersion);
   }
 
   /// Deletes the old entries that predate [versions.gcBeforeRuntimeVersion].


### PR DESCRIPTION
- Cleanup: removed `runtimeVersion` because we were querying always the current runtime, and the cache itself is already base on `runtimeVersion`.
- Fix: removed the separate `isCurrent` handling, storing only entries with `isCurrent = true`. (not sure how large of an issue this was, but simpler rules should be better)

This is part of the analysis caching issues in #2053, #2057 and #2060.