### PR TITLE
Remove bad packages from search index.

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -315,6 +315,9 @@ String renderPkgShowPage(
   pageDescription += ' - ${selectedVersion.ellipsizedDescription}';
   final canonicalUrl =
       isVersionPage ? urls.pkgPageUrl(package.name, includeHost: true) : null;
+  final noIndex = (card?.isSkipped ?? false) ||
+      (card?.overallScore == 0.0) ||
+      (package.isDiscontinued ?? false);
   return renderLayoutPage(
     PageType.package,
     content,
@@ -323,7 +326,7 @@ String renderPkgShowPage(
     faviconUrl: isFlutterPackage ? staticUrls.flutterLogo32x32 : null,
     canonicalUrl: canonicalUrl,
     platform: hasPlatformSearch ? singlePlatform : null,
-    noIndex: package.isDiscontinued == true, // isDiscontinued may be null
+    noIndex: noIndex,
   );
 }
 

--- a/app/test/frontend/golden/pkg_show_page.html
+++ b/app/test/frontend/golden/pkg_show_page.html
@@ -97,7 +97,7 @@
             <li class="tab" data-name="-versions-tab-" role="button">Versions</li>
             <li class="tab" data-name="-analysis-tab-" role="button">
               <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
+                <span class="number -rotten" title="Analysis and more details.">3</span>
               </div>
             </li>
           </ul>
@@ -231,11 +231,11 @@ import 'package:foobar_pkg/foolib.dart';
                 </td>
                 <td class="score-value">
                   <div class="score-percent-row">
-                    <div class="score-percent" style="left: 0%;">--</div>
+                    <div class="score-percent" style="left: 10%;">10</div>
                   </div>
                   <div class="score-progress-row">
                     <div class="score-progress-frame">
-                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
+                      <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
                     </div>
                   </div>
                 </td>
@@ -277,11 +277,11 @@ import 'package:foobar_pkg/foolib.dart';
                 </td>
                 <td>
                   <div class="score-percent-row">
-                    <div class="score-percent" style="left: 0%;">0</div>
+                    <div class="score-percent" style="left: 3%;">3</div>
                   </div>
                   <div class="score-progress-row">
                     <div class="score-progress-frame">
-                      <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
+                      <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
                     </div>
                   </div>
                 </td>

--- a/app/test/frontend/golden/pkg_show_page_legacy.html
+++ b/app/test/frontend/golden/pkg_show_page_legacy.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="robots" content="noindex"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta property="og:site_name" content="Dart Packages"/>

--- a/app/test/frontend/golden/pkg_show_page_outdated.html
+++ b/app/test/frontend/golden/pkg_show_page_outdated.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="x-ua-compatible" content="ie=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="robots" content="noindex"/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:site" content="@dart_lang"/>
     <meta property="og:site_name" content="Dart Packages"/>

--- a/app/test/frontend/golden/pkg_show_version_page.html
+++ b/app/test/frontend/golden/pkg_show_version_page.html
@@ -99,7 +99,7 @@
             <li class="tab" data-name="-versions-tab-" role="button">Versions</li>
             <li class="tab" data-name="-analysis-tab-" role="button">
               <div class="score-box">
-                <span class="number -rotten" title="Analysis and more details.">0</span>
+                <span class="number -rotten" title="Analysis and more details.">3</span>
               </div>
             </li>
           </ul>
@@ -233,11 +233,11 @@ import 'package:foobar_pkg/foolib.dart';
                 </td>
                 <td class="score-value">
                   <div class="score-percent-row">
-                    <div class="score-percent" style="left: 0%;">--</div>
+                    <div class="score-percent" style="left: 10%;">10</div>
                   </div>
                   <div class="score-progress-row">
                     <div class="score-progress-frame">
-                      <div class="score-progress" style="width: 0%; background: rgb(204, 204, 204);"></div>
+                      <div class="score-progress" style="width: 10%; background: rgb(120, 134, 149);"></div>
                     </div>
                   </div>
                 </td>
@@ -279,11 +279,11 @@ import 'package:foobar_pkg/foolib.dart';
                 </td>
                 <td>
                   <div class="score-percent-row">
-                    <div class="score-percent" style="left: 0%;">0</div>
+                    <div class="score-percent" style="left: 3%;">3</div>
                   </div>
                   <div class="score-progress-row">
                     <div class="score-progress-frame">
-                      <div class="score-progress" style="width: 0%; background: rgb(187, 36, 0);"></div>
+                      <div class="score-progress" style="width: 3%; background: rgb(187, 36, 0);"></div>
                     </div>
                   </div>
                 </td>

--- a/app/test/frontend/templates_test.dart
+++ b/app/test/frontend/templates_test.dart
@@ -134,7 +134,7 @@ void main() {
           devPackageVersion,
           1,
           AnalysisView(
-            card: ScoreCardData(reportTypes: ['pana']),
+            card: ScoreCardData(reportTypes: ['pana'], healthScore: 0.1),
             panaReport: PanaReport(
                 timestamp: new DateTime(2018, 02, 05),
                 panaRuntimeInfo: _panaRuntimeInfo,
@@ -186,7 +186,7 @@ void main() {
           devPackageVersion,
           1,
           AnalysisView(
-            card: ScoreCardData(reportTypes: ['pana']),
+            card: ScoreCardData(reportTypes: ['pana'], healthScore: 0.1),
             panaReport: PanaReport(
                 timestamp: new DateTime(2018, 02, 05),
                 panaRuntimeInfo: _panaRuntimeInfo,


### PR DESCRIPTION
Removes package page when:
- package is marked as discontinued
- package is legacy (Dart 1 only)
- package is obsolete (Too old version)
- package score is 0 (no use, too many penalties).

Fixes #2128.
