### PR TITLE
Bump dartdoc to 0.28.3+2 and markdown to 2.0.3

### DIFF
--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -16,7 +16,7 @@ final RegExp runtimeVersionPattern = RegExp(r'\d{4}\.\d{2}\.\d{2}');
 /// Increment the version when a change is significant enough to trigger
 /// reprocessing, including: version change in pana, dartdoc, or the SDKs,
 /// or when an feature or bugfix should be picked up by the analysis ASAP.
-const String runtimeVersion = '2019.04.02';
+const String runtimeVersion = '2019.04.16';
 final Version semanticRuntimeVersion = Version.parse(runtimeVersion);
 
 /// The version which marks the earliest version of the data which we'd like to

--- a/app/lib/shared/versions.dart
+++ b/app/lib/shared/versions.dart
@@ -44,7 +44,7 @@ final String flutterVersion = '1.4.7';
 final Version semanticFlutterVersion = Version.parse(flutterVersion);
 
 // keep in-sync with pkg/pub_dartdoc/pubspec.yaml
-final String dartdocVersion = '0.28.2';
+final String dartdocVersion = '0.28.3+2';
 final Version semanticDartdocVersion = Version.parse(dartdocVersion);
 
 // Version that control the dartdoc serving.

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   matcher:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   intl: '>=0.13.0 <0.16.0'
   json_annotation: '^2.0.0'
   logging: '>=0.9.3 <1.0.0'
-  markdown: '>=2.0.0 <2.1.0'
+  markdown: '>=2.0.3 <2.1.0'
   meta: ^1.1.2
   mime: '>=0.9.3 <0.10.0'
   mustache: ^1.0.0

--- a/app/test/shared/versions_test.dart
+++ b/app/test/shared/versions_test.dart
@@ -30,7 +30,7 @@ void main() {
     // This test is a reminder that if pana, the SDK or any of the above
     // versions change, we should also adjust the [runtimeVersion]. Before
     // updating the hash value, double-check if it is being updated.
-    expect(hash, 113282038);
+    expect(hash, 923787263);
   });
 
   test('runtime version should be (somewhat) lexicographically ordered', () {

--- a/pkg/pub_dartdoc/pubspec.lock
+++ b/pkg/pub_dartdoc/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       name: dartdoc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.28.2"
+    version: "0.28.3+2"
   file:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   matcher:
     dependency: transitive
     description:

--- a/pkg/pub_dartdoc/pubspec.yaml
+++ b/pkg/pub_dartdoc/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   pub_dartdoc_data:
     path: ../pub_dartdoc_data
   # dartdoc version to be pinned, keep in-sync with app/lib/shared/versions.dart
-  dartdoc: 0.28.2
+  dartdoc: 0.28.3+2
 
 dev_dependencies:
   test: '^1.3.0'


### PR DESCRIPTION
This bumps markdown to a version which properly escapes fenced code block "info strings."