### PR TITLE
Move dependency graph scan to a separate isolate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 
 ## Next Release (replace with git tag when deployed)
 
+ * Dependency graph monitoring in a separate isolate of the `frontend` service.
+
 ## `20190416t133139-all`
 
  * Old dartdoc content will be deleted after 180 days, even if it is the only successful dartdoc run.

--- a/app/lib/shared/deps_graph.dart
+++ b/app/lib/shared/deps_graph.dart
@@ -76,13 +76,14 @@ class PackageDependencyBuilder {
 
   DateTime _lastTs;
 
+  /// The future will complete once the initial database has been scanned and a
+  /// graph has been built.
   static Future<PackageDependencyBuilder> loadInitialGraphFromDb(
       DatastoreDB db, OnAffected onAffected) async {
     final sw = Stopwatch()..start();
     final builder = PackageDependencyBuilder._(db, onAffected);
     await builder.scanExistingPackageGraph();
     _logger.info('Scanned initial dependency graph in ${sw.elapsed}.');
-    builder.monitorInBackground();
     return builder;
   }
 


### PR DESCRIPTION
We have 4-4 web-serving isolates on the `app` services, and each of them keeps track of the package dependency graph. This is inefficient, and contributes to the race conditions we seem to have in the logs. Moving it to a separate "worker" isolate.