### PR TITLE
Delete old dartdoc content even if it is the latest successful run.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
 
+ * Old dartdoc content will be deleted after 180 days, even if it is the only successful dartdoc run.
 
 ## `20190404t123731-all`
 

--- a/app/lib/dartdoc/models.dart
+++ b/app/lib/dartdoc/models.dart
@@ -171,6 +171,11 @@ class DartdocEntry {
     // Older entry seems to be better.
     return true;
   }
+
+  /// The current age of the entry.
+  Duration get age {
+    return DateTime.now().toUtc().difference(timestamp);
+  }
 }
 
 @JsonSerializable()


### PR DESCRIPTION
Previously: if we had an old runtime that created dartdoc content, and the current one failed on it, we'd keep the old one forever. With this change we'll delete the old one after it reaches the old content threshold (180 days).