### PR TITLE
Break long words (and package names) when they are wider than the content area.

### DIFF
--- a/pkg/web_css/lib/src/_base.scss
+++ b/pkg/web_css/lib/src/_base.scss
@@ -10,6 +10,7 @@ body {
   line-height: 1.6;
   margin: 0;
   padding: 0;
+  overflow-wrap: break-word;
 }
 
 body, input, button {

--- a/pkg/web_css/lib/src/_pkg.scss
+++ b/pkg/web_css/lib/src/_pkg.scss
@@ -12,7 +12,6 @@
 .package-header > .title {
   font-size: 32px;
   font-weight: 600;
-  display: inline-block;
   margin: 0;
 }
 


### PR DESCRIPTION
- fixes #2276
- fixes #2272
