### PR TITLE
Remove IP checks for cron job requests.

### DIFF
--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -33,12 +33,6 @@ Future<void> runHandler(
   handler = _redirectToHttpsWrapper(handler);
   handler = _logRequestWrapper(logger, handler);
   await runAppEngine((HttpRequest request) {
-    if (request.headers['x-appengine-cron'] != null &&
-        request.headers['x-appengine-cron'].contains('true') &&
-        request.connectionInfo.remoteAddress != InternetAddress('10.0.0.1')) {
-      throw Exception('Expected cron from 10.0.0.1 instead it came '
-          'from ${request.connectionInfo.remoteAddress}');
-    }
     shelf_io.handleRequest(request, handler);
   }, shared: true);
 }


### PR DESCRIPTION
It would be really nice if we could check the IP, but this does not
seem possible. The IP is included in 'X-Forwarded-For' header, which
is no more trust worthy than 'X-AppEngine-Cron', so we'll just
settle with testing that.