### PR TITLE
Check e-mail string in Oauth token info processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
  * Run `gcloud app deploy cron.yaml` to update cron-job retry logic.
 
+ * Behaviour changes:
+
+   * OAuth: accept only validated e-mails that look like e-mails (have @, . and e-mail-like structure).
+
 ## `20190306t115839-all`
  
  * Run `app/bin/tools/backfill_packageversions.dart` to backfill `PubSpec`

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -15,6 +15,7 @@ import 'package:simple_cache/simple_cache.dart';
 import 'package:retry/retry.dart';
 import 'package:uuid/uuid.dart';
 
+import '../shared/email.dart' show isValidEmail;
 import 'models.dart';
 
 final _logger = new Logger('pub.account.backend');
@@ -306,7 +307,8 @@ class GoogleOauth2AuthProvider extends AuthProvider {
           // info.userId.isEmpty ||
           info.verifiedEmail != true ||
           info.email == null ||
-          info.email.isEmpty) {
+          info.email.isEmpty ||
+          !isValidEmail(info.email)) {
         _logger.warning('OAuth2 token info invalid: ${info.toJson()}');
         return null;
       }


### PR DESCRIPTION
We probably don't need this, but shouldn't hurt either.