### PR TITLE
Updated script.dart build trigger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN pub get --offline --no-precompile
 WORKDIR /project/pkg/web_app
 RUN pub get --no-precompile
 RUN pub get --offline --no-precompile
+RUN ./build.sh
 
 WORKDIR /project/app
 RUN pub get --no-precompile

--- a/pkg/web_app/build.sh
+++ b/pkg/web_app/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Compiles script.dart to JavaScript and places the output in the static/js directory.
 
 set -e
 

--- a/pkg/web_app/build.sh
+++ b/pkg/web_app/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WEB_APP_DIR="${SCRIPT_DIR}"
+PROJECT_DIR="$( cd ${WEB_APP_DIR}/../.. && pwd )"
+STATIC_DIR="${PROJECT_DIR}/static"
+
+# Change to web_app folder
+cd "${WEB_APP_DIR}";
+
+dart2js \
+  --csp \
+  --dump-info \
+  --minify \
+  --trust-primitives \
+  --omit-implicit-checks \
+  "${WEB_APP_DIR}/lib/script.dart" \
+  -o \
+  "${STATIC_DIR}/js/script.dart.js"


### PR DESCRIPTION
- introduced a `build.sh` script that invokes `dart2js`
- running the script from `Dockerfile`
- running the script from the static file initialization code, when any file in the `pkg/web_app` directory changes (this is useful for local development). previously it did check only the `script.dart` file, but (a) I'm planning to refactor that into multiple files, and (b) we also want to trigger the build when the build script changes.