### PR TITLE
Reduce the log level when the SDK index is missing.

### DIFF
--- a/app/bin/service/search.dart
+++ b/app/bin/service/search.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:isolate';
 
+import 'package:_discoveryapis_commons/_discoveryapis_commons.dart'
+    show DetailedApiRequestError;
 import 'package:gcloud/db.dart' as db;
 import 'package:gcloud/service_scope.dart';
 import 'package:gcloud/storage.dart';
@@ -130,6 +132,12 @@ Future _updateDartSdkIndex() async {
         await dartSdkIndex.merge();
         _logger.info('Dart SDK index loaded successfully.');
         return;
+      }
+    } on DetailedApiRequestError catch (e, st) {
+      if (e.status == 404) {
+        _logger.info('Error loading Dart SDK index.', e, st);
+      } else {
+        _logger.warning('Error loading Dart SDK index.', e, st);
       }
     } catch (e, st) {
       _logger.warning('Error loading Dart SDK index.', e, st);


### PR DESCRIPTION
This happens when we have a new deploy, and `search` is trying to load the SDK index before it is ready. On 404 we should not emit warnings (we still emit warning every 10 minutes if it is not yet successful).