### PR TITLE
Fix: delete PackageInvite instead of updating confirmed field.

### DIFF
--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -250,18 +250,9 @@ class Backend {
     return null;
   }
 
-  /// Updates the confirmed timestamp in the [invite].
+  /// Delete the invite and clear package cache.
   Future confirmPackageInvite(models.PackageInvite invite) async {
-    await db.withTransaction((tx) async {
-      final pi = (await tx.lookup<models.PackageInvite>([invite.key])).single;
-      if (pi != null && pi.confirmed == null) {
-        pi.confirmed = DateTime.now().toUtc();
-        tx.queueMutations(inserts: [pi]);
-        await tx.commit();
-      } else {
-        await tx.rollback();
-      }
-    });
+    await db.commit(deletes: [invite.key]);
     await uiPackageCache.invalidateUIPackagePage(invite.packageName);
   }
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -461,9 +461,6 @@ class PackageInvite extends db.Model {
   @db.IntProperty()
   int notificationCount;
 
-  @db.DateTimeProperty()
-  DateTime confirmed;
-
   String get packageName => parentKey.id as String;
 
   /// Create a composite id.
@@ -483,8 +480,7 @@ class PackageInvite extends db.Model {
   bool isValid({@required String recipientEmail, @required String urlNonce}) {
     return this.recipientEmail == recipientEmail &&
         this.urlNonce == urlNonce &&
-        !isExpired() &&
-        confirmed != null;
+        !isExpired();
   }
 }
 


### PR DESCRIPTION
The `confirmed != null` causes a bug when there was an earlier invite that was confirmed with the same package+uploader combination. Deleting the `PackageInvite` will be a better route, we already keep a `History` record for invites and changes.