### PR TITLE
Hide the documentation URL properly (if internal)

### DIFF
--- a/app/lib/frontend/templates/package.dart
+++ b/app/lib/frontend/templates/package.dart
@@ -146,11 +146,7 @@ String _renderSidebar(
   final baseUrl = packageLinks.repositoryUrl ?? packageLinks.homepageUrl;
 
   String documentationUrl = packageLinks.documentationUrl;
-  if (documentationUrl != null &&
-      (documentationUrl.startsWith('https://www.dartdocs.org/') ||
-          documentationUrl.startsWith('http://www.dartdocs.org/') ||
-          documentationUrl.startsWith('https://pub.dartlang.org/') ||
-          documentationUrl.startsWith('http://pub.dartlang.org/'))) {
+  if (urls.hideUserProvidedDocUrl(documentationUrl)) {
     documentationUrl = null;
   }
   final dartdocsUrl = urls.pkgDocUrl(
@@ -183,7 +179,7 @@ String _renderSidebar(
   addLink(packageLinks.repositoryUrl, 'Repository',
       detectServiceProvider: true);
   addLink(packageLinks.issueTrackerUrl, 'View/report issues');
-  addLink(packageLinks.documentationUrl, 'Documentation');
+  addLink(documentationUrl, 'Documentation');
   addLink(dartdocsUrl, 'API reference');
 
   return templateCache.renderTemplate('pkg/sidebar', {

--- a/app/lib/shared/urls.dart
+++ b/app/lib/shared/urls.dart
@@ -211,3 +211,16 @@ String inferServiceProviderName(String url) {
 String panaMaintenanceUrl() {
   return 'https://pub.dartlang.org/documentation/pana/$panaVersion/#maintenance-score';
 }
+
+/// Return true if the user-provided `documentation` URL should not be shown.
+bool hideUserProvidedDocUrl(String url) {
+  if (url == null || url.isEmpty) return true;
+  final uri = Uri.parse(url);
+  if (uri == null) return true;
+  if (uri.scheme != 'http' && uri.scheme != 'https') return true;
+  final host = uri.host.toLowerCase();
+  return host == 'dartdocs.org' ||
+      host == 'www.dartdocs.org' ||
+      host == 'pub.dartlang.org' ||
+      host == 'pub.dev';
+}


### PR DESCRIPTION
As we always display the API docs URL, we should hide the pubspec-provided `documentation:` URL if it is pointing to the pub site itself. However, that logic had a bug, and we didn't hide it. I've fixed that, and also added additional checks.