### PR TITLE
Publisher Datastore model

### DIFF
--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -50,6 +50,10 @@ class Package extends db.ExpandoModel {
   @db.ModelKeyProperty(propertyName: 'latest_dev_version')
   db.Key latestDevVersionKey;
 
+  /// The publisher id (if the package is associated with a publisher).
+  @db.StringProperty()
+  String publisherId;
+
   /// List of User.userId
   @db.StringListProperty()
   List<String> uploaders;
@@ -196,6 +200,10 @@ class PackageVersion extends db.ExpandoModel {
   // TODO: set it to required: true once the integrity check script passes
   @db.StringProperty(required: false)
   String uploader;
+
+  /// The publisher id at the time of the upload.
+  @db.StringProperty()
+  String publisherId;
 
   // Convenience Fields:
 

--- a/app/lib/frontend/models.dart
+++ b/app/lib/frontend/models.dart
@@ -50,7 +50,7 @@ class Package extends db.ExpandoModel {
   @db.ModelKeyProperty(propertyName: 'latest_dev_version')
   db.Key latestDevVersionKey;
 
-  /// The publisher id (if the package is associated with a publisher).
+  /// The publisher id (null, if the package does not have a publisher).
   @db.StringProperty()
   String publisherId;
 

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -19,6 +19,9 @@ class Publisher extends db.ExpandoModel {
   @db.StringProperty()
   String websiteUrl;
 
+  @db.StringProperty()
+  String contactEmail;
+
   @db.DateTimeProperty()
   DateTime created;
 

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -83,7 +83,4 @@ class PublisherMember extends db.ExpandoModel {
   /// One of [PublisherMemberRole].
   @db.StringProperty()
   String role;
-
-  @db.BoolProperty()
-  bool isPublic;
 }

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -8,7 +8,7 @@ import 'package:gcloud/db.dart' as db;
 @db.Kind(name: 'Publisher', idType: db.IdType.String)
 class Publisher extends db.ExpandoModel {
   /// The associated domain name of the publisher.
-  String get domainName => id as String;
+  String get publisherId => id as String;
 
   /// Markdown formatted description of the publisher.
   ///
@@ -33,7 +33,7 @@ class Publisher extends db.ExpandoModel {
 @db.Kind(name: 'PublisherInfo', idType: db.IdType.String)
 class PublisherInfo extends db.ExpandoModel {
   /// The associated domain name of the publisher.
-  String get domainName => id as String;
+  String get publisherId => id as String;
 
   @db.DateTimeProperty()
   DateTime updated;
@@ -72,7 +72,7 @@ class PublisherMember extends db.ExpandoModel {
   db.Key get publisherKey => parentKey;
 
   /// The associated domain name of the publisher.
-  String get domainName => publisherKey.id as String;
+  String get publisherId => publisherKey.id as String;
 
   /// The userId of the member.
   String get userId => id as String;

--- a/app/lib/publisher/models.dart
+++ b/app/lib/publisher/models.dart
@@ -1,0 +1,89 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:gcloud/db.dart' as db;
+
+/// Canonical publisher data.
+@db.Kind(name: 'Publisher', idType: db.IdType.String)
+class Publisher extends db.ExpandoModel {
+  /// The associated domain name of the publisher.
+  String get domainName => id as String;
+
+  /// Markdown formatted description of the publisher.
+  ///
+  /// Limited to 64 KB in length.
+  @db.StringProperty()
+  String description;
+
+  @db.StringProperty()
+  String websiteUrl;
+
+  @db.DateTimeProperty()
+  DateTime created;
+
+  @db.DateTimeProperty()
+  DateTime updated;
+}
+
+/// Derived publisher data.
+@db.Kind(name: 'PublisherInfo', idType: db.IdType.String)
+class PublisherInfo extends db.ExpandoModel {
+  /// The associated domain name of the publisher.
+  String get domainName => id as String;
+
+  @db.DateTimeProperty()
+  DateTime updated;
+
+  /// List of packages that are associated with this publisher.
+  @db.StringListProperty()
+  List<String> packages;
+
+  /// List of userIds that are administrators of this publisher.
+  /// (their e-mail address is public information)
+  @db.StringListProperty()
+  List<String> admins;
+
+  /// List of userIds that are public members of this publisher.
+  /// (their e-mail address is public information)
+  @db.StringListProperty()
+  List<String> publicMembers;
+}
+
+/// Values for [PublisherMember.role]
+abstract class PublisherMemberRole {
+  /// Administrator of the publisher.
+  static const String admin = 'admin';
+
+  /// Accepted membership.
+  static const String member = 'member';
+
+  /// Invited but not accepted.
+  static const String pending = 'pending';
+}
+
+/// Stores the membership information of a single user.
+@db.Kind(name: 'PublisherMember', idType: db.IdType.String)
+class PublisherMember extends db.ExpandoModel {
+  /// The key of the publisher.
+  db.Key get publisherKey => parentKey;
+
+  /// The associated domain name of the publisher.
+  String get domainName => publisherKey.id as String;
+
+  /// The userId of the member.
+  String get userId => id as String;
+
+  @db.DateTimeProperty()
+  DateTime invited;
+
+  @db.DateTimeProperty()
+  DateTime accepted;
+
+  /// One of [PublisherMemberRole].
+  @db.StringProperty()
+  String role;
+
+  @db.BoolProperty()
+  bool isPublic;
+}


### PR DESCRIPTION
#1518

- I remember that we've talked about `Publisher` containing the member entries, but I don't think we should do that. Having a separate entity for the membership allows us to track invites and roles separately.
- The invite also differs from the `PackageInvite` because it doesn't need a nonce, we can do it on the pub site, without a shared secret.
- Added `publisherId` to both `Package` and `PackageVersion`, the later to track if a specific version was published under the publisher or earlier (or under a different publisher if it gets moved between them).
