### PR TITLE
Remove namespace fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
 
+ * Removed `namespace` and `qualifiedPackage` fields from `PackageVersionPubspec` and `PackageVersionInfo`.
+
 ## `20190325t131912-all`
 
  * Fixes to invitation logic.

--- a/app/bin/tools/backfill_packageversions.dart
+++ b/app/bin/tools/backfill_packageversions.dart
@@ -58,8 +58,8 @@ Future _backfillPackage(String package) async {
   final packageKey = dbService.emptyKey.append(Package, id: package);
   final query = dbService.query<PackageVersion>(ancestorKey: packageKey);
   await for (PackageVersion pv in query.run()) {
-    final qualifiedKey = QualifiedVersionKey(
-        namespace: null, package: pv.package, version: pv.version);
+    final qualifiedKey =
+        QualifiedVersionKey(package: pv.package, version: pv.version);
 
     final pvPubspecKey = dbService.emptyKey
         .append(PackageVersionPubspec, id: qualifiedKey.qualifiedVersion);

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -949,8 +949,8 @@ Future<_ValidatedUpload> _parseAndValidateUpload(
 
   final versionString = canonicalizeVersion(pubspec.version);
 
-  final key = models.QualifiedVersionKey(
-      namespace: null, package: pubspec.name, version: versionString);
+  final key =
+      models.QualifiedVersionKey(package: pubspec.name, version: versionString);
 
   final version = new models.PackageVersion()
     ..id = versionString

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -237,7 +237,6 @@ class PackageVersion extends db.ExpandoModel {
 
   QualifiedVersionKey get qualifiedVersionKey {
     return QualifiedVersionKey(
-      namespace: '',
       package: package,
       version: version,
     );
@@ -251,13 +250,7 @@ class PackageVersion extends db.ExpandoModel {
 @db.Kind(name: 'PackageVersionPubspec', idType: db.IdType.String)
 class PackageVersionPubspec extends db.ExpandoModel {
   @db.StringProperty(required: true)
-  String namespace;
-
-  @db.StringProperty(required: true)
   String package;
-
-  @db.StringProperty(required: true)
-  String qualifiedPackage;
 
   @db.StringProperty(required: true)
   String version;
@@ -272,15 +265,12 @@ class PackageVersionPubspec extends db.ExpandoModel {
 
   void initFromKey(QualifiedVersionKey key) {
     id = key.qualifiedVersion;
-    namespace = key.namespace ?? '';
     package = key.package;
-    qualifiedPackage = key.qualifiedPackage;
     version = key.version;
   }
 
   QualifiedVersionKey get qualifiedVersionKey {
     return QualifiedVersionKey(
-      namespace: namespace,
       package: package,
       version: version,
     );
@@ -291,13 +281,7 @@ class PackageVersionPubspec extends db.ExpandoModel {
 @db.Kind(name: 'PackageVersionInfo', idType: db.IdType.String)
 class PackageVersionInfo extends db.ExpandoModel {
   @db.StringProperty(required: true)
-  String namespace;
-
-  @db.StringProperty(required: true)
   String package;
-
-  @db.StringProperty(required: true)
-  String qualifiedPackage;
 
   @db.StringProperty(required: true)
   String version;
@@ -354,49 +338,40 @@ class PackageVersionInfo extends db.ExpandoModel {
 
   void initFromKey(QualifiedVersionKey key) {
     id = key.qualifiedVersion;
-    namespace = key.namespace ?? '';
     package = key.package;
-    qualifiedPackage = key.qualifiedPackage;
     version = key.version;
   }
 
   QualifiedVersionKey get qualifiedVersionKey {
     return QualifiedVersionKey(
-      namespace: namespace,
       package: package,
       version: version,
     );
   }
 }
 
-/// An identifier to point to a specific [namespace], [package] and [version].
+/// An identifier to point to a specific [package] and [version].
 class QualifiedVersionKey {
-  final String namespace;
   final String package;
   final String version;
 
   QualifiedVersionKey({
-    @required this.namespace,
     @required this.package,
     @required this.version,
   });
 
-  String get qualifiedPackage =>
-      namespace == null || namespace.isEmpty ? package : '$namespace:$package';
-
-  String get qualifiedVersion => '$qualifiedPackage-$version';
+  String get qualifiedVersion => '$package-$version';
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is QualifiedVersionKey &&
           runtimeType == other.runtimeType &&
-          namespace == other.namespace &&
           package == other.package &&
           version == other.version;
 
   @override
-  int get hashCode => namespace.hashCode ^ package.hashCode ^ version.hashCode;
+  int get hashCode => package.hashCode ^ version.hashCode;
 
   @override
   String toString() => qualifiedVersion;

--- a/app/test/frontend/backend_test.dart
+++ b/app/test/frontend/backend_test.dart
@@ -665,17 +665,13 @@ void main() {
         expect(version.sortOrder, 1);
 
         expect(versionPubspec.id, 'foobar_pkg-0.1.1+5');
-        expect(versionPubspec.namespace, '');
         expect(versionPubspec.package, testPackage.name);
-        expect(versionPubspec.qualifiedPackage, testPackage.name);
         expect(versionPubspec.version, testPackageVersion.version);
         expect(versionPubspec.updated.compareTo(dateBeforeTest) >= 0, isTrue);
         expect(versionPubspec.pubspec.asJson, loadYaml(testPackagePubspec));
 
         expect(versionInfo.id, 'foobar_pkg-0.1.1+5');
-        expect(versionInfo.namespace, '');
         expect(versionInfo.package, testPackage.name);
-        expect(versionInfo.qualifiedPackage, testPackage.name);
         expect(versionInfo.version, testPackageVersion.version);
         expect(versionInfo.updated.compareTo(dateBeforeTest) >= 0, isTrue);
         expect(versionInfo.readmeFilename, 'README.md');


### PR DESCRIPTION
I think the idea of `namespace` is going away in this separate form. Maybe the `qualifiedVersion` should be revisited, the `-` may not be the best long-term separator there...