### PR TITLE
Use dart2js --csp, and remove unsafe-eval CSP rule.

### DIFF
--- a/app/lib/frontend/static_files.dart
+++ b/app/lib/frontend/static_files.dart
@@ -198,6 +198,7 @@ Future updateLocalBuiltFiles() async {
     final pr = await runProc(
       'dart2js',
       [
+        '--csp',
         '--dump-info',
         '--minify',
         '--trust-primitives',

--- a/app/lib/shared/handlers.dart
+++ b/app/lib/shared/handlers.dart
@@ -77,7 +77,6 @@ final _contentSecurityPolicyMap = <String, List<String>>{
   'object-src': _none,
   'script-src': <String>[
     "'self'",
-    "'unsafe-eval'", // dart2js requires it
     'https://www.googletagmanager.com/',
     'https://www.google.com/',
     'https://www.google-analytics.com/',

--- a/pkg/web_app/lib/script.dart
+++ b/pkg/web_app/lib/script.dart
@@ -451,4 +451,5 @@ void _updateDartdocStatus() {
   }
 }
 
+/// The dataset attribute name we use to store the documentation status.
 const _hasDocumentationAttr = 'hasDocumentation';


### PR DESCRIPTION
Fixes #2212. Tested it locally, looks good.