### PR TITLE
No fallback to e-mail when checking the uploader status.

### DIFF
--- a/app/bin/tools/uploader.dart
+++ b/app/bin/tools/uploader.dart
@@ -73,7 +73,7 @@ Future addUploader(String packageName, String uploaderEmail) async {
         await accountBackend.getEmailsOfUserIds(package.uploaders);
     print('Current uploaders: $uploaderEmails');
     final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
-    if (package.hasUploader(user.userId, uploaderEmail)) {
+    if (package.hasUploader(user.userId)) {
       throw new Exception('Uploader $uploaderEmail already exists');
     }
     package.addUploader(user.userId, uploaderEmail);
@@ -105,7 +105,7 @@ Future removeUploader(String packageName, String uploaderEmail) async {
         await accountBackend.getEmailsOfUserIds(package.uploaders);
     print('Current uploaders: $uploaderEmails');
     final user = await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
-    if (!package.hasUploader(user.userId, uploaderEmail)) {
+    if (!package.hasUploader(user.userId)) {
       throw new Exception('Uploader $uploaderEmail does not exist');
     }
     if (package.uploaderCount <= 1) {

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -475,7 +475,7 @@ class GCloudPackageRepository extends PackageRepository {
 
       // Check if the uploader of the new version is allowed to upload to
       // the package.
-      if (!package.hasUploader(user.userId, user.email)) {
+      if (!package.hasUploader(user.userId)) {
         _logger.info('User ${user.userId} (${user.email}) is not an uploader '
             'for package ${package.name}, rolling transaction back.');
         await T.rollback();
@@ -619,7 +619,7 @@ class GCloudPackageRepository extends PackageRepository {
       // TODO: do not create a new User for unverified uploader email
       final uploader =
           await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
-      if (package.hasUploader(uploader.userId, uploaderEmail)) {
+      if (package.hasUploader(uploader.userId)) {
         // The requested uploaderEmail is already part of the uploaders.
         return;
       }
@@ -674,7 +674,7 @@ class GCloudPackageRepository extends PackageRepository {
 
       final uploader =
           await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
-      if (package.hasUploader(uploader.userId, uploader.email)) {
+      if (package.hasUploader(uploader.userId)) {
         // The requested uploaderEmail is already part of the uploaders.
         await tx.rollback();
         return;
@@ -711,7 +711,7 @@ class GCloudPackageRepository extends PackageRepository {
     }
 
     // Fail if calling user doesn't have permission to change uploaders.
-    if (!package.hasUploader(userId, userEmail)) {
+    if (!package.hasUploader(userId)) {
       throw new UnauthorizedAccessException(
           'Calling user does not have permission to change uploaders.');
     }
@@ -733,7 +733,7 @@ class GCloudPackageRepository extends PackageRepository {
         }
 
         // Fail if calling user doesn't have permission to change uploaders.
-        if (!package.hasUploader(user.userId, user.email)) {
+        if (!package.hasUploader(user.userId)) {
           await T.rollback();
           throw new UnauthorizedAccessException(
               'Calling user does not have permission to change uploaders.');
@@ -742,7 +742,7 @@ class GCloudPackageRepository extends PackageRepository {
         final uploader =
             await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
         // Fail if the uploader we want to remove does not exist.
-        if (!package.hasUploader(uploader.userId, uploaderEmail)) {
+        if (!package.hasUploader(uploader.userId)) {
           await T.rollback();
           throw new GenericProcessingException(
               'The uploader to remove does not exist.');

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -80,20 +80,15 @@ class Package extends db.ExpandoModel {
   }
 
   // Check if a user is an uploader for a package.
-  bool hasUploader(String uploaderId, String uploaderEmail) {
-    if (uploaderId != null && uploaders.contains(uploaderId)) {
-      return true;
-    }
-    // fallback to emails in case the migration did not happen to this yet
-    final lowerEmail = uploaderEmail.toLowerCase();
-    return uploaderEmails.any((s) => s.toLowerCase() == lowerEmail);
+  bool hasUploader(String uploaderId) {
+    return uploaderId != null && uploaders.contains(uploaderId);
   }
 
   int get uploaderCount => uploaders.length;
 
   /// Add the id and the email to the list of uploaders.
   void addUploader(String uploaderId, String uploaderEmail) {
-    if (uploaderId != null) {
+    if (uploaderId != null && !uploaders.contains(uploaderId)) {
       uploaders.add(uploaderId);
     }
     uploaderEmails.add(uploaderEmail.toLowerCase());


### PR DESCRIPTION
This is a low-risk step towards using only ids: we keep updating both the email and the ids on add/remove uploader, but only use the ids to check if they are uploaders. If there is a bug, we can treat the emails as the canonical source of truth, otherwise we can switch to ids in the next-next release.