### PR TITLE
 Deduplicate information in HTML page's meta description.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -151,9 +151,8 @@ String renderPkgShowPage(
   final bool hasPlatformSearch =
       singlePlatform != null && singlePlatform != KnownPlatforms.other;
   final bool hasOnlyFlutterPlatform = singlePlatform == KnownPlatforms.flutter;
-  final bool isFlutterPackage = hasOnlyFlutterPlatform ||
-      latestStableVersion.pubspec.dependsOnFlutterSdk ||
-      latestStableVersion.pubspec.hasFlutterPlugin;
+  final bool isFlutterPackage =
+      hasOnlyFlutterPlatform || latestStableVersion.pubspec.usesFlutter;
 
   String readmeFilename;
   String renderedReadme;
@@ -304,22 +303,15 @@ String renderPkgShowPage(
   final packageAndVersion = isVersionPage
       ? '${selectedVersion.package} ${selectedVersion.version}'
       : selectedVersion.package;
-  var pageDescription = packageAndVersion;
-  if (isFlutterPackage) {
-    pageDescription += ' Flutter and Dart package';
-  } else {
-    pageDescription += ' Dart package';
-  }
   final pageTitle =
       '$packageAndVersion | ${isFlutterPackage ? 'Flutter' : 'Dart'} Package';
-  pageDescription += ' - ${selectedVersion.ellipsizedDescription}';
   final canonicalUrl =
       isVersionPage ? urls.pkgPageUrl(package.name, includeHost: true) : null;
   return renderLayoutPage(
     PageType.package,
     content,
     title: pageTitle,
-    pageDescription: pageDescription,
+    pageDescription: selectedVersion.ellipsizedDescription,
     faviconUrl: isFlutterPackage ? staticUrls.flutterLogo32x32 : null,
     canonicalUrl: canonicalUrl,
     platform: hasPlatformSearch ? singlePlatform : null,

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -15,8 +15,8 @@
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png"/>
     <meta property="og:image" content="/static/img/dart-logo-400x400.png"/>
     <link rel="shortcut icon" href="/favicon.ico"/>
-    <meta name="description" content="foobar_pkg Dart package - my package description"/>
-    <meta property="og:description" content="foobar_pkg Dart package - my package description"/>
+    <meta name="description" content="my package description"/>
+    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/highlight/github.css" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_discontinued.html
+++ b/app/test/frontend/golden/pkg_show_page_discontinued.html
@@ -16,8 +16,8 @@
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png"/>
     <meta property="og:image" content="/static/img/dart-logo-400x400.png"/>
     <link rel="shortcut icon" href="/favicon.ico"/>
-    <meta name="description" content="foobar_pkg Dart package - my package description"/>
-    <meta property="og:description" content="foobar_pkg Dart package - my package description"/>
+    <meta name="description" content="my package description"/>
+    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/highlight/github.css" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
+++ b/app/test/frontend/golden/pkg_show_page_flutter_plugin.html
@@ -15,8 +15,8 @@
     <meta itemprop="image" content="/static/img/dart-logo-400x400.png"/>
     <meta property="og:image" content="/static/img/dart-logo-400x400.png"/>
     <link rel="shortcut icon" href="/static/img/flutter-logo-32x32.png"/>
-    <meta name="description" content="foobar_pkg Flutter and Dart package - my package description"/>
-    <meta property="og:description" content="foobar_pkg Flutter and Dart package - my package description"/>
+    <meta name="description" content="my package description"/>
+    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/highlight/github.css" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -17,8 +17,8 @@
     <link rel="shortcut icon" href="/favicon.ico"/>
     <link rel="canonical" href="https://pub.dartlang.org/packages/foobar_pkg"/>
     <meta property="og:url" content="https://pub.dartlang.org/packages/foobar_pkg"/>
-    <meta name="description" content="foobar_pkg 0.1.1+5 Dart package - my package description"/>
-    <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description"/>
+    <meta name="description" content="my package description"/>
+    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/highlight/github.css" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -17,8 +17,8 @@
     <link rel="shortcut icon" href="/favicon.ico"/>
     <link rel="canonical" href="https://pub.dartlang.org/packages/foobar_pkg"/>
     <meta property="og:url" content="https://pub.dartlang.org/packages/foobar_pkg"/>
-    <meta name="description" content="foobar_pkg 0.1.1+5 Dart package - my package description"/>
-    <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description"/>
+    <meta name="description" content="my package description"/>
+    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/highlight/github.css" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -17,8 +17,8 @@
     <link rel="shortcut icon" href="/favicon.ico"/>
     <link rel="canonical" href="https://pub.dartlang.org/packages/foobar_pkg"/>
     <meta property="og:url" content="https://pub.dartlang.org/packages/foobar_pkg"/>
-    <meta name="description" content="foobar_pkg 0.1.1+5 Dart package - my package description"/>
-    <meta property="og:description" content="foobar_pkg 0.1.1+5 Dart package - my package description"/>
+    <meta name="description" content="my package description"/>
+    <meta property="og:description" content="my package description"/>
     <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom"/>
     <link href="/static/highlight/github.css" rel="stylesheet"/>
     <link href="/static/css/github-markdown.css?hash=mocked_hash_244413523" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
The title already contains the package name, version, and "[Flutter | Dart] package".
Fixes #2126