### PR TITLE
Delete more of old ScoreCards

### DIFF
--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -220,43 +220,31 @@ class ScoreCardBackend {
     final deletes = <db.Key>[];
     final now = new DateTime.now();
 
-    // deleting reports
-    final reportQuery = _db.query<ScoreCardReport>()
-      ..filter('runtimeVersion <', versions.gcBeforeRuntimeVersion);
-    await for (ScoreCardReport report in reportQuery.run()) {
-      final age = now.difference(report.updated);
-      if (age <= _deleteThreshold) {
-        continue;
+    Future deleteQuery<T extends db.Model>(db.Query<T> query) async {
+      await for (T model in query.run()) {
+        deletes.add(model.key);
+        if (deletes.length == 20) {
+          await _db.commit(deletes: deletes);
+          deletes.clear();
+        }
       }
-      deletes.add(report.key);
-      if (deletes.length == 20) {
+      if (deletes.isNotEmpty) {
         await _db.commit(deletes: deletes);
         deletes.clear();
       }
-    }
-    if (deletes.isNotEmpty) {
-      await _db.commit(deletes: deletes);
-      deletes.clear();
     }
 
+    // deleting reports
+    await deleteQuery(_db.query<ScoreCardReport>()
+      ..filter('runtimeVersion <', versions.gcBeforeRuntimeVersion));
+    await deleteQuery(_db.query<ScoreCardReport>()
+      ..filter('updated <', now.subtract(_deleteThreshold)));
+
     // deleting scorecards
-    final cardQuery = _db.query<ScoreCard>()
-      ..filter('runtimeVersion <', versions.gcBeforeRuntimeVersion);
-    await for (ScoreCard report in cardQuery.run()) {
-      final age = now.difference(report.updated);
-      if (age <= _deleteThreshold) {
-        continue;
-      }
-      deletes.add(report.key);
-      if (deletes.length == 20) {
-        await _db.commit(deletes: deletes);
-        deletes.clear();
-      }
-    }
-    if (deletes.isNotEmpty) {
-      await _db.commit(deletes: deletes);
-      deletes.clear();
-    }
+    await deleteQuery(_db.query<ScoreCard>()
+      ..filter('runtimeVersion <', versions.gcBeforeRuntimeVersion));
+    await deleteQuery(_db.query<ScoreCard>()
+      ..filter('updated <', now.subtract(_deleteThreshold)));
   }
 
   /// Returns the status of a package and version.

--- a/app/lib/scorecard/backend.dart
+++ b/app/lib/scorecard/backend.dart
@@ -220,6 +220,7 @@ class ScoreCardBackend {
     final deletes = <db.Key>[];
     final now = new DateTime.now();
 
+    // Deletes the entries that are returned from the [query].
     Future deleteQuery<T extends db.Model>(db.Query<T> query) async {
       await for (T model in query.run()) {
         deletes.add(model.key);


### PR DESCRIPTION
- The current GC threshold is `2018.12.05` (runtimeVersions before this time will be deleted).
- Each analysis should be re-done in ~30 days, it is very unlikely that a report for the current runtime did succeeded at one point, but failed ever since in the past half year, and if it does, we should probably delete that report anyway.