### PR TITLE
Reduce spelling correction candidates: no suffix list.

### DIFF
--- a/app/lib/search/text_utils.dart
+++ b/app/lib/search/text_utils.dart
@@ -130,7 +130,6 @@ Set<String> ngrams(String input, int minLength, int maxLength) {
 /// Generates lookup candidates that are, either:
 /// - derived by deleting one character from [token],
 /// - are the prefix part of [token] (min 4 characters)
-/// - are the suffix part of [token] (min 4 characters)
 Set<String> deriveLookupCandidates(String token) {
   final set = Set<String>();
   if (token.length <= 3) {
@@ -141,9 +140,6 @@ Set<String> deriveLookupCandidates(String token) {
     final suffix = i == token.length - 1 ? '' : token.substring(i + 1);
     if (prefix.length > 3) {
       set.add(prefix);
-    }
-    if (suffix.length > 3) {
-      set.add(suffix);
     }
     set.add(prefix + suffix);
   }

--- a/app/test/search/index_simple_test.dart
+++ b/app/test/search/index_simple_test.dart
@@ -94,11 +94,11 @@ void main() {
       for (String name in names) {
         index.add(name, name);
       }
-      final match = index.lookupTokens('location');
+      final match = index.lookupTokens('geolocation');
       // location should be the top value, everything else should be lower
       expect(match.tokenWeights, {
-        'location': 1.0,
-        'geolocation': closeTo(0.578, 0.001),
+        'geolocation': 1.0,
+        'geolocator': closeTo(0.45, 0.01),
       });
     });
   });

--- a/app/test/search/text_utils_test.dart
+++ b/app/test/search/text_utils_test.dart
@@ -177,7 +177,6 @@ Other useful methods will be added soon...
             'acdef', // b deleted
             'bcdef', // a deleted
             'abcd', // prefix of the input
-            'cdef', // postfix of the input
           ]));
     });
   });


### PR DESCRIPTION
This is in preparation to introduce trie to store the candidates.

~140 MB less memory (~1.8M word candidates removed). #1750

I was a bit worried on the (geo)location example, but it turns out that it is likely that the API of the package contains the location word separately or as part of a camelcased word, in the end we will find it. I didn't find any query that was doing worse with this change.