### PR TITLE
Set background color to white

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,11 +6,8 @@
   box-sizing: border-box;
 }
 
-html {
-  background-color: #fff;
-}
-
 body {
+  background-color: #fff;
   line-height: 1.6;
   margin: 0;
   padding: 0;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,6 +6,10 @@
   box-sizing: border-box;
 }
 
+html {
+  background-color: #fff;
+}
+
 body {
   line-height: 1.6;
   margin: 0;


### PR DESCRIPTION
![Unavngivet](https://user-images.githubusercontent.com/947230/55104161-23750c00-50ca-11e9-959d-3b63a3a1fdc4.png)

Steam's in-game browser uses a black background by default which makes it impossible to read the content on the site. Setting the background color to white should fix it.