### PR TITLE
Self-contained dependency graph checker.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
  * `Package.uploaderEmails` and `PackageVersion.uploaderEmail` is no longer used/updated.
  * Removed `namespace` and `qualifiedPackage` fields from `PackageVersionPubspec` and `PackageVersionInfo`.
  * Upgrade Flutter SDK to 1.4.7, bumped runtimeVersion to `2019.04.02`.
+ * Dependency graph monitoring uses `PackageVersionPubspec`, and triggers affected notifications internally.
 
 ## `20190325t131912-all`
 


### PR DESCRIPTION
- uses `PackageVersionPubspec` instead of `PackageVersion`, much faster Datastore responses (half the total time on my dev machine)
- triggers the notifications internally via the callback function

The later enables us to decouple it from the package upload callback of the `frontend`, making it possible to move it out of `frontend`, and have it running in `analyzer` and `dartdoc` separately.