### PR TITLE
Reject uploads on case insensitive filename matches.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -860,6 +860,19 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
 
   final files = await listTarball(filename);
 
+  // Check whether the files can be extracted on case-preserving file systems
+  // (e.g. on Windows). We can't allow two files with the same case-insensitive
+  // name.
+  final lowerCaseFiles = <String>{};
+  for (String file in files) {
+    final lower = file.toLowerCase();
+    if (lowerCaseFiles.contains(lower)) {
+      throw GenericProcessingException(
+          'Filename collision on case-preserving file systems: $file.');
+    }
+    lowerCaseFiles.add(lower);
+  }
+
   // Searches in [files] for a file name [name] and compare in a
   // case-insensitive manner.
   //

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -51,8 +51,7 @@ Future<T> withTempDirectory<T>(Future<T> func(Directory dir),
 }
 
 Future<List<String>> listTarball(String path) async {
-  // List files up-to 4 directory levels:
-  final args = ['--exclude=*/*/*/*/*', '-tzf', path];
+  final args = ['-tzf', path];
   final result = await Process.run('tar', args);
   if (result.exitCode != 0) {
     _logger.warning('The "tar $args" command failed:\n'


### PR DESCRIPTION
- Fixes #2104
- Removed directory depth limit from `listTarball`, as we want to check all files.
- I wanted to limit the number of libraries in the same PR, but was undecided on the limit to use (e.g. how should https://pub.dartlang.org/packages/googleapis#-installing-tab- be limited)?