### PR TITLE
Tracking experimental serving status in request context.

### DIFF
--- a/app/lib/frontend/handlers.dart
+++ b/app/lib/frontend/handlers.dart
@@ -98,6 +98,7 @@ const _handlers = <String, shelf.Handler>{
   '/packages.json': packagesHandler,
   '/help': helpPageHandler,
   '/oauth/callback': oauthCallbackHandler,
+  '/experimental': experimentalHandler,
 };
 
 /// Handles requests for /debug

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -76,6 +76,18 @@ Future<shelf.Response> staticsHandler(shelf.Request request) async {
   return notFoundHandler(request);
 }
 
+/// Handles requests for /experimental
+Future<shelf.Response> experimentalHandler(shelf.Request request) async {
+  final enabled = request.requestedUri.queryParameters['enabled'] == '1';
+  final cookie = Cookie('experimental', enabled ? '1' : '0')
+    ..httpOnly = true
+    ..path = '/'
+    ..maxAge = enabled ? 7 * 24 * 60 * 60 : 0; // cookie lives for one week
+  return htmlResponse('Cookie enabled: $enabled', headers: {
+    HttpHeaders.setCookieHeader: cookie.toString(),
+  });
+}
+
 Future<shelf.Response> formattedNotFoundHandler(shelf.Request request) async {
   final packages = await topFeaturedPackages();
   final message =

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/service_scope.dart' as ss;
+
+/// Sets the active [RequestContext].
+void registerRequestContext(RequestContext value) =>
+    ss.register(#_request_context, value);
+
+/// The active [RequestContext].
+RequestContext get requestContext =>
+    ss.lookup(#_request_context) as RequestContext ?? const RequestContext();
+
+/// Holds flags for request context.
+class RequestContext {
+  final bool isExperimental;
+
+  const RequestContext({this.isExperimental = false});
+}

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -36,7 +36,7 @@ Future<void> runHandler(
   handler = _redirectToHttpsWrapper(handler);
   handler = _logRequestWrapper(logger, handler);
   handler = _cspHeaderWrapper(handler);
-  handler = _clientContextWrapper(handler);
+  handler = _requestContextWrapper(handler);
   await runAppEngine((HttpRequest request) {
     // If request origins from the appengine cron scheduler, and we have a
     // cron handler we call that.
@@ -53,8 +53,8 @@ Future<void> runHandler(
   }, shared: true, port: port);
 }
 
-/// Populates [clientContext] with the extracted request attributes.
-shelf.Handler _clientContextWrapper(shelf.Handler handler) {
+/// Populates [requestContext] with the extracted request attributes.
+shelf.Handler _requestContextWrapper(shelf.Handler handler) {
   return (shelf.Request request) async {
     final isPubDev = request.requestedUri.host == 'pub.dev';
     final cookies =

--- a/app/lib/shared/utils.dart
+++ b/app/lib/shared/utils.dart
@@ -440,3 +440,31 @@ Future<R> retryAsync<R>(
     }
   }
 }
+
+/// Parses the Cookie HTTP header and returns a map of the values.
+Map<String, String> parseCookieHeader(String cookieHeader) {
+  if (cookieHeader == null) {
+    return const <String, String>{};
+  }
+  final r = <String, String>{};
+  cookieHeader
+      .split(';')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .map(
+        (s) {
+          try {
+            return Cookie.fromSetCookieValue(s);
+          } catch (_) {
+            return null;
+          }
+        },
+      )
+      .where((c) => c != null)
+      .forEach(
+        (c) {
+          r[c.name] = c.value;
+        },
+      );
+  return r;
+}

--- a/app/test/shared/utils_test.dart
+++ b/app/test/shared/utils_test.dart
@@ -107,4 +107,19 @@ void main() {
       expect(boundedList(numbers10, offset: 9, limit: 10), [9]);
     });
   });
+
+  group('parseCookieHeader', () {
+    test('no value', () {
+      expect(parseCookieHeader(null), {});
+      expect(parseCookieHeader(' '), {});
+    });
+
+    test('single value', () {
+      expect(parseCookieHeader('a=b'), {'a': 'b'});
+    });
+
+    test('two values', () {
+      expect(parseCookieHeader('a=b; c=dd'), {'a': 'b', 'c': 'dd'});
+    });
+  });
 }


### PR DESCRIPTION
At first I wanted to put the `isExperimental` flag inside `shelf.Request.context`, but turned out that it then requires us to pass that or the extracted flag to all of the underlying methods.

I'll need to refactor the template cache a bit before applying this transparently.