### PR TITLE
Handle legacy sessions without openid scope

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -276,7 +276,9 @@ class GoogleOauth2AuthProvider extends AuthProvider {
         return null;
       }
 
-      if (info.expiresIn == null ||
+      if (info.userId == null ||
+          info.userId.isEmpty ||
+          info.expiresIn == null ||
           info.expiresIn <= 0 ||
           info.verifiedEmail != true ||
           info.email == null ||

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -154,16 +154,19 @@ class AccountBackend {
     final mappingKey = _db.emptyKey.append(OAuthUserID, id: auth.oauthUserId);
 
     final user = await retry(() async {
-      // Check existing mapping.
-      final mapping = (await _db.lookup<OAuthUserID>([mappingKey])).single;
-      if (mapping != null) {
-        final user = (await _db.lookup<User>([mapping.userIdKey])).single;
-        // TODO: we should probably have some kind of consistency mitigation
-        if (user == null) {
-          throw Exception('Incomplete OAuth userId mapping: '
-              'missing User (`${mapping.userId}`) referenced by `${mapping.id}`.');
+      // Handle legacy logins that don't have 'openid' scope
+      if (auth.oauthUserId != null) {
+        // Check existing mapping.
+        final mapping = (await _db.lookup<OAuthUserID>([mappingKey])).single;
+        if (mapping != null) {
+          final user = (await _db.lookup<User>([mapping.userIdKey])).single;
+          // TODO: we should probably have some kind of consistency mitigation
+          if (user == null) {
+            throw Exception('Incomplete OAuth userId mapping: '
+                'missing User (`${mapping.userId}`) referenced by `${mapping.id}`.');
+          }
+          return user;
         }
-        return user;
       }
 
       // Check pre-migrated User with existing email.
@@ -174,6 +177,12 @@ class AccountBackend {
       // TODO: trigger consistency mitigation if more than one email exists
       if (usersWithEmail.length == 1 &&
           usersWithEmail.single.oauthUserId == null) {
+        // Handle legacy logins that don't have 'openid' scope, and thus, no
+        // user_id (oauthUserId), these can't be upgraded yet.
+        if (auth.oauthUserId == null) {
+          return usersWithEmail.single;
+        }
+
         // We've found a single pre-migrated User with empty oauthUserId: need
         // to create OAuthUserID for it.
         final updatedUser = await _db.withTransaction((tx) async {
@@ -191,6 +200,20 @@ class AccountBackend {
         return updatedUser;
       }
 
+      // Create new user without oauth2 user_id, to support legacy clients
+      // that don't have 'openid' scope, and thus, no user_id.
+      if (auth.oauthUserId == null) {
+        final newUser = User()
+          ..parentKey = _db.emptyKey
+          ..id = _uuid.v4().toString()
+          ..oauthUserId = null
+          ..email = auth.email
+          ..created = DateTime.now().toUtc();
+        await _db.commit(inserts: [newUser]);
+        return newUser;
+      }
+
+      // Create new user with oauth2 user_id mapping
       final newUser = User()
         ..parentKey = _db.emptyKey
         ..id = _uuid.v4().toString()
@@ -276,10 +299,11 @@ class GoogleOauth2AuthProvider extends AuthProvider {
         return null;
       }
 
-      if (info.userId == null ||
-          info.userId.isEmpty ||
-          info.expiresIn == null ||
+      if (info.expiresIn == null ||
           info.expiresIn <= 0 ||
+          // TODO: Enable when pub client is requesting the correct scopes.
+          // info.userId == null ||
+          // info.userId.isEmpty ||
           info.verifiedEmail != true ||
           info.email == null ||
           info.email.isEmpty) {


### PR DESCRIPTION
The pub client doesn't explicitly request the 'openid' scope.
So we can't expect it to be present... At some point it was just automatically granted to everybody regardless of whether they requested it or not.
But since we're explicitly requesting it, we can't rely on it's presence until we've updated the pub client.