### PR TITLE
Dynamic atom feed URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ AppEngine version, listed here to ease deployment and troubleshooting.
 ## Next Release (replace with git tag when deployed)
 
  * Dependency graph monitoring in a separate isolate of the `frontend` service.
+ * `/feed.atom` changes random seed to generate `uuid` for feed entry.
 
 ## `20190416t133139-all`
 

--- a/app/lib/frontend/handlers/atom_feed.dart
+++ b/app/lib/frontend/handlers/atom_feed.dart
@@ -11,7 +11,7 @@ import 'package:markdown/markdown.dart' as md;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:uuid/uuid.dart';
 
-import '../../shared/urls.dart' show siteRoot;
+import '../../shared/urls.dart' as urls;
 
 import '../backend.dart';
 import '../models.dart';
@@ -104,11 +104,9 @@ class Feed {
       this.entries);
 
   String toXmlDocument() {
-    final buffer = StringBuffer();
-    buffer..writeln('<?xml version="1.0" encoding="UTF-8"?>');
-
+    final buffer = StringBuffer('<?xml version="1.0" encoding="UTF-8"?>');
     writeToXmlBuffer(buffer);
-    return '$buffer';
+    return buffer.toString();
   }
 
   void writeToXmlBuffer(StringBuffer buffer) {
@@ -140,19 +138,13 @@ class Feed {
 Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
   final uuid = Uuid();
 
-  // TODO: Remove this after the we moved the to the dart version of the app.
-  final requestedUri = Uri.parse('$siteRoot/feed.atom');
-
   final entries = versions.map((PackageVersion version) {
-    final url = requestedUri
-        .resolve('/packages/${version.package}#${version.version}')
-        .toString();
-    final alternateUrl = requestedUri
-        .resolve('/packages/${Uri.encodeComponent(version.package)}')
-        .toString();
+    final pkgPage = urls.pkgPageUrl(version.package);
+    final alternateUrl = requestedUri.replace(path: pkgPage).toString();
     final alternateTitle = version.package;
 
-    final id = uuid.v5(Uuid.NAMESPACE_URL, url);
+    final id =
+        uuid.v5(Uuid.NAMESPACE_URL, version.qualifiedVersionKey.toString());
     final title = 'v${version.version} of ${version.package}';
 
     // NOTE: A pubspec.yaml file can have "author: ..." or "authors: ...".

--- a/app/lib/frontend/handlers/atom_feed.dart
+++ b/app/lib/frontend/handlers/atom_feed.dart
@@ -104,7 +104,8 @@ class Feed {
       this.entries);
 
   String toXmlDocument() {
-    final buffer = StringBuffer('<?xml version="1.0" encoding="UTF-8"?>');
+    final buffer = StringBuffer();
+    buffer.writeln('<?xml version="1.0" encoding="UTF-8"?>');
     writeToXmlBuffer(buffer);
     return buffer.toString();
   }
@@ -143,8 +144,13 @@ Feed feedFromPackageVersions(Uri requestedUri, List<PackageVersion> versions) {
     final alternateUrl = requestedUri.replace(path: pkgPage).toString();
     final alternateTitle = version.package;
 
-    final id =
-        uuid.v5(Uuid.NAMESPACE_URL, version.qualifiedVersionKey.toString());
+    // TODO: use only qualifiedVersion as seed after the domain migration
+    final seed = (requestedUri.host == 'pub.dartlang.org')
+        ? requestedUri
+            .resolve('/packages/${version.package}#${version.version}')
+            .toString()
+        : version.qualifiedVersionKey.toString();
+    final id = uuid.v5(Uuid.NAMESPACE_URL, seed);
     final title = 'v${version.version} of ${version.package}';
 
     // NOTE: A pubspec.yaml file can have "author: ..." or "authors: ...".

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -37,7 +37,7 @@ void main() {
         <subtitle>Last Updated Packages</subtitle>
 (\\s*)
         <entry>
-          <id>urn:uuid:d4fe7eb8-fc0e-5515-a5e5-5868b339d660</id>
+          <id>urn:uuid:ebaa25c2-6b0c-5829-a686-dc55c2bbd8e4</id>
           <title>v0.1.1\\+5 of foobar_pkg</title>
           <updated>${testPackageVersion.created.toIso8601String()}</updated>
           <author><name>Hans Juergen &lt;hans@juergen.com&gt;</name></author>

--- a/app/test/frontend/handlers/atom_feed_test.dart
+++ b/app/test/frontend/handlers/atom_feed_test.dart
@@ -37,7 +37,7 @@ void main() {
         <subtitle>Last Updated Packages</subtitle>
 (\\s*)
         <entry>
-          <id>urn:uuid:ebaa25c2-6b0c-5829-a686-dc55c2bbd8e4</id>
+          <id>urn:uuid:d4fe7eb8-fc0e-5515-a5e5-5868b339d660</id>
           <title>v0.1.1\\+5 of foobar_pkg</title>
           <updated>${testPackageVersion.created.toIso8601String()}</updated>
           <author><name>Hans Juergen &lt;hans@juergen.com&gt;</name></author>


### PR DESCRIPTION
Feed urls will use the same host as the requested URL (already used it for id and base url, but not for packages). I've changed the uuid seed for going forward, but kept the old one for compatibility on pub.dartlang.org