### PR TITLE
Refactor template cache

### DIFF
--- a/app/lib/frontend/templates/_cache.dart
+++ b/app/lib/frontend/templates/_cache.dart
@@ -30,10 +30,8 @@ class TemplateCache {
       (file) {
         final t = mustache.Template(file.readAsStringSync(), lenient: true);
         final relativePath = path.relative(file.path, from: templateFolder);
-        final ext = path.extension(relativePath);
-        final simplePath =
-            relativePath.substring(0, relativePath.length - ext.length);
-        _parsedMustacheTemplates[simplePath] = t;
+        final name = path.withoutExtension(relativePath);
+        _parsedMustacheTemplates[name] = t;
       },
     );
   }

--- a/app/lib/frontend/templates/_cache.dart
+++ b/app/lib/frontend/templates/_cache.dart
@@ -40,7 +40,7 @@ class TemplateCache {
   String renderTemplate(String template, values) {
     final parsedTemplate = _parsedMustacheTemplates[template];
     if (parsedTemplate == null) {
-      throw Exception('Template $template was not found.');
+      throw ArgumentError('Template $template was not found.');
     }
     return parsedTemplate.renderString(values);
   }

--- a/app/lib/frontend/templates/_cache.dart
+++ b/app/lib/frontend/templates/_cache.dart
@@ -26,14 +26,11 @@ class TemplateCache {
             path.join(resolveAppDir(), 'lib/frontend/templates/views');
 
   /// Renders [template] with given [values].
-  ///
-  /// If [escapeValues] is `false`, values in `values` will not be escaped.
-  String renderTemplate(String template, values, {bool escapeValues = true}) {
+  String renderTemplate(String template, values) {
     final mustache.Template parsedTemplate =
         _cachedMustacheTemplates.putIfAbsent(template, () {
       final file = File('$_templateDirectory/$template.mustache');
-      return mustache.Template(file.readAsStringSync(),
-          htmlEscapeValues: escapeValues, lenient: true);
+      return mustache.Template(file.readAsStringSync(), lenient: true);
     });
     return parsedTemplate.renderString(values);
   }

--- a/app/lib/frontend/templates/_cache.dart
+++ b/app/lib/frontend/templates/_cache.dart
@@ -20,8 +20,8 @@ class TemplateCache {
     _loadDirectory(path.join(resolveAppDir(), 'lib/frontend/templates/views'));
   }
 
-  void _loadDirectory(String dirPath) {
-    Directory(dirPath)
+  void _loadDirectory(String templateFolder) {
+    Directory(templateFolder)
         .listSync(recursive: true)
         .where((fse) => fse is File)
         .cast<File>()
@@ -29,7 +29,7 @@ class TemplateCache {
         .forEach(
       (file) {
         final t = mustache.Template(file.readAsStringSync(), lenient: true);
-        final relativePath = path.relative(file.path, from: dirPath);
+        final relativePath = path.relative(file.path, from: templateFolder);
         final ext = path.extension(relativePath);
         final simplePath =
             relativePath.substring(0, relativePath.length - ext.length);

--- a/app/lib/frontend/templates/layout.dart
+++ b/app/lib/frontend/templates/layout.dart
@@ -82,7 +82,7 @@ String renderLayoutPage(
     'schema_org_searchaction_json':
         isRoot ? json.encode(_schemaOrgSearchAction) : null,
   };
-  return templateCache.renderTemplate('layout', values, escapeValues: false);
+  return templateCache.renderTemplate('layout', values);
 }
 
 String renderPlatformTabs({

--- a/app/lib/frontend/templates/listing.dart
+++ b/app/lib/frontend/templates/listing.dart
@@ -20,8 +20,7 @@ String renderPagination(PageLinks pageLinks) {
   final values = {
     'page_links': pageLinks.hrefPatterns(),
   };
-  return templateCache.renderTemplate('pagination', values,
-      escapeValues: false);
+  return templateCache.renderTemplate('pagination', values);
 }
 
 /// Renders the `views/pkg/index.mustache` template.

--- a/app/lib/frontend/templates/views/layout.mustache
+++ b/app/lib/frontend/templates/views/layout.mustache
@@ -15,8 +15,8 @@
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:site" content="@dart_lang" />
   <meta property="og:site_name" content="Dart Packages" />
-  <title>{{title}}</title>
-  <meta property="og:title" content="{{title}}" />
+  <title>{{& title}}</title>
+  <meta property="og:title" content="{{& title}}" />
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet" />
   <meta itemprop="image" content="{{{static_assets_dir}}}/img/dart-logo-400x400.png" />
   <meta property="og:image" content="{{{static_assets_dir}}}/img/dart-logo-400x400.png" />
@@ -27,8 +27,8 @@
   <link rel="canonical" href="{{{canonicalUrl}}}"/>
   <meta property="og:url" content="{{{canonicalUrl}}}" />
   {{/canonicalUrl}}
-  <meta name="description" content="{{pageDescription}}" />
-  <meta property="og:description" content="{{pageDescription}}" />
+  <meta name="description" content="{{& pageDescription}}" />
+  <meta property="og:description" content="{{& pageDescription}}" />
   <link rel="alternate" type="application/atom+xml" title="Updated Packages Feed for Pub" href="/feed.atom" />
   <link href="{{{static_assets_dir}}}/highlight/github.css" rel="stylesheet" />
   <link href="{{{static_assets.github_markdown_css}}}" rel="stylesheet" type="text/css" />

--- a/app/lib/frontend/templates/views/pagination.mustache
+++ b/app/lib/frontend/templates/views/pagination.mustache
@@ -5,8 +5,8 @@
 <ul class="pagination">
   {{#page_links}}
     <li class="{{#active}}-active{{/active}}{{#disabled}}-disabled{{/disabled}}">
-      <a href="{{#render_link}}{{href}}{{/render_link}}"{{#rel_prev}} rel="prev"{{/rel_prev}}{{#rel_next}} rel="next"{{/rel_next}}>
-        <span>{{{text}}}</span>
+      <a href="{{#render_link}}{{& href}}{{/render_link}}"{{#rel_prev}} rel="prev"{{/rel_prev}}{{#rel_next}} rel="next"{{/rel_next}}>
+        <span>{{& text}}</span>
       </a>
     </li>
   {{/page_links}}


### PR DESCRIPTION
Enabling `escapeValues: false` was a bit strange, we should rather use the default escaping and mark the non-escaped values in the template (with `{{{` or `{{&`). I've checked the templates and all of the values that are now marked as such are prepared with HTML escaping in the preparation step.

The pre-loading of the template is better for the dual-setup template rendering: we'll have simpler logic when we are about to decide which template to use.