### PR TITLE
Do not create User for hasUploader check.

### DIFF
--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -121,7 +121,8 @@ class AccountBackend {
   /// not exists.
   ///
   /// Throws Exception if more then one `User` entry exists.
-  Future<User> lookupOrCreateUserByEmail(String email) async {
+  Future<User> lookupOrCreateUserByEmail(String email,
+      {bool create = true}) async {
     email = email.toLowerCase();
     final query = _db.query<User>()..filter('email =', email);
     final list = await query.run().toList();
@@ -130,6 +131,9 @@ class AccountBackend {
     }
     if (list.length == 1) {
       return list.single;
+    }
+    if (!create) {
+      return null;
     }
     final id = _uuid.v4().toString();
     final user = User()

--- a/app/lib/account/backend.dart
+++ b/app/lib/account/backend.dart
@@ -117,12 +117,10 @@ class AccountBackend {
     return result;
   }
 
-  /// Returns the `User` entry for the [email] or creates a new one if it does
-  /// not exists.
+  /// Returns the `User` entry for the [email] or null if it does not exists.
   ///
   /// Throws Exception if more then one `User` entry exists.
-  Future<User> lookupOrCreateUserByEmail(String email,
-      {bool create = true}) async {
+  Future<User> lookupUserByEmail(String email) async {
     email = email.toLowerCase();
     final query = _db.query<User>()..filter('email =', email);
     final list = await query.run().toList();
@@ -132,11 +130,21 @@ class AccountBackend {
     if (list.length == 1) {
       return list.single;
     }
-    if (!create) {
-      return null;
+    return null;
+  }
+
+  /// Returns the `User` entry for the [email] or creates a new one if it does
+  /// not exists.
+  ///
+  /// Throws Exception if more then one `User` entry exists.
+  Future<User> lookupOrCreateUserByEmail(String email) async {
+    email = email.toLowerCase();
+    User user = await lookupUserByEmail(email);
+    if (user != null) {
+      return user;
     }
     final id = _uuid.v4().toString();
-    final user = User()
+    user = User()
       ..parentKey = _db.emptyKey
       ..id = id
       ..email = email

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -595,8 +595,7 @@ class GCloudPackageRepository extends PackageRepository {
             'Not a valid e-mail: `$uploaderEmail`.');
       }
 
-      final uploader = await accountBackend
-          .lookupOrCreateUserByEmail(uploaderEmail, create: false);
+      final uploader = await accountBackend.lookupUserByEmail(uploaderEmail);
       if (uploader != null && package.hasUploader(uploader.userId)) {
         // The requested uploaderEmail is already part of the uploaders.
         return;

--- a/app/lib/frontend/backend.dart
+++ b/app/lib/frontend/backend.dart
@@ -595,10 +595,9 @@ class GCloudPackageRepository extends PackageRepository {
             'Not a valid e-mail: `$uploaderEmail`.');
       }
 
-      // TODO: do not create a new User for unverified uploader email
-      final uploader =
-          await accountBackend.lookupOrCreateUserByEmail(uploaderEmail);
-      if (package.hasUploader(uploader.userId)) {
+      final uploader = await accountBackend
+          .lookupOrCreateUserByEmail(uploaderEmail, create: false);
+      if (uploader != null && package.hasUploader(uploader.userId)) {
         // The requested uploaderEmail is already part of the uploaders.
         return;
       }

--- a/app/test/frontend/backend_test_utils.dart
+++ b/app/test/frontend/backend_test_utils.dart
@@ -450,6 +450,11 @@ class AccountBackendMock implements AccountBackend {
   }
 
   @override
+  Future<User> lookupUserByEmail(String email) async {
+    return users.firstWhere((u) => u.email == email, orElse: () => null);
+  }
+
+  @override
   Future<User> lookupOrCreateUserByEmail(String email) async {
     return users.firstWhere((u) => u.email == email, orElse: () {
       final u = User()


### PR DESCRIPTION
I can't really decide what to make of the `lookupOrCreateUserByEmail` method name. We could use
`lookupUserByEmail` with the same signature, or make `create = false` by default, and change the current callers to follow the new signature. wdyt?