### PR TITLE
validate that we received a user_id

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -276,7 +276,9 @@ class GoogleOauth2AuthProvider extends AuthProvider {
         return null;
       }
 
-      if (info.expiresIn == null ||
+      if (info.userId == null ||
+          info.userId.isEmpty ||
+          info.expiresIn == null ||
           info.expiresIn <= 0 ||
           info.verifiedEmail != true ||
           info.email == null ||


### PR DESCRIPTION
This seems like it shouldn't be necessary.
But if this truly why, we're seeing 500s, then I suppose
it's better to be defensive.