### PR TITLE
Fix configuration initialization.

### DIFF
--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -5,7 +5,10 @@
 import 'dart:io';
 
 import 'package:googleapis_auth/auth.dart' as auth;
+import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+
+final _logger = Logger('configuration');
 
 Configuration _configuration;
 
@@ -185,8 +188,14 @@ class EnvConfig {
 /// Configuration from the environment variables.
 final EnvConfig envConfig = EnvConfig._detect();
 
-auth.ServiceAccountCredentials _loadCredentials([String path]) {
-  path ??= envConfig.gcloudKey;
-  final content = File(path).readAsStringSync();
-  return auth.ServiceAccountCredentials.fromJson(content);
+auth.ServiceAccountCredentials _loadCredentials() {
+  if (envConfig.hasCredentials) {
+    final path = envConfig.gcloudKey;
+    final content = File(path).readAsStringSync();
+    return auth.ServiceAccountCredentials.fromJson(content);
+  } else {
+    _logger.info(
+        'Missing GCLOUD_PROJECT and/or GCLOUD_KEY, service account credentials are not loaded.');
+    return null;
+  }
 }


### PR DESCRIPTION
#2146 changed the way we load the security credentials: previously it was lazily initialized, and only accessed after a `hasCredentials` check. Now we are trying to load it early, and we should allow to return null in that method. I've added an extra logging for it.