### PR TITLE
Updated configuration and request context variables.

### DIFF
--- a/app/lib/frontend/handlers/landing.dart
+++ b/app/lib/frontend/handlers/landing.dart
@@ -41,15 +41,15 @@ Future<shelf.Response> _indexHandler(
     return redirectResponse(
         request.requestedUri.replace(path: newPath).toString());
   }
-  final isProd = requestContext.isProductionHost;
+  final useCache = requestContext.uiCacheEnabled;
   String pageContent =
-      isProd ? await backend.uiPackageCache?.getUIIndexPage(platform) : null;
+      useCache ? await backend.uiPackageCache?.getUIIndexPage(platform) : null;
   if (pageContent == null) {
     final packages = await topFeaturedPackages(platform: platform);
     final minilist = renderMiniList(packages);
 
     pageContent = renderIndexPage(minilist, platform);
-    if (isProd) {
+    if (useCache) {
       await backend.uiPackageCache?.setUIIndexPage(platform, pageContent);
     }
   }

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -27,7 +27,7 @@ Future<shelf.Response> helpPageHandler(shelf.Request request) async {
 
 /// Handles requests for /robots.txt
 Future<shelf.Response> robotsTxtHandler(shelf.Request request) async {
-  if (!requestContext.searchEnginesEnabled) {
+  if (requestContext.blockRobots) {
     return rejectRobotsHandler(request);
   }
   final uri = request.requestedUri;
@@ -39,7 +39,7 @@ sitemap: $sitemapUri
 
 /// Handles requests for /sitemap.txt
 Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
-  if (!requestContext.searchEnginesEnabled) {
+  if (requestContext.blockRobots) {
     return notFoundHandler(request);
   }
 

--- a/app/lib/frontend/handlers/misc.dart
+++ b/app/lib/frontend/handlers/misc.dart
@@ -27,7 +27,7 @@ Future<shelf.Response> helpPageHandler(shelf.Request request) async {
 
 /// Handles requests for /robots.txt
 Future<shelf.Response> robotsTxtHandler(shelf.Request request) async {
-  if (!requestContext.isProductionHost) {
+  if (!requestContext.searchEnginesEnabled) {
     return rejectRobotsHandler(request);
   }
   final uri = request.requestedUri;
@@ -39,7 +39,7 @@ sitemap: $sitemapUri
 
 /// Handles requests for /sitemap.txt
 Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
-  if (!requestContext.isProductionHost) {
+  if (!requestContext.searchEnginesEnabled) {
     return notFoundHandler(request);
   }
 
@@ -53,23 +53,19 @@ Future<shelf.Response> siteMapTxtHandler(shelf.Request request) async {
 
   final twoYearsAgo = DateTime.now().subtract(twoYears);
   final items = <String>[];
-  if (requestContext.showPackages) {
-    final pages = ['/', '/help', '/web', '/flutter'];
-    items.addAll(pages.map((page) => uri.replace(path: page).toString()));
-  }
+  final pages = ['/', '/help', '/web', '/flutter'];
+  items.addAll(pages.map((page) => uri.replace(path: page).toString()));
 
   final stream = backend.allPackageNames(
       updatedSince: twoYearsAgo, excludeDiscontinued: true);
   await for (var package in stream) {
     if (isSoftRemoved(package)) continue;
-    if (requestContext.showPackages) {
-      final path = urls.pkgPageUrl(package);
-      items.add(uri.replace(path: path).toString());
-    }
-    if (requestContext.showApiDocs) {
-      final path = urls.pkgDocUrl(package, isLatest: true);
-      items.add(uri.replace(path: path).toString());
-    }
+
+    final pkgPath = urls.pkgPageUrl(package);
+    items.add(uri.replace(path: pkgPath).toString());
+
+    final docPath = urls.pkgDocUrl(package, isLatest: true);
+    items.add(uri.replace(path: docPath).toString());
   }
 
   items.sort();

--- a/app/lib/frontend/handlers/package.dart
+++ b/app/lib/frontend/handlers/package.dart
@@ -117,8 +117,8 @@ Future<shelf.Response> _packageVersionHandlerHtml(
   }
   final Stopwatch sw = Stopwatch()..start();
   String cachedPage;
-  final bool isProd = requestContext.isProductionHost;
-  if (isProd && backend.uiPackageCache != null) {
+  final bool useCache = requestContext.uiCacheEnabled;
+  if (useCache && backend.uiPackageCache != null) {
     cachedPage =
         await backend.uiPackageCache.getUIPackagePage(packageName, versionName);
   }
@@ -179,7 +179,7 @@ Future<shelf.Response> _packageVersionHandlerHtml(
         analysisView);
     _packageDoneLatencyTracker.add(serviceSw.elapsed);
 
-    if (isProd && backend.uiPackageCache != null) {
+    if (useCache && backend.uiPackageCache != null) {
       await backend.uiPackageCache
           .setUIPackagePage(packageName, versionName, cachedPage);
     }

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -17,8 +17,8 @@ class RequestContext {
   /// Whether experimental UI features are activated.
   final bool isExperimental;
 
-  /// Whether indexing of the content by search engines is enabled.
-  final bool searchEnginesEnabled;
+  /// Whether indexing of the content by robots should be blocked.
+  final bool blockRobots;
 
   /// Whether the use of UI cache is enabled (when there is a risk of cache
   /// pollution by visually changing the site).
@@ -26,7 +26,7 @@ class RequestContext {
 
   const RequestContext({
     this.isExperimental = false,
-    this.searchEnginesEnabled = false,
+    this.blockRobots = true,
     this.uiCacheEnabled = false,
   });
 }

--- a/app/lib/frontend/request_context.dart
+++ b/app/lib/frontend/request_context.dart
@@ -14,22 +14,19 @@ RequestContext get requestContext =>
 
 /// Holds flags for request context.
 class RequestContext {
-  /// Whether the request is on a production host (vs. staging or dev)
-  final bool isProductionHost;
-
-  /// Whether the request is on a host that should serve packages.
-  final bool showPackages;
-
-  /// Whether the request is on a host the should serve API docs.
-  final bool showApiDocs;
-
   /// Whether experimental UI features are activated.
   final bool isExperimental;
 
+  /// Whether indexing of the content by search engines is enabled.
+  final bool searchEnginesEnabled;
+
+  /// Whether the use of UI cache is enabled (when there is a risk of cache
+  /// pollution by visually changing the site).
+  final bool uiCacheEnabled;
+
   const RequestContext({
-    this.isProductionHost = false,
-    this.showPackages = true,
-    this.showApiDocs = true,
     this.isExperimental = false,
+    this.searchEnginesEnabled = false,
+    this.uiCacheEnabled = false,
   });
 }

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -69,8 +69,8 @@ class Configuration {
   /// the Datastore.
   final auth.ServiceAccountCredentials credentials;
 
-  /// Whether indexing of the content by search engines is enabled.
-  final bool searchEnginesEnabled;
+  /// Whether indexing of the content by robots should be blocked.
+  final bool blockRobots;
 
   /// The list of hostnames which are considered production hosts (e.g. which
   /// are not limited in the cache use).
@@ -96,7 +96,7 @@ class Configuration {
       pubSiteAudience:
           '818368855108-e8skaopm5ih5nbb82vhh66k7ft5o7dn3.apps.googleusercontent.com',
       credentials: _loadCredentials(),
-      searchEnginesEnabled: true,
+      blockRobots: false,
       productionHosts: const ['pub.dartlang.org', 'pub.dev', 'api.pub.dev'],
     );
   }
@@ -117,7 +117,7 @@ class Configuration {
       pubSiteAudience:
           '621485135717-idb8t8nnguphtu2drfn2u4ig7r56rm6n.apps.googleusercontent.com',
       credentials: _loadCredentials(),
-      searchEnginesEnabled: false,
+      blockRobots: true,
       productionHosts: const ['dartlang-pub-dev.appspot.com'],
     );
   }
@@ -134,7 +134,7 @@ class Configuration {
     @required this.pubClientAudience,
     @required this.pubSiteAudience,
     @required this.credentials,
-    @required this.searchEnginesEnabled,
+    @required this.blockRobots,
     @required this.productionHosts,
   });
 

--- a/app/lib/shared/configuration.dart
+++ b/app/lib/shared/configuration.dart
@@ -69,6 +69,13 @@ class Configuration {
   /// the Datastore.
   final auth.ServiceAccountCredentials credentials;
 
+  /// Whether indexing of the content by search engines is enabled.
+  final bool searchEnginesEnabled;
+
+  /// The list of hostnames which are considered production hosts (e.g. which
+  /// are not limited in the cache use).
+  final List<String> productionHosts;
+
   /// Create a configuration for production deployment.
   ///
   /// This will use the Datastore from the cloud project and the Cloud Storage
@@ -77,18 +84,21 @@ class Configuration {
   factory Configuration._prod() {
     final projectId = 'dartlang-pub';
     return Configuration(
-        projectId: projectId,
-        packageBucketName: 'pub-packages',
-        dartdocStorageBucketName: '$projectId--dartdoc-storage',
-        popularityDumpBucketName: '$projectId--popularity',
-        searchSnapshotBucketName: '$projectId--search-snapshot',
-        backupSnapshotBucketName: '$projectId--backup-snapshots',
-        searchServicePrefix: 'https://search-dot-$projectId.appspot.com',
-        pubHostedUrl: 'https://pub.dartlang.org',
-        pubClientAudience: _pubClientAudience,
-        pubSiteAudience:
-            '818368855108-e8skaopm5ih5nbb82vhh66k7ft5o7dn3.apps.googleusercontent.com',
-        credentials: _loadCredentials());
+      projectId: projectId,
+      packageBucketName: 'pub-packages',
+      dartdocStorageBucketName: '$projectId--dartdoc-storage',
+      popularityDumpBucketName: '$projectId--popularity',
+      searchSnapshotBucketName: '$projectId--search-snapshot',
+      backupSnapshotBucketName: '$projectId--backup-snapshots',
+      searchServicePrefix: 'https://search-dot-$projectId.appspot.com',
+      pubHostedUrl: 'https://pub.dartlang.org',
+      pubClientAudience: _pubClientAudience,
+      pubSiteAudience:
+          '818368855108-e8skaopm5ih5nbb82vhh66k7ft5o7dn3.apps.googleusercontent.com',
+      credentials: _loadCredentials(),
+      searchEnginesEnabled: true,
+      productionHosts: const ['pub.dartlang.org', 'pub.dev', 'api.pub.dev'],
+    );
   }
 
   /// Create a configuration for development/staging deployment.
@@ -107,6 +117,8 @@ class Configuration {
       pubSiteAudience:
           '621485135717-idb8t8nnguphtu2drfn2u4ig7r56rm6n.apps.googleusercontent.com',
       credentials: _loadCredentials(),
+      searchEnginesEnabled: false,
+      productionHosts: const ['dartlang-pub-dev.appspot.com'],
     );
   }
 
@@ -122,6 +134,8 @@ class Configuration {
     @required this.pubClientAudience,
     @required this.pubSiteAudience,
     @required this.credentials,
+    @required this.searchEnginesEnabled,
+    @required this.productionHosts,
   });
 
   /// Create a configuration based on the environment variables.

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -68,13 +68,13 @@ shelf.Handler _requestContextWrapper(shelf.Handler handler) {
     final hasExperimentalCookie = cookies['experimental'] == '1';
     final isExperimental = isPubDev || hasExperimentalCookie;
 
-    final searchEnginesEnabled = hasExperimentalCookie ||
-        (activeConfiguration.searchEnginesEnabled && isProductionHost);
+    final enableRobots = hasExperimentalCookie ||
+        (!activeConfiguration.blockRobots && isProductionHost);
     final uiCacheEnabled = isProductionHost;
 
     registerRequestContext(RequestContext(
       isExperimental: isExperimental,
-      searchEnginesEnabled: searchEnginesEnabled,
+      blockRobots: !enableRobots,
       uiCacheEnabled: uiCacheEnabled,
     ));
     return await handler(request);

--- a/app/lib/shared/handler_helpers.dart
+++ b/app/lib/shared/handler_helpers.dart
@@ -17,6 +17,7 @@ import '../frontend/request_context.dart';
 import '../frontend/service_utils.dart';
 import '../frontend/templates/layout.dart';
 
+import 'configuration.dart';
 import 'handlers.dart';
 import 'markdown.dart';
 import 'utils.dart' show fileAnIssueContent, parseCookieHeader;
@@ -59,24 +60,22 @@ Future<void> runHandler(
 shelf.Handler _requestContextWrapper(shelf.Handler handler) {
   return (shelf.Request request) async {
     final host = request.requestedUri.host;
-    final isProductionHost = host == 'pub.dartlang.org' ||
-        host == 'pub.dev' ||
-        host == 'api.pub.dev';
-    final isPubDev =
-        host == 'pub.dev' || host == 'pubdev-dot-dartlang-pub-dev.appspot.com';
-    final isApiPubDev = host == 'api.pub.dev' ||
-        host == 'apipubdev-dot-dartlang-pub-dev.appspot.com';
+    final isProductionHost = activeConfiguration.productionHosts.contains(host);
+    final isPubDev = host == 'pub.dev';
 
     final cookies =
         parseCookieHeader(request.headers[HttpHeaders.cookieHeader]);
     final hasExperimentalCookie = cookies['experimental'] == '1';
     final isExperimental = isPubDev || hasExperimentalCookie;
 
+    final searchEnginesEnabled = hasExperimentalCookie ||
+        (activeConfiguration.searchEnginesEnabled && isProductionHost);
+    final uiCacheEnabled = isProductionHost;
+
     registerRequestContext(RequestContext(
-      isProductionHost: isProductionHost,
-      showPackages: !isApiPubDev,
-      showApiDocs: !isPubDev,
       isExperimental: isExperimental,
+      searchEnginesEnabled: searchEnginesEnabled,
+      uiCacheEnabled: uiCacheEnabled,
     ));
     return await handler(request);
   };


### PR DESCRIPTION
- split `isProductionHost` into two to better represent the meaning of it:
  - `uiCacheEnabled` to control whether a request should use UI cache to serve the content
  - `searchEnginesEnabled` to control whether the request should serve `robots.txt` and `sitemap.txt` 
    - it also depends on the project-level configuration, only prod is enabled for search engines
    - to make it testable on staging, if the experimental cookie is set, we do serve the above files

- updated config to also contain the list of host names that are considered 'production' (and staging gets its own one)

- removed pkg/doc split, as we are not going to do it right now
 