### PR TITLE
When loading a scorecard, try to load the full ones first.

### DIFF
--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -178,8 +178,8 @@ Future<shelf.Response> apiPackageMetricsHandler(shelf.Request request) async {
   }
   final packageName = parts[3];
   final packageVersion = request.requestedUri.queryParameters['version'];
-  final data = await scoreCardBackend
-      .getScoreCardData(packageName, packageVersion);
+  final data =
+      await scoreCardBackend.getScoreCardData(packageName, packageVersion);
   if (data == null) {
     return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }

--- a/app/lib/frontend/handlers/custom_api.dart
+++ b/app/lib/frontend/handlers/custom_api.dart
@@ -179,7 +179,7 @@ Future<shelf.Response> apiPackageMetricsHandler(shelf.Request request) async {
   final packageName = parts[3];
   final packageVersion = request.requestedUri.queryParameters['version'];
   final data = await scoreCardBackend
-      .getScoreCardData(packageName, packageVersion, onlyCurrent: false);
+      .getScoreCardData(packageName, packageVersion);
   if (data == null) {
     return jsonResponse({}, status: 404, pretty: isPrettyJson(request));
   }

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -48,8 +48,8 @@ Future<SearchResultPage> _loadResultForPackages(
   if (versionKeys.isNotEmpty) {
     // Analysis data fetched concurrently to reduce overall latency.
     final Future<List<ScoreCardData>> analysisExtractsFuture = Future.wait(
-        packageEntries.map((p) => scoreCardBackend
-            .getScoreCardData(p.name, p.latestVersion)));
+        packageEntries.map(
+            (p) => scoreCardBackend.getScoreCardData(p.name, p.latestVersion)));
     final Future<List> allVersionsFuture = dbService.lookup(versionKeys);
 
     final List batchResults =

--- a/app/lib/frontend/search_service.dart
+++ b/app/lib/frontend/search_service.dart
@@ -49,7 +49,7 @@ Future<SearchResultPage> _loadResultForPackages(
     // Analysis data fetched concurrently to reduce overall latency.
     final Future<List<ScoreCardData>> analysisExtractsFuture = Future.wait(
         packageEntries.map((p) => scoreCardBackend
-            .getScoreCardData(p.name, p.latestVersion, onlyCurrent: false)));
+            .getScoreCardData(p.name, p.latestVersion)));
     final Future<List> allVersionsFuture = dbService.lookup(versionKeys);
 
     final List batchResults =

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:gcloud/db.dart' as db;
 import 'package:gcloud/service_scope.dart' as ss;
 import 'package:logging/logging.dart';
-import 'package:meta/meta.dart';
 
 import '../frontend/models.dart' show Package, PackageVersion;
 import '../shared/packages_overrides.dart';
@@ -39,14 +38,8 @@ class ScoreCardBackend {
   ScoreCardBackend(this._db);
 
   /// Returns the [ScoreCardData] for the given package and version.
-  ///
-  /// When [onlyCurrent] is false, it will try to load earlier versions of the
-  /// data.
   Future<ScoreCardData> getScoreCardData(
-    String packageName,
-    String packageVersion, {
-    @required bool onlyCurrent,
-  }) async {
+      String packageName, String packageVersion) async {
     final requiredReportTypes = ReportType.values;
     if (packageVersion == null || packageVersion == 'latest') {
       final key = _db.emptyKey.append(Package, id: packageName);
@@ -71,10 +64,6 @@ class ScoreCardBackend {
         await scoreCardMemcache.setScoreCardData(data);
         return data;
       }
-    }
-
-    if (onlyCurrent) {
-      return null;
     }
 
     // List cards that at minimum have a pana report.

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -47,10 +47,7 @@ class ScoreCardBackend {
     String packageVersion, {
     @required bool onlyCurrent,
   }) async {
-    final requiredReportTypes = const <String>[
-      ReportType.pana,
-      ReportType.dartdoc,
-    ];
+    final requiredReportTypes = ReportType.values;
     if (packageVersion == null || packageVersion == 'latest') {
       final key = _db.emptyKey.append(Package, id: packageName);
       final ps = await _db.lookup([key]);
@@ -96,9 +93,7 @@ class ScoreCardBackend {
                 latest.semanticRuntimeVersion, current.semanticRuntimeVersion)
             ? current
             : latest);
-    final data = latest.toData();
-    await scoreCardMemcache.setScoreCardData(data);
-    return data;
+    return latest.toData();
   }
 
   /// Creates or updates a [ScoreCardReport] entry with the report's [data].

--- a/app/lib/scorecard/models.dart
+++ b/app/lib/scorecard/models.dart
@@ -46,6 +46,8 @@ abstract class PackageFlags {
 abstract class ReportType {
   static const String pana = 'pana';
   static const String dartdoc = 'dartdoc';
+
+  static const values = const <String>[pana, dartdoc];
 }
 
 abstract class ReportStatus {

--- a/app/lib/scorecard/scorecard_memcache.dart
+++ b/app/lib/scorecard/scorecard_memcache.dart
@@ -43,11 +43,10 @@ class ScoreCardMemcache {
   }
 
   Future setScoreCardData(ScoreCardData data) async {
-    if (!data.isCurrent) {
-      return;
+    if (data.isCurrent && data.hasReports(ReportType.values)) {
+      await _data.setText(_dataKey(data.packageName, data.packageVersion),
+          convert.json.encode(data.toJson()));
     }
-    await _data.setText(_dataKey(data.packageName, data.packageVersion),
-        convert.json.encode(data.toJson()));
   }
 
   Future invalidate(String package, String version) async {

--- a/app/lib/shared/analyzer_client.dart
+++ b/app/lib/shared/analyzer_client.dart
@@ -30,11 +30,7 @@ final Logger _logger = new Logger('pub.analyzer_client');
 /// analysis data. This keeps the interface narrow over the raw analysis data.
 class AnalyzerClient {
   Future<AnalysisView> getAnalysisView(String package, String version) async {
-    final card = await scoreCardBackend.getScoreCardData(
-      package,
-      version,
-      onlyCurrent: false,
-    );
+    final card = await scoreCardBackend.getScoreCardData(package, version);
     if (card == null) {
       return new AnalysisView();
     }


### PR DESCRIPTION
This will reduce the amount of time for a newly uploaded version to get the analysis displayed. Instead of waiting for both `pana` and `dartdoc`, we start to serve the analysis as soon as `pana` gets completed.

The pana-only card will be returned only when there is no other one (from a different runtimeVersion) with a full report.

The other parts are mostly cleanups.