### PR TITLE
Fix NPE in header check

### DIFF
--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -32,8 +32,9 @@ Future<void> runHandler(
   handler = _redirectToHttpsWrapper(handler);
   handler = _logRequestWrapper(logger, handler);
   await runAppEngine((HttpRequest request) {
-    if (request.headers['x-appengine-cron'].contains('true') &&
-        !isCronJobRequest(request)) {
+    if (request.headers['x-appengine-cron'] != null &&
+        request.headers['x-appengine-cron'].contains('true') &&
+        request.connectionInfo.remoteAddress != InternetAddress('10.0.0.1')) {
       throw AssertionError('AppEngine violated our trust!');
     }
     shelf_io.handleRequest(request, handler);


### PR DESCRIPTION
I think `isCronJobRequest` is `package:appengine` needs to be updated too for both the NPE protection, and also to use lowercase Header key.