### PR TITLE
Fix lowercase e-mails in user accounts.

### DIFF
--- a/app/bin/tools/backfill_user_ids.dart
+++ b/app/bin/tools/backfill_user_ids.dart
@@ -64,6 +64,7 @@ Future main(List<String> args) async {
       }
     }
 
+    // Delete users with non-lowercase e-mails.
     await for (User user in dbService.query<User>().run()) {
       if (user.email != user.email.toLowerCase()) {
         print('Deleting: ${user.email} ${user.userId} ${user.oauthUserId}');

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -113,6 +113,7 @@ class AccountBackend {
   ///
   /// Throws Exception if more then one `User` entry exists.
   Future<User> lookupOrCreateUserByEmail(String email) async {
+    email = email.toLowerCase();
     final query = _db.query<User>()..filter('email =', email);
     final list = await query.run().toList();
     if (list.length > 1) {
@@ -282,7 +283,7 @@ class GoogleOauth2AuthProvider extends AuthProvider {
         return null;
       }
 
-      return AuthResult(info.userId, info.email);
+      return AuthResult(info.userId, info.email.toLowerCase());
     } on oauth2_v2.ApiRequestError catch (e) {
       _logger.info('Access denied for OAuth2 access token.', e);
     } catch (e, st) {

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -604,6 +604,7 @@ class GCloudPackageRepository extends PackageRepository {
 
   @override
   Future addUploader(String packageName, String uploaderEmail) async {
+    uploaderEmail = uploaderEmail.toLowerCase();
     await withAuthenticatedUser((AuthenticatedUser user) async {
       final packageKey = db.emptyKey.append(models.Package, id: packageName);
       final package = (await db.lookup([packageKey])).first as models.Package;
@@ -718,6 +719,7 @@ class GCloudPackageRepository extends PackageRepository {
 
   @override
   Future removeUploader(String packageName, String uploaderEmail) async {
+    uploaderEmail = uploaderEmail.toLowerCase();
     return withAuthenticatedUser((AuthenticatedUser user) {
       return db.withTransaction((Transaction T) async {
         final packageKey = db.emptyKey.append(models.Package, id: packageName);
@@ -969,7 +971,8 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
     ..libraries = libraries
     ..downloads = 0
     ..sortOrder = 1
-    ..uploader = user.userId;
+    ..uploader = user.userId
+    ..uploaderEmail = user.email;
 
   final versionPubspec = models.PackageVersionPubspec()
     ..initFromKey(key)

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -96,7 +96,7 @@ class Package extends db.ExpandoModel {
     if (uploaderId != null) {
       uploaders.add(uploaderId);
     }
-    uploaderEmails.add(uploaderEmail);
+    uploaderEmails.add(uploaderEmail.toLowerCase());
   }
 
   // Remove the email from the list of uploaders.
@@ -206,7 +206,7 @@ class PackageVersion extends db.ExpandoModel {
   @db.StringProperty()
   String uploader;
 
-  @db.StringProperty(required: true)
+  @db.StringProperty()
   String uploaderEmail;
 
   // Convenience Fields:

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -378,16 +378,10 @@ void main() {
       }
 
       test('successful', () async {
-        final fooLowerB = AuthenticatedUser('uuid-foo-at-b-com', 'foo@b.com');
-        final fooUpperB = AuthenticatedUser('uuid-foo-at-B-com', 'foo@B.com');
+        final foo = AuthenticatedUser('uuid-foo-at-b-com', 'foo@b.com');
+        await scoped(() => testSuccessful(foo, ['foo@b.com'], 'bar@b.com'));
         await scoped(
-            () => testSuccessful(fooLowerB, ['foo@b.com'], 'bar@b.com'));
-        await scoped(
-            () => testSuccessful(fooUpperB, ['foo@b.com'], 'bar@B.com'));
-        await scoped(() =>
-            testSuccessful(fooUpperB, ['foo@B.com', 'bar@b.com'], 'baz@b.com'));
-        await scoped(() =>
-            testSuccessful(fooLowerB, ['foo@B.com', 'bar@B.com'], 'baz@B.com'));
+            () => testSuccessful(foo, ['foo@b.com', 'bar@b.com'], 'baz@b.com'));
       });
     });
 


### PR DESCRIPTION
- `frontend/backend.dart#975` was removed in #2052, not deployed to production, and I felt it is safer to keep it there for the time being
- migration script was updated to also update email to lowercase if needed.
- migration script was updated to remove `User` entities if the email is not lowercased (the appropriate ids will get updated in prior steps, and package and version will have the correct IDs).